### PR TITLE
add appropriate attribution to each demo page

### DIFF
--- a/examples/assets/attributions.md
+++ b/examples/assets/attributions.md
@@ -2,35 +2,41 @@
 
 ## Astronaut.*
 
-By [Poly](https://poly.google.com/user/4aEd8rQgKu2) / [CC-BY] ([source](https://poly.google.com/view/dLHpzNdygsg))
+Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+(<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
 
 ## Barramundi Fish
 
-By [Microsoft](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BarramundiFish) /
-[CC-0] ([source](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BarramundiFish))
+Barramundi Fish by <a href="https://www.microsoft.com/">Microsoft</a>,
+licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC-0</a>
+(<a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BarramundiFish">source</a>)
 
-## DamagedHelmet
+## Damaged Helmet
 
-By [theblueturtle_](https://sketchfab.com/theblueturtle_) /
-Creative Commons Attribution-NonCommercial ([source](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet))
+Damaged Helmet by <a href="https://sketchfab.com/theblueturtle_">theblueturtle_</a>,
+licensed under Creative Commons Attribution-NonCommercial
+(<a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet">source</a>)
 
 ## equirectangular.png
 
-By [WestLangley](https://github.com/WestLangley) / [three.js-MIT]
-([source](https://github.com/mrdoob/three.js/blob/dev/examples/textures/equirectangular.png))
+equirectangular.png by <a href="https://github.com/WestLangley">WestLangley</a>
+licensed under <a href="https://github.com/mrdoob/three.js/blob/dev/LICENSE">MIT</a>
+(<a href="https://github.com/mrdoob/three.js/blob/dev/examples/textures/equirectangular.png">source</a>)
 
 ## FlightHelmet
 
-By [Microsoft](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/FlightHelmet) /
-[CC-0] ([source](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/FlightHelmet))
-
+Flight Helmet by <a href="https://www.microsoft.com/">Microsoft</a>,
+licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC-0</a>
+(<a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BarramundiFish">source</a>)
 
 
 ## Shishkebab.*
 
-By [Poly](https://poly.google.com/user/4aEd8rQgKu2) / [CC-BY] ([source](https://poly.google.com/view/6uTsH2jqgVn))
+Shishkebab by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+(<a href="https://poly.google.com/view/6uTsH2jqgVn">source</a>)
 
+## cube.gltf, offcenter-cube.gltf, pbr-spheres.glb, reflective-sphere.gltf
 
-[CC-BY]: https://creativecommons.org/licenses/by/2.0/
-[CC-0]: https://creativecommons.org/publicdomain/zero/1.0/
-[three.js-MIT]: https://github.com/mrdoob/three.js/blob/dev/LICENSE
+Contributed by <a href="https://github.com/jsantell">jsantell</a>

--- a/examples/augmented-reality.html
+++ b/examples/augmented-reality.html
@@ -62,6 +62,11 @@
                 </model-viewer>
             </template>
         </demo-snippet>
+        <div>
+          Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
+        </div>
     </div>
     <script src="./built/dependencies.js"></script>
     <script src="../dist/model-viewer-element.js"></script>

--- a/examples/background-color.html
+++ b/examples/background-color.html
@@ -95,6 +95,17 @@
                 </script>
             </template>
         </demo-snippet>
+
+        <div>
+          Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
+        </div>
+        <div>
+          Shishkebab by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/6uTsH2jqgVn">source</a>)
+        </div>        
     </div>
 
     <script src="./scripts/helpers.js"></script>

--- a/examples/background-image.html
+++ b/examples/background-image.html
@@ -104,6 +104,24 @@
                 </script>
             </template>
         </demo-snippet>
+
+        <div>
+          Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
+        </div>
+
+        <div>
+          Damaged Helmet by <a href="https://sketchfab.com/theblueturtle_">theblueturtle_</a>,
+          licensed under Creative Commons Attribution-NonCommercial
+          (<a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet">source</a>)
+        </div>
+
+        <div>
+          equirectangular.png by <a href="https://github.com/WestLangley">WestLangley</a>
+          licensed under <a href="https://github.com/mrdoob/three.js/blob/dev/LICENSE">MIT</a>
+          (<a href="https://github.com/mrdoob/three.js/blob/dev/examples/textures/equirectangular.png">source</a>)
+        </div>
     </div>
     <script src="./scripts/helpers.js"></script>
     <script src="./built/dependencies.js"></script>

--- a/examples/default.html
+++ b/examples/default.html
@@ -52,6 +52,12 @@
             </template>
         </demo-snippet>
     </div>
+
+    <div>
+      Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+      licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+      (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
+    </div>
     <script src="./built/dependencies.js"></script>
     <script src="../dist/model-viewer-element.js"></script>
 </body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -69,6 +69,12 @@
                 </model-viewer>
             </template>
         </demo-snippet>
+
+        <div>
+          Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
+        </div>
     </div>
     <script src="./built/dependencies.js"></script>
     <script src="../dist/model-viewer-element.js"></script>

--- a/examples/list.html
+++ b/examples/list.html
@@ -66,6 +66,11 @@ model-viewer {
         <model-viewer auto-rotate background-color="#4885ed" src="assets/Astronaut.glb"></model-viewer>
         <model-viewer auto-rotate background-color="#4885ed" src="assets/Astronaut.glb"></model-viewer>
 
+        <div>
+          Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
+        </div>
     <script src="../dist/model-viewer-element.js"></script>
 </body>
 </html>

--- a/examples/loading.html
+++ b/examples/loading.html
@@ -112,6 +112,18 @@
                 </script>
             </template>
         </demo-snippet>
+
+        <div>
+          Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
+        </div>
+
+        <div>
+          Shishkebab by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/6uTsH2jqgVn">source</a>)
+        </div>
     </div>
     <script src="scripts/helpers.js"></script>
     <script src="./built/dependencies.js"></script>

--- a/examples/multiple-elements.html
+++ b/examples/multiple-elements.html
@@ -92,6 +92,12 @@
             <model-viewer src="assets/Astronaut.glb"
                 auto-rotate background-color="#db3236"></model-viewer>
         </div>
+
+        <div>
+          Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
+        </div>
     </div>
 
     <script src="../../dist/model-viewer-element.js"></script>

--- a/examples/pbr.html
+++ b/examples/pbr.html
@@ -84,6 +84,22 @@
                 </demo-snippet>
             </template>
         </lazy-inject>
+
+        <div>
+          Barramundi Fish by <a href="https://www.microsoft.com/">Microsoft</a>,
+          licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC-0</a>
+          (<a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BarramundiFish">source</a>)
+        </div>
+        <div>
+          Damaged Helmet by <a href="https://sketchfab.com/theblueturtle_">theblueturtle_</a>,
+          licensed under Creative Commons Attribution-NonCommercial
+          (<a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet">source</a>)
+        </div>
+        <div>
+          Flight Helmet by <a href="https://www.microsoft.com/">Microsoft</a>,
+          licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC-0</a>
+          (<a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BarramundiFish">source</a>)
+        </div>
     <script src="./scripts/helpers.js"></script>
     <script src="./scripts/lazy-inject.js"></script>
     <script src="./built/dependencies.js"></script>

--- a/examples/sources.html
+++ b/examples/sources.html
@@ -98,6 +98,12 @@
                 </script>
             </template>
         </demo-snippet>
+
+        <div>
+          Astronaut by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>
+          (<a href="https://poly.google.com/view/dLHpzNdygsg">source</a>)
+        </div>
     </div>
     <script src="./scripts/helpers.js"></script>
     <script src="./built/dependencies.js"></script>


### PR DESCRIPTION
Convert the format of attributions in `examples/assets/attributions.md`
to html for ease of reference.

Further work on #111 