### PR TITLE
Implemented interaction-policy 'allow-toggle'

### DIFF
--- a/src/test/features/controls-spec.ts
+++ b/src/test/features/controls-spec.ts
@@ -283,6 +283,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
       test('creates SmoothControls if enabled', () => {
         expect(controls).to.be.ok;
+        expect(controls.interactionEnabled).to.be.true;
       });
 
       test(
@@ -303,6 +304,17 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
                 .to.be.equal('always-allow');
           });
 
+      test(
+          'sets controls interactionPolicy to allow-toggle',
+          async () => {
+            element.interactionPolicy = 'allow-toggle';
+            await timePasses();
+            expect(controls.options.interactionPolicy)
+                .to.be.equal('allow-toggle');
+            expect(controls.interactionEnabled)
+                .to.be.false;
+          });
+
       test('sets max radius greater than the camera framed distance', () => {
         const cameraDistance = element[$scene].camera.position.distanceTo(
             element[$scene].model.position);
@@ -314,6 +326,49 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         element.cameraControls = false;
         await timePasses();
         expect(controls.interactionEnabled).to.be.false;
+      });
+
+      suite('interactionPolicy allow-toggle', () => {
+        test(
+          'toggles interactionEnable on click',
+          async () => {
+            element.interactionPolicy = 'allow-toggle';
+            await timePasses();
+            expect(controls.interactionEnabled, 'initial')
+                .to.be.false;
+            
+            dispatchSyntheticEvent(element, 'click', {clientX: 0, clientY: 10});
+
+            expect(controls.interactionEnabled, 'toggled on')
+                .to.be.true;
+
+            dispatchSyntheticEvent(element, 'click', {clientX: 0, clientY: 10});
+
+            expect(controls.interactionEnabled, 'toggled off')
+                .to.be.false;
+          });
+
+        test(
+          'does not toggle interactionEnabled on drag',
+          async () => {
+            element.interactionPolicy = 'allow-toggle';
+            await timePasses();
+            expect(controls.interactionEnabled, 'initial')
+                .to.be.false;
+            
+            dispatchSyntheticEvent(element, 'click', {clientX: 0, clientY: 10});
+
+            expect(controls.interactionEnabled, 'toggled on')
+                .to.be.true;
+
+            dispatchSyntheticEvent(element, 'mousedown', {clientX: 0, clientY: 10});
+            dispatchSyntheticEvent(element, 'mousemove', {clientX: 200, clientY: 200});
+            dispatchSyntheticEvent(element, 'mouseup', {clientX: 200, clientY: 200});
+            dispatchSyntheticEvent(element, 'click', {clientX: 200, clientY: 200});
+
+            expect(controls.interactionEnabled, 'keeps toggle on')
+                .to.be.true;
+          });
       });
 
       suite('when user is interacting', () => {

--- a/src/test/three-components/SmoothControls-spec.ts
+++ b/src/test/three-components/SmoothControls-spec.ts
@@ -402,6 +402,103 @@ suite('SmoothControls', () => {
             expect(controls.getFieldOfView())
                 .to.be.lessThan(DEFAULT_OPTIONS.maximumFieldOfView!);
           });
+
+          test('handles cursor when interaction enabled', () => {
+            expect(element.style.cursor).to.be.equal('grab');
+          });
+
+          test('handles cursor when interaction start', () => {
+            dispatchSyntheticEvent(element, 'mousedown');
+
+            expect(element.style.cursor).to.be.equal('grabbing');
+          });
+
+          test('handles cursor when disabled', () => {
+            controls.disableInteraction();
+
+            expect(element.style.cursor).to.be.equal('');
+          });
+        });
+
+        suite('allow-toggle', () => {
+          setup(() => {
+            controls.applyOptions({interactionPolicy: 'allow-toggle'});
+            settleControls(controls);
+          });
+
+          test('handles cursor when interaction enabled', () => {
+            expect(element.style.cursor).to.be.equal('grab');
+          });
+
+          test('handles cursor when interaction start', () => {
+            dispatchSyntheticEvent(element, 'mousedown');
+
+            expect(element.style.cursor).to.be.equal('grabbing');
+          });
+
+          test('handles cursor when interaction disabled', () => {
+            controls.disableInteraction();
+
+            expect(element.style.cursor).to.be.equal('pointer');
+          });
+        });
+
+        suite('wasDragInteraction', () => {
+          setup(() => {
+            controls.applyOptions({interactionPolicy: 'always-allow'});
+            settleControls(controls);
+          });
+
+          test('wasDragInteraction false when no mousemove', () => {
+            dispatchSyntheticEvent(element, 'mousedown', {clientX: 0, clientY: 10});
+            dispatchSyntheticEvent(element, 'mouseup', {clientX: 0, clientY: 10});
+
+            expect(controls.wasDragInteraction()).to.be.false;
+          });
+
+          test('wasDragInteraction true when mousemove', () => {
+            dispatchSyntheticEvent(element, 'mousedown', {clientX: 0, clientY: 10});
+            dispatchSyntheticEvent(
+              element, 'mousemove',
+              {clientX: controls.options.minDragDistance, clientY: 10}
+            );
+            dispatchSyntheticEvent(element, 'mouseup',
+              {clientX: controls.options.minDragDistance, clientY: 10}
+            );
+
+            expect(controls.wasDragInteraction()).to.be.true;
+          });
+
+          test('not wasDragInteraction when small mousemove', () => {
+            dispatchSyntheticEvent(element, 'mousedown', {clientX: 0, clientY: 10});
+            dispatchSyntheticEvent(element, 'mousemove', {clientX: 1, clientY: 10});
+            dispatchSyntheticEvent(element, 'mouseup', {clientX: 0, clientY: 10});
+
+            expect(controls.wasDragInteraction()).to.be.false;
+          });
+
+          test('wasDragInteraction when mouseup greater than minDragDistance', () => {
+            dispatchSyntheticEvent(element, 'mousedown', {clientX: 0, clientY: 0});
+            dispatchSyntheticEvent(
+              element, 'mouseup',
+              {clientX: controls.options.minDragDistance! * 2, clientY: 0}
+            );
+
+            expect(controls.wasDragInteraction()).to.be.true;
+          });
+
+          test('wasDragInteraction when mouseup ends in the same spot', () => {
+            const touchUpAndDownPointer = {clientX: 0, clientY: 10};
+            dispatchSyntheticEvent(element, 'mousedown', touchUpAndDownPointer);
+            dispatchSyntheticEvent(
+              element, 'mousemove',
+              {clientX: 10000, clientY: 0}
+            );
+            dispatchSyntheticEvent(element, 'mouseup', touchUpAndDownPointer);
+            
+            // expect(controls.distanceMoved()).to.eql(100);
+            expect(controls.wasDragInteraction()).to.be.true;
+          });
         });
 
         suite('events', () => {


### PR DESCRIPTION
## What?

This PR creates a new `interaction-policy` called `allow-toggle`. When this interaction policy is enabled users must tap/click on the `<model-viewer>` to turn on the ability interact (orbit / zoom). Once the initial tap/click is performed then the user can interact with the `<model-viewer>` as per normal for instance by dragging to rotate the model.

## Why?

On mobile there are a some cases where `<model-viewer>` interferes with normal interaction. For instance:

- When a `<model-viewer>`  takes up the entire page and the user is trying to scroll below the fold but cannot since the `<model-viewer>` fills the entire page
- When a `<model-viewer>` is in a carousel and you can swipe/drag on the carousel to go to the next slide `<model-viewer>` will prevent this interaction

## What to focus on?

- The `click` event is used to toggle interaction in `controls.ts`
- `controls.ts` aims to still have logic to enable/disable interactions on `SmoothControls` vs all logic for toggling interaction living in `SmoothControls`
- `click` is fired after a `mousemove` on desktop which means that if the user has dragged we should assume they want to continue interacting with the `<model-viewer>` and not toggle off/disable interaction
- On desktop the cursor is a `pointer` when the `<model-viewer>` interaction has not been toggled. Once toggled it becomes `grab`. When dragging the cursor is `grabbing`

## Further work

- There's a piece of UX missing which is some sort icon/indicator that shows whether the `<model-viewer>` can be interacted with (think a play pause button on a video player)
- Likely some sort of event must be fired to let the hosted application/page know whether interaction is enabled/disabled
- It maybe advantageous to refactor `cursor` logic out of `SmoothControls`