### PR TITLE
Only render elements when they're within the viewport. Fixes #36

### DIFF
--- a/examples/assets/cube.gltf
+++ b/examples/assets/cube.gltf
@@ -1,0 +1,164 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "THREE.GLTFExporter"
+  },
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ],
+      "name": "Scene"
+    }
+  ],
+  "scene": 0,
+  "nodes": [
+    {
+      "matrix": [
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "name": "Box",
+      "mesh": 0
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 288,
+      "byteLength": 288,
+      "target": 34962,
+      "byteStride": 12
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 576,
+      "byteLength": 192,
+      "target": 34962,
+      "byteStride": 8
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 768,
+      "byteLength": 72,
+      "target": 34963
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 840,
+      "uri": "data:application/octet-stream;base64,AAAAPwAAAD8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAgD8AAIA/AACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAgD8AAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AACAPwAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAIA/AACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAgD8AAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AACAPwAAgD8AAAAAAAAAAAAAgD8AAAAAAAACAAEAAgADAAEABAAGAAUABgAHAAUACAAKAAkACgALAAkADAAOAA0ADgAPAA0AEAASABEAEgATABEAFAAWABUAFgAXABUA"
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.5,
+        0.5,
+        0.5
+      ],
+      "min": [
+        -0.5,
+        -0.5,
+        -0.5
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1,
+        1
+      ],
+      "min": [
+        -1,
+        -1,
+        -1
+      ],
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        1,
+        1
+      ],
+      "min": [
+        0,
+        0
+      ],
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5123,
+      "count": 36,
+      "max": [
+        23
+      ],
+      "min": [
+        0
+      ],
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.10196078431372549,
+          0,
+          1,
+          1
+        ],
+        "metallicFactor": 0.5,
+        "roughnessFactor": 0.5
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "mode": 4,
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1,
+            "TEXCOORD_0": 2
+          },
+          "indices": 3,
+          "material": 0
+        }
+      ]
+    }
+  ]
+}

--- a/examples/list.html
+++ b/examples/list.html
@@ -1,0 +1,57 @@
+<!--
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>XRModelElement - List of Models</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, user-scalable=no,
+  minimum-scale=1.0, maximum-scale=1.0">
+  <link href="./third_party/prism/prism.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Fira+Sans:200" rel="stylesheet">
+  <link type="text/css" href="style.css" rel="stylesheet" />
+  <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
+<style>
+xr-model {
+  width: 50%;
+  margin: 0 auto;
+}
+</style>
+</head>
+<body>
+    <div id="container">
+        <h1>XRModelElement - List of Models</h1>
+        <p class="desc">This page tests usages of the <code>&lt;xr-model&gt;</code> element using defaults and features not covered in other tests.</p>
+
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+        <xr-model auto-rotate vignette background-color="#4885ed" src="assets/Astronaut.glb"></xr-model>
+
+    <script src="../dist/xr-model-element.js"></script>
+    <script src="./third_party/prism/prism.js"></script>
+</body>
+</html>

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -50,4 +50,3 @@ export const waitForEvent = (target, eventName, predicate) =>
       }
       target.addEventListener(eventName, handler);
     });
-

--- a/src/test/three-components/Renderer-spec.js
+++ b/src/test/three-components/Renderer-spec.js
@@ -39,6 +39,7 @@ suite('Renderer', () => {
       height: 100,
       renderer,
     });
+    scene.isVisible = true;
 
     scene.renderCount = 0;
     const drawImage = scene.context.drawImage;
@@ -60,11 +61,13 @@ suite('Renderer', () => {
       renderer.render(performance.now());
       expect(scene1.renderCount).to.be.equal(0);
       expect(scene2.renderCount).to.be.equal(0);
+      expect(renderer.scenesRendered).to.be.equal(0);
 
       scene1.isDirty = true;
       renderer.render(performance.now());
       expect(scene1.renderCount).to.be.equal(1);
       expect(scene2.renderCount).to.be.equal(0);
+      expect(renderer.scenesRendered).to.be.equal(1);
     });
 
     test('marks scenes no longer dirty after rendering', async function () {
@@ -80,6 +83,27 @@ suite('Renderer', () => {
       renderer.render(performance.now());
       expect(scene.renderCount).to.be.equal(1);
       expect(!scene.isDirty).to.be.ok;
+    });
+
+    test('does not render scenes marked as !isVisible', async function () {
+      let scene = createScene();
+      let renderer = new Renderer();
+      renderer.registerScene(scene);
+
+      scene.isVisible = false;
+      scene.isDirty = true;
+
+      renderer.render(performance.now());
+      expect(scene.renderCount).to.be.equal(0);
+      expect(scene.isDirty).to.be.ok;
+      expect(renderer.scenesRendered).to.be.equal(0);
+
+      scene.isVisible = true;
+
+      renderer.render(performance.now());
+      expect(scene.renderCount).to.be.equal(1);
+      expect(!scene.isDirty).to.be.ok;
+      expect(renderer.scenesRendered).to.be.equal(1);
     });
   });
 });

--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -92,6 +92,7 @@ export default class ModelScene extends Scene {
     this.add(this.directionalLight);
     this.pivot.add(this.model);
 
+    this.isVisible = false;
     this.isDirty = false;
     this.hasLoaded = false;
 

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -63,6 +63,7 @@ export default class Renderer extends EventDispatcher {
     ];
 
     this.scenes = new Set();
+    this.scenesRendered = 0;
     this.setRendererSize(1, 1);
   }
 
@@ -87,11 +88,12 @@ export default class Renderer extends EventDispatcher {
   }
 
   render(t) {
+    this.scenesRendered = 0;
     for (let scene of this.scenes) {
       const {element, width, height, context} = scene;
       element[$tick](t);
 
-      if (!scene.isDirty || scene.paused) {
+      if (!scene.isVisible || !scene.isDirty || scene.paused) {
         continue;
       }
 
@@ -131,6 +133,7 @@ export default class Renderer extends EventDispatcher {
           heightDPR);
 
       scene.isDirty = false;
+      this.scenesRendered++;
     }
   }
 }

--- a/src/xr-model-element-base.js
+++ b/src/xr-model-element-base.js
@@ -25,7 +25,6 @@ const renderer = new Renderer();
 
 const $updateSize = Symbol('updateSize');
 
-export const $renderer = Symbol('renderer');
 export const $container = Symbol('container');
 export const $canvas = Symbol('canvas');
 export const $scene = Symbol('scene');
@@ -33,6 +32,7 @@ export const $needsRender = Symbol('needsRender');
 export const $tick = Symbol('tick');
 export const $onModelLoad = Symbol('onModelLoad');
 export const $onResize = Symbol('onResize');
+export const $renderer = Symbol('renderer');
 
 /**
  * Definition for a basic <xr-model> element.
@@ -111,6 +111,8 @@ export default class XRModelElementBase extends UpdatingElement {
       this[$updateSize](this.getBoundingClientRect(), true);
     });
 
+    this[$renderer] = renderer;
+
     // Set a resize observer so we can scale our canvas
     // if our <xr-model> changes
     this.resizeObserver = new ResizeObserver(entries => {
@@ -127,6 +129,19 @@ export default class XRModelElementBase extends UpdatingElement {
       }
     });
     this.resizeObserver.observe(this);
+
+    this.intersectionObserver = new IntersectionObserver(entries => {
+      for (let entry of entries) {
+        if (entry.target === this) {
+          this[$scene].isVisible = entry.isIntersecting;
+        }
+      }
+    }, {
+      root: null,
+      rootMargin: '10px',
+      threshold: 0.1,
+    });
+    this.intersectionObserver.observe(this);
   }
 
   connectedCallback() {


### PR DESCRIPTION
Doesn't work with wc polyfilled Firefox due to the size not taking effect so can't get that test passing. Filing follow up w/r/t polyfilled wc. Did confirm it works in Fx63 though manually. Can't get my test runner to target my own binary instead of Fx60 ESR.