### PR TITLE
Add modified equirect2cubemap to source tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "resize-observer-polyfill": "^1.5.0",
     "rollup": "^0.66.0",
     "rollup-plugin-cleanup": "^3.0.0-beta.1",
-    "rollup-plugin-commonjs": "^9.2.0",
-    "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "typescript": "^3.1.3",
     "wct-browser-legacy": "^1.0.1",
@@ -57,7 +55,6 @@
     "@jsantell/wagner": "0.0.3",
     "@magicleap/prismatic": "^0.17.5",
     "@polymer/lit-element": "^0.6.2",
-    "three": "^0.94.0",
-    "three.equirectangular-to-cubemap": "^1.1.0"
+    "three": "^0.94.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,6 @@ const fs = require('fs');
 const path = require('path');
 const rollup = require('rollup');
 const resolve = require('rollup-plugin-node-resolve');
-const commonjs = require('rollup-plugin-commonjs');
 const cleanup = require('rollup-plugin-cleanup');
 const banner = fs.readFileSync(path.join(__dirname, 'licenses.txt'));
 
@@ -28,7 +27,6 @@ const plugins = [
     include: ['lib/**'],
     comments: 'none',
   }),
-  commonjs(),
   resolve(),
 ];
 

--- a/src/third_party/three.equirectangular-to-cubemap/EquirectangularToCubemap.js
+++ b/src/third_party/three.equirectangular-to-cubemap/EquirectangularToCubemap.js
@@ -1,0 +1,28 @@
+import * as THREE from 'three';
+
+export default function EquirectangularToCubemap(renderer) {
+  this.renderer = renderer;
+  this.scene = new THREEScene();
+
+  var gl = this.renderer.getContext();
+  this.maxSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE)
+
+                     this.camera = new THREE.CubeCamera(1, 100000, 1);
+
+  this.material =
+      new THREE.MeshBasicMaterial({map: null, side: THREE.BackSide});
+
+  this.mesh =
+      new THREE.Mesh(new THREE.IcosahedronGeometry(100, 4), this.material);
+  this.scene.add(this.mesh);
+}
+
+EquirectangularToCubemap.prototype.convert = function(source, size) {
+  var mapSize = Math.min(size, this.maxSize);
+  this.camera = new THREE.CubeCamera(1, 100000, mapSize);
+  this.material.map = source;
+
+  this.camera.updateCubeMap(this.renderer, this.scene);
+
+  return this.camera.renderTarget.texture;
+}

--- a/src/third_party/three.equirectangular-to-cubemap/LICENSE
+++ b/src/third_party/three.equirectangular-to-cubemap/LICENSE
@@ -1,0 +1,8 @@
+Copyright (C) 2016 Jaume Sanchez Elias, http://www.clicktorelease.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/src/third_party/three.equirectangular-to-cubemap/METADATA
+++ b/src/third_party/three.equirectangular-to-cubemap/METADATA
@@ -1,0 +1,16 @@
+name: "three.equirectangular-to-cubemap"
+description:
+  "JavaScript 3D Library Helper"
+
+third_party {
+  url {
+    type: HOMEPAGE
+    value: "https://github.com/spite/THREE.EquirectangularToCubemap"
+  }
+  url {
+    type: GIT
+    value: "https://github.com/spite/THREE.EquirectangularToCubemap.git"
+  }
+  version: "1.1.0"
+  last_upgrade_date { year: 2018 month: 11 day: 7 }
+}

--- a/src/three-components/TextureUtils.js
+++ b/src/three-components/TextureUtils.js
@@ -14,7 +14,7 @@
  */
 
 import {TextureLoader} from 'three';
-import EquirectangularToCubemap from 'three.equirectangular-to-cubemap';
+import EquirectangularToCubemap from '../third_party/three.equirectangular-to-cubemap/EquirectangularToCubemap.js';
 
 const CUBE_MAP_SIZE = 1024;
 const loader = new TextureLoader();
@@ -32,7 +32,8 @@ export const loadTexture = (url) =>
  * @param {THREE.Texture} texture
  * @return {THREE.Texture}
  */
-export const equirectangularToCubemap = async function(renderer, texture) {
+export const equirectangularToCubemap =
+    async function(renderer, texture) {
   const equiToCube = new EquirectangularToCubemap(renderer);
   const cubemap = equiToCube.convert(texture, CUBE_MAP_SIZE);
   return cubemap;
@@ -52,7 +53,7 @@ export const toCubemapAndEquirect = async (renderer, url) => {
   try {
     const equirect = await loadTexture(url);
     const cubemap = await equirectangularToCubemap(renderer, equirect);
-    return { equirect, cubemap };
+    return {equirect, cubemap};
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
Removes the need for non-standard loading semantics from the source tree

The helper has been ESM-ified.

Cannot check tests until #77 is merged, so will wait until I can rebase on top of that.

Fixes #80 