### PR TITLE
Avoid unnecessary framebuffer clears.

### DIFF
--- a/src/three-components/ModelScene.js
+++ b/src/three-components/ModelScene.js
@@ -84,6 +84,8 @@ export default class ModelScene extends Scene {
     const skysphereMat = new MeshBasicMaterial({
       side: BackSide,
       color: 0xffffff,
+      depthTest: false,
+      depthWrite: false
     });
     this.skysphere = new Mesh(skysphereGeo, skysphereMat);
 

--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -55,6 +55,7 @@ export default class Renderer extends EventDispatcher {
     this.context = this.canvas.getContext('webgl', webGlOptions);
     this.renderer =
         new WebGLRenderer({canvas: this.canvas, context: this.context});
+    this.renderer.autoClear = false;
     this.renderer.setPixelRatio(DPR);
     this.renderer.gammaInput = true;
     this.renderer.gammaOutput = true;
@@ -143,7 +144,7 @@ export default class Renderer extends EventDispatcher {
 
       const camera = scene.getCamera();
 
-      this.renderer.clear();
+      this.renderer.clearDepth();
       if (width > this.width || height > this.height) {
         const maxWidth = Math.max(width, this.width);
         const maxHeight = Math.max(height, this.height);


### PR DESCRIPTION
Considering we're currently using a sphere as background which fills all the pixels there is no need to clear all the pixels.

@jsantell `multi-16.html` currently has issues with the `camera.far` a bit too tight and it's clipping the back of the background sphere. After this PR you'll see 2 astronauts in the top-right view. The second astronaut is from the previous rendered view.