### PR TITLE
Skysphere fixes

### DIFF
--- a/examples/multiple-elements.html
+++ b/examples/multiple-elements.html
@@ -62,24 +62,38 @@
         <p class="desc">This page tests many models on the same page.</p>
 
         <div class="grid">
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <xr-model src="assets/Astronaut.glb" preload auto-rotate background-color="#4885ed"></xr-model>
-            <!--
-            -->
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#4885ed"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#3cba54"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#f4c20d"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#db3236"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#4885ed"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#3cba54"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#f4c20d"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#db3236"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#4885ed"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#3cba54"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#f4c20d"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#db3236"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#4885ed"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#3cba54"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#f4c20d"></xr-model>
+            <xr-model src="assets/Astronaut.glb"
+                preload  auto-rotate background-color="#db3236"></xr-model>
         </div>
     </div>
 

--- a/src/features/controls.js
+++ b/src/features/controls.js
@@ -20,6 +20,7 @@ import {FRAMED_HEIGHT} from '../three-components/ModelScene.js';
 import {$needsRender, $onModelLoad, $onResize, $scene} from '../xr-model-element-base.js';
 
 const ORBIT_NEAR_PLANE = 0.01;
+const ORBIT_FAR_PLANE = 1000;
 
 export const $controls = Symbol('controls');
 const $updateOrbitCamera = Symbol('updateOrbitCamera');
@@ -41,6 +42,7 @@ export const ControlsMixin = (XRModelElement) => {
 
       this[$orbitCamera] = this[$scene].camera.clone();
       this[$orbitCamera].near = ORBIT_NEAR_PLANE;
+      this[$orbitCamera].far = ORBIT_FAR_PLANE;
       this[$orbitCamera].updateProjectionMatrix();
       this[$controls] = null;
     }

--- a/src/features/environment.js
+++ b/src/features/environment.js
@@ -17,7 +17,7 @@ import {Color} from 'three';
 
 import EnvMapGenerator from '../three-components/EnvMapGenerator.js';
 import {toCubemapAndEquirect} from '../three-components/TextureUtils.js';
-import {$needsRender, $onModelLoad, $renderer, $scene} from '../xr-model-element-base.js';
+import {$needsRender, $onModelLoad, $renderer, $scene, $tick} from '../xr-model-element-base.js';
 
 const DEFAULT_BACKGROUND_COLOR = '#ffffff';
 const DEFAULT_ENVMAP_SIZE = 512;
@@ -81,6 +81,12 @@ export const EnvironmentMixin = (XRModelElement) => {
       }
 
       this[$setEnvironmentColor](this.backgroundColor);
+    }
+
+    [$tick](time, delta) {
+      super[$tick](time, delta);
+      const camera = this[$scene].getCamera();
+      this[$scene].skysphere.position.copy(camera.position);
     }
 
     [$onModelLoad](e) {

--- a/src/test/three-components/ModelScene-spec.js
+++ b/src/test/three-components/ModelScene-spec.js
@@ -21,6 +21,13 @@ import XRModelElementBase, {$canvas} from '../../xr-model-element-base.js';
 
 const expect = chai.expect;
 
+// Checks that the skysphere is within the camera's far plane
+function ensureSkysphereVisible(scene) {
+  expect(scene.skysphere.scale.x).to.be.equal(scene.skysphere.scale.y);
+  expect(scene.skysphere.scale.y).to.be.equal(scene.skysphere.scale.z);
+  expect(scene.skysphere.scale.x).to.be.lessThan(scene.camera.far);
+}
+
 function ensureRoomFitsAspect(roomBox, aspect) {
   expect(roomBox.max.x).to.be.equal(aspect * FRAMED_HEIGHT / 2);
   expect(roomBox.min.x).to.be.equal(aspect * FRAMED_HEIGHT / -2);
@@ -85,6 +92,7 @@ suite('ModelScene', () => {
 
       ensureRoomFitsAspect(scene.roomBox, aspect);
       ensureWidthAndDepthEqual(scene.roomBox);
+      ensureSkysphereVisible(scene);
     });
 
     test('increases depth of room for Y-rotation', () => {
@@ -98,6 +106,7 @@ suite('ModelScene', () => {
 
       ensureRoomFitsAspect(scene.roomBox, aspect);
       ensureWidthAndDepthEqual(scene.roomBox);
+      ensureSkysphereVisible(scene);
     });
 
     test('increases width of room for Y-rotation', () => {
@@ -111,6 +120,7 @@ suite('ModelScene', () => {
 
       ensureRoomFitsAspect(scene.roomBox, aspect);
       ensureWidthAndDepthEqual(scene.roomBox);
+      ensureSkysphereVisible(scene);
     });
 
     test('reduce depth of room if Y-axis-bound', () => {
@@ -128,6 +138,7 @@ suite('ModelScene', () => {
       // width of the model
       expect(scene.roomBox.max.z).to.be.equal(1.5);
       expect(scene.roomBox.min.z).to.be.equal(-1.5);
+      ensureSkysphereVisible(scene);
     });
 
     test('updates skysphere size to fully enclose room', () => {
@@ -144,6 +155,18 @@ suite('ModelScene', () => {
       expect(scene.skysphere.scale.x).to.be.greaterThan(size.x);
       expect(scene.skysphere.scale.y).to.be.greaterThan(size.y);
       expect(scene.skysphere.scale.z).to.be.greaterThan(size.z);
+      ensureSkysphereVisible(scene);
+    });
+
+    test('the skysphere is still within far plane for extreme aspects', () => {
+      dummyMesh.geometry.applyMatrix(new Matrix4().makeScale(200, 100, 300));
+      scene.model.setObject(dummyMesh);
+
+      const width = 1000;
+      const height = 50;
+      const aspect = width / height;
+      scene.setSize(width, height);
+      ensureSkysphereVisible(scene);
     });
 
     test('cannot set the canvas smaller than 1x1', () => {


### PR DESCRIPTION
Attach the skysphere to the camera, and properly size the skysphere according to the largest size (with padding), rather than the reduced Z-depth. Fixes #82

![screenshot from 2018-11-08 19-42-47](https://user-images.githubusercontent.com/641267/48242364-bddce900-e38f-11e8-9de0-b4582c29f4d5.png)
