### PR TITLE
Remove fullscreen request needed only for experimental WebXR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11432,6 +11432,12 @@
         "triple-beam": "^1.2.0"
       }
     },
+    "wkfs-polyfill": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/wkfs-polyfill/-/wkfs-polyfill-0.2.1.tgz",
+      "integrity": "sha512-BEpaZJrcoSv8j+vIJfrBBUAYyFymlx156he8WaCs603qbnujx9vxtVociFPTEcIWQY9/y68rIAHh1Rl+8MzBqw==",
+      "dev": true
+    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "typescript": "^3.1.3",
     "wct-browser-legacy": "^1.0.1",
-    "web-component-tester": "^6.9.2"
+    "web-component-tester": "^6.9.2",
+    "wkfs-polyfill": "^0.2.1"
   },
   "dependencies": {
     "lit-element": "^2.0.0",

--- a/src/model-viewer-base.ts
+++ b/src/model-viewer-base.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import 'wkfs-polyfill';
 import {property} from 'lit-element';
 import {UpdatingElement} from 'lit-element/lib/updating-element';
 


### PR DESCRIPTION
<!-- Instructions: https://github.com/GoogleWebComponents/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
Fixes #543 

Unless I'm not understanding the use of the Fullscreen API call purpose here, doing an Intent to the native ARCore viewer does not require the Fullscreen API and this matches the description https://github.com/GoogleWebComponents/model-viewer/blob/master/POLYFILLS.md#regarding-fullscreen-api of only needing for the 'experimental Web XR Device API-based AR mode'.