### PR TITLE
Implement fake static shadows that do not require recomputing during rotation

### DIFF
--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -56,7 +56,6 @@ export default class Renderer extends EventDispatcher {
     this.renderer =
         new WebGLRenderer({canvas: this.canvas, context: this.context});
     this.renderer.setPixelRatio(DPR);
-    this.renderer.shadowMap.enabled = true;
     this.renderer.gammaInput = true;
     this.renderer.gammaOutput = true;
     this.renderer.gammaFactor = GAMMA_FACTOR;

--- a/src/three-components/StaticShadow.js
+++ b/src/three-components/StaticShadow.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Color, Mesh, RGBAFormat, MeshBasicMaterial, MultiplyBlending, OrthographicCamera, PlaneGeometry, ShaderMaterial, UniformsUtils, Vector3, WebGLRenderTarget} from 'three';
+
+const $camera = Symbol('camera');
+const $renderTarget = Symbol('renderTarget');
+
+const scale = new Vector3();
+
+const DEFAULT_CONFIG = {
+  near: 0.01,
+  far: 100,
+  textureWidth: 512,
+  textureHeight: 512,
+};
+
+const shadowGeneratorMaterial = new MeshBasicMaterial({
+  color: 0x000000,
+});
+
+const shadowTextureMaterial = new MeshBasicMaterial({
+  transparent: true,
+  opacity: 0.1,
+});
+
+/**
+ * Creates a mesh that can receive and render pseudo-shadows
+ * only updated when calling its render method. This is different
+ * from non-auto-updating shadows because the resulting material
+ * applied to the mesh is disconnected from the renderer's shadow map
+ * and can be freely rotated and positioned like a regular texture.
+ */
+export default class StaticShadow extends Mesh {
+  /**
+   * Create a shadow mesh.
+   */
+  constructor() {
+    const geometry = new PlaneGeometry(1, 1);
+    geometry.rotateX(-Math.PI / 2);
+
+    super(geometry, shadowTextureMaterial.clone());
+
+    this[$renderTarget] = new WebGLRenderTarget(
+        DEFAULT_CONFIG.textureWidth, DEFAULT_CONFIG.textureHeight, {
+          format: RGBAFormat,
+        });
+    this.material.map = this[$renderTarget].texture;
+    this.material.needsUpdate = true;
+
+    this[$camera] = new OrthographicCamera();
+    this[$camera].matrixAutoUpdate = false;
+  }
+
+  /**
+   * Updates the generated static shadow. The size of the camera is dependent
+   * on the current scale of the StaticShadow that will host the texture.
+   * It's expected for the StaticShadow to be facing the light source.
+   *
+   * @param {THREE.WebGLRenderer} renderer
+   * @param {THREE.Scene} scene
+   * @param {THREE.DirectionalLight} light
+   * @param {Object} config
+   * @param {number} config.near
+   * @param {number} config.far
+   * @param {number} config.textureWidth
+   * @param {number} config.textureHeight
+   */
+  render(renderer, scene, light, config = {}) {
+    const userSceneOverrideMaterial = scene.overrideMaterial;
+    const userClearAlpha = renderer.getClearAlpha();
+    const userRenderTarget = renderer.getRenderTarget();
+
+    config = Object.assign({}, config, DEFAULT_CONFIG);
+
+    renderer.setClearAlpha(0);
+    scene.overrideMaterial = shadowGeneratorMaterial;
+
+    // Update render target size if necessary
+    if (this[$renderTarget].width !== config.textureWidth ||
+        this[$renderTarget].height !== config.textureHeight) {
+      this[$renderTarget].setSize(config.textureWidth, config.textureHeight);
+    }
+
+    // Set the camera to where the light source is,
+    // and facing its target.
+    light.updateMatrixWorld(true);
+    light.target.updateMatrixWorld(true);
+    this[$camera].position.setFromMatrixPosition(light.matrixWorld);
+    this[$camera].lookAt(light.target.position);
+    this[$camera].updateMatrix();
+    this[$camera].updateMatrixWorld();
+
+    // Update the camera's frustum to fully engulf the StaticShadow
+    // mesh that will be rendering the generated texture.
+    this.updateMatrixWorld(true);
+    scale.setFromMatrixScale(this.matrixWorld);
+    this[$camera].top = scale.z / 2;
+    this[$camera].bottom = scale.z / -2;
+    this[$camera].left = scale.x / -2;
+    this[$camera].right = scale.x / 2;
+    this[$camera].near = config.near;
+    this[$camera].far = config.far;
+    this[$camera].updateProjectionMatrix();
+
+    renderer.render(scene, this[$camera], this[$renderTarget], true);
+    this.material.needsUpdate = true;
+
+    // Reset the values on the renderer and scene
+    scene.overrideMaterial = userSceneOverrideMaterial;
+    renderer.setClearAlpha(userClearAlpha);
+    renderer.setRenderTarget(userRenderTarget);
+  }
+}


### PR DESCRIPTION
Fixes #13 

![screenshot from 2018-11-07 16-26-58](https://user-images.githubusercontent.com/641267/48170017-8c3e2200-e2aa-11e8-84a5-dd0610c03867.png)

A nice scale and blur (once post processing adding for an easy blur or something) would be nice in the future