### PR TITLE
Support ShadyCSS hooks to provide support when webcomponent polyfills/ShadyCSS are necessary

### DIFF
--- a/src/xr-model-element-base.js
+++ b/src/xr-model-element-base.js
@@ -57,6 +57,11 @@ export default class XRModelElementBase extends UpdatingElement {
    */
   constructor() {
     super();
+
+    if (window.ShadyCSS) {
+      window.ShadyCSS.styleElement(this);
+    }
+
     const {shadowRoot} = this;
     shadowRoot.appendChild(template.content.cloneNode(true));
 

--- a/src/xr-model-element.js
+++ b/src/xr-model-element.js
@@ -20,6 +20,11 @@ import {ControlsMixin} from './features/controls.js';
 import {MagicLeapMixin} from './features/magic-leap.js';
 import {PosterMixin} from './features/poster.js';
 import XRModelElementBase from './xr-model-element-base.js';
+import template from './template.js';
+
+if (window.ShadyCSS) {
+  window.ShadyCSS.prepareTemplate(template, 'xr-model');
+}
 
 const XRModelElement = [
   PosterMixin,


### PR DESCRIPTION
Fixes #70.

Running in Firefox 60:

![screenshot from 2018-11-08 12-53-29](https://user-images.githubusercontent.com/641267/48226942-dc25f300-e355-11e8-8dd5-9c7d90051d2c.png)

