### PR TITLE
Check 'experimental-webgl' when fetching a context

### DIFF
--- a/src/three-components/Renderer.js
+++ b/src/three-components/Renderer.js
@@ -18,9 +18,9 @@ import {EventDispatcher, WebGLRenderer} from 'three';
 import {IS_AR_CANDIDATE} from '../constants.js';
 import {$tick} from '../model-viewer-base.js';
 
-import TextureUtils from './TextureUtils.js';
 import {ARRenderer} from './ARRenderer.js';
-import * as WebGLExtensionUtils from './WebGLExtensionUtils.js';
+import TextureUtils from './TextureUtils.js';
+import * as WebGLUtils from './WebGLUtils.js';
 
 const GAMMA_FACTOR = 2.2;
 const DPR = window.devicePixelRatio;
@@ -50,11 +50,16 @@ export default class Renderer extends EventDispatcher {
     }
 
     this.canvas = document.createElement('canvas');
-    this.context = this.canvas.getContext('webgl', webGlOptions);
-    WebGLExtensionUtils.applyExtensionCompatibility(this.context);
+    // Need to support both 'webgl' and 'experimental-webgl' (IE11).
+    this.context = WebGLUtils.getContext(this.canvas, webGlOptions);
+    // Patch the gl context's extension functions before passing
+    // it to three.
+    WebGLUtils.applyExtensionCompatibility(this.context);
 
-    this.renderer =
-        new WebGLRenderer({canvas: this.canvas, context: this.context});
+    this.renderer = new WebGLRenderer({
+      canvas: this.canvas,
+      context: this.context,
+    });
     this.renderer.autoClear = false;
     this.renderer.setPixelRatio(DPR);
     this.renderer.gammaOutput = true;

--- a/src/three-components/WebGLUtils.js
+++ b/src/three-components/WebGLUtils.js
@@ -13,37 +13,40 @@
  * limitations under the License.
  */
 
-const testShaders = {
-  // In some Firefox builds (mobile Android on Pixel at least),
-  // EXT_shader_texture_lod is reported as being supported, but
-  // fails in practice.
-  // @see https://bugzilla.mozilla.org/show_bug.cgi?id=1451287
-  'EXT_shader_texture_lod': `
-#extension GL_EXT_shader_texture_lod : enable
-precision mediump float;
-uniform sampler2D tex;
-void main() {
-    gl_FragColor = texture2DLodEXT(tex, vec2(0.0, 0.0), 0.0);
-}
-`,
-};
-
-const confirmExtension = (gl, name) => {
-  const shader = gl.createShader(gl.FRAGMENT_SHADER);
-  gl.shaderSource(shader, testShaders[name]);
-  gl.compileShader(shader);
-
-  const status = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
-
-  gl.deleteShader(shader);
-  return status;
-};
+export const getContext = (canvas, options) =>
+  canvas.getContext('webgl', options) ||
+  canvas.getContext('experimental-webgl', options);
 
 /**
  * Patch the values reported by WebGLRenderingContext's
  * extension store to fix compatibility issues.
  */
 export const applyExtensionCompatibility = gl => {
+  const testShaders = {
+    // In some Firefox builds (mobile Android on Pixel at least),
+    // EXT_shader_texture_lod is reported as being supported, but
+    // fails in practice.
+    // @see https://bugzilla.mozilla.org/show_bug.cgi?id=1451287
+    'EXT_shader_texture_lod': `
+      #extension GL_EXT_shader_texture_lod : enable
+      precision mediump float;
+      uniform sampler2D tex;
+      void main() {
+        gl_FragColor = texture2DLodEXT(tex, vec2(0.0, 0.0), 0.0);
+      }`,
+  };
+
+  function confirmExtension (gl, name) {
+    const shader = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(shader, testShaders[name]);
+    gl.compileShader(shader);
+
+    const status = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+
+    gl.deleteShader(shader);
+    return status;
+  }
+
   const getExtension = gl.getExtension;
   gl.getExtension = name => {
     let extension;


### PR DESCRIPTION
Since IE11 supports this type. Fixes #253 
Changed the WebGL extensions utility to a general webgl utility. Ideally, three would handle this context picking for us, but it accesses extensions during context creation, so we need to patch the context before creating the WebGLRenderer.