### PR TITLE
Static shadow fixes

### DIFF
--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -269,6 +269,13 @@ export default class ModelScene extends Scene {
       return;
     }
 
+    // Remove and cache the current pivot rotation so that the shadow's
+    // capture is unrotated so it can be freely rotated when applied
+    // as a texture.
+    const currentRotation = this.pivot.rotation.y;
+    this.pivot.rotation.y = 0;
+
+    this.shadow.position.set(0, 0, 0);
     this.shadow.scale.x = this.roomSize.x;
     this.shadow.scale.z = this.roomSize.z;
     this.shadow.render(this.renderer.renderer, this, this.shadowLight);
@@ -276,5 +283,15 @@ export default class ModelScene extends Scene {
     // Lazily add the shadow so we're only displaying it once it has
     // a generated texture.
     this.pivot.add(this.shadow);
+    this.pivot.rotation.y = currentRotation;
+
+    // If model has vertical room, it'll be positioned at (0, 5, 0)
+    // and appear to be floating. This should be ultimately user-configurable,
+    // but for now, move the shadow to the bottom of the model if the
+    // element and model are width-bound.
+    const modelHeight = this.model.size.y * this.model.scale.y;
+    if (modelHeight < FRAMED_HEIGHT) {
+      this.shadow.position.y  = (FRAMED_HEIGHT / 2) - modelHeight / 2
+    }
   }
 }

--- a/src/three-components/StaticShadow.js
+++ b/src/three-components/StaticShadow.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {Color, Mesh, RGBAFormat, MeshBasicMaterial, MultiplyBlending, OrthographicCamera, PlaneGeometry, ShaderMaterial, UniformsUtils, Vector3, WebGLRenderTarget} from 'three';
+import {Color, Mesh, MeshBasicMaterial, MultiplyBlending, OrthographicCamera, PlaneGeometry, RGBAFormat, ShaderMaterial, UniformsUtils, Vector3, WebGLRenderTarget} from 'three';
 
 const $camera = Symbol('camera');
 const $renderTarget = Symbol('renderTarget');
@@ -82,6 +82,7 @@ export default class StaticShadow extends Mesh {
     const userSceneOverrideMaterial = scene.overrideMaterial;
     const userClearAlpha = renderer.getClearAlpha();
     const userRenderTarget = renderer.getRenderTarget();
+    const shadowParent = this.parent;
 
     config = Object.assign({}, config, DEFAULT_CONFIG);
 
@@ -115,7 +116,18 @@ export default class StaticShadow extends Mesh {
     this[$camera].far = config.far;
     this[$camera].updateProjectionMatrix();
 
+    // There's a chance the shadow will be in the scene that's being rerendered;
+    // temporarily remove it incase.
+    if (shadowParent) {
+      shadowParent.remove(this);
+    }
+
     renderer.render(scene, this[$camera], this[$renderTarget], true);
+
+    if (shadowParent) {
+      shadowParent.add(this);
+    }
+
     this.material.needsUpdate = true;
 
     // Reset the values on the renderer and scene


### PR DESCRIPTION
Remove the shadow from the scene when recomputing/resizing, and capture shadow when no pivot rotation is applied. Fixes #87

Also fixes the issue seen on multi-16 when shadows can be slightly off based off of when the snapshot occurs. Removing the pivot's rotation before capturing fixes this as well:
![screenshot from 2018-11-08 11-58-13](https://user-images.githubusercontent.com/641267/48224298-2c00bc00-e34e-11e8-82b5-dd9be26fd363.png)