### PR TITLE
Framing models

### DIFF
--- a/src/features/controls.js
+++ b/src/features/controls.js
@@ -16,8 +16,9 @@
 import {PerspectiveCamera, Vector3} from 'three';
 
 import OrbitControls from '../third_party/three/OrbitControls.js';
-import {$onResize, $scene, $needsRender} from '../xr-model-element-base.js';
+import {$onResize, $onModelLoad, $scene, $needsRender} from '../xr-model-element-base.js';
 
+const $updateOrbitCamera = Symbol('updateOrbitCamera');
 const $controls = Symbol('controls');
 const $onControlsChange = Symbol('onControlsChange');
 const $orbitCamera = Symbol('orbitCamera');
@@ -67,18 +68,28 @@ export const ControlsMixin = (XRModelElement) => {
       }
     }
 
+    /**
+     * Copies over the default camera's values in order to frame
+     * the scene correctly.
+     */
+    [$updateOrbitCamera]() {
+      // The default camera already has positioned itself correctly
+      // to frame the canvas. Copy its values.
+      this[$controls].target.set(0, 5, 0);
+      this[$orbitCamera].position.copy(this[$defaultCamera].position);
+      this[$orbitCamera].aspect = this[$defaultCamera].aspect;
+      this[$orbitCamera].rotation.set(0, 0, 0);
+      this[$orbitCamera].updateProjectionMatrix();
+    }
+
     [$onResize](e) {
       super[$onResize](e);
+      this[$updateOrbitCamera]();
+    }
 
-      const {width, height} = e;
-
-      // @TODO need to appropriately position the camera
-      // @see ModelScene#setSize
-      this[$controls].target.set(0, 5, 0);
-      this[$orbitCamera].position.set(0, 5, 15);
-      this[$orbitCamera].rotation.set(0, 0, 0);
-      this[$orbitCamera].aspect = width / height;
-      this[$orbitCamera].updateProjectionMatrix();
+    [$onModelLoad](e) {
+      super[$onModelLoad](e);
+      this[$updateOrbitCamera]();
     }
 
     [$onControlsChange](e) {

--- a/src/test/utils-spec.js
+++ b/src/test/utils-spec.js
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import {BoxBufferGeometry, Mesh, MeshBasicMaterial, Vector3} from 'three';
+import {BoxBufferGeometry, Mesh, Box3, Vector3} from 'three';
 
-import {deserializeUrl, setScaleFromLimit} from '../utils.js';
+import {deserializeUrl, fitWithinBox} from '../utils.js';
 
 const expect = chai.expect;
 
@@ -38,25 +38,33 @@ suite('utils', () => {
     });
   });
 
-  suite('setScaleFromLimit', () => {
+  suite('fitWithinBox', () => {
     test('increases the scale of a small object to fill the limit', () => {
-      const object =
-          new Mesh(new BoxBufferGeometry(1, 1, 1), new MeshBasicMaterial());
-      const limit = 2;
+      const room = new Box3().set(new Vector3(-5, 0, -5), new Vector3(5, 10, 5));
+      const object = new Mesh(new BoxBufferGeometry(1, 1, 1));
 
-      setScaleFromLimit(limit, object);
+      fitWithinBox(room, object);
 
-      expect(object.scale).to.be.eql(new Vector3(2, 2, 2));
+      expect(object.scale).to.be.eql(new Vector3(10, 10, 10));
     });
 
     test('decreases the scale of a large object to fit the limit', () => {
-      const object =
-          new Mesh(new BoxBufferGeometry(1, 1, 1), new MeshBasicMaterial());
-      const limit = 0.5;
+      const room = new Box3().set(new Vector3(-5, 0, -5), new Vector3(5, 10, 5));
+      const object = new Mesh(new BoxBufferGeometry(100, 100, 100));
 
-      setScaleFromLimit(limit, object);
+      fitWithinBox(room, object);
 
-      expect(object.scale).to.be.eql(new Vector3(0.5, 0.5, 0.5));
+      expect(object.scale).to.be.eql(new Vector3(0.1, 0.1, 0.1));
+    });
+    
+    test('updates object position to center its volume within box', () => {
+      const room = new Box3().set(new Vector3(-5, 0, -5), new Vector3(5, 10, 5));
+      const object = new Mesh(new BoxBufferGeometry(1, 2, 1));
+
+      fitWithinBox(room, object);
+
+      expect(object.scale).to.be.eql(new Vector3(5, 5, 5));
+      expect(object.position).to.be.eql(new Vector3(0, 5, 0));
     });
   });
 });


### PR DESCRIPTION
Properly center models within the allowed canvas space, and change depth to be as small as possible, yet bigger than the X extents so no clipping occurs during rotation. Correctly position cameras to fully 'frame' the element. Fixes #49.
![screenshot from 2018-10-31 11-37-23](https://user-images.githubusercontent.com/641267/47811104-342f7a80-dd02-11e8-9053-82a962433bf5.png)


Note the floating astronaut in the bottom left corner


![screenshot from 2018-10-31 11-12-43](https://user-images.githubusercontent.com/641267/47811107-37c30180-dd02-11e8-97be-6b4d9e624c28.png)
