### PR TITLE
Hotspot helper

### DIFF
--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -214,13 +214,21 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       this[$pixelPosition].y *= -1;
       raycaster.setFromCamera(this[$pixelPosition], this[$scene].getCamera());
       const hits = raycaster.intersectObject(this[$scene], true);
+
       if (hits.length === 0) {
         return {position: '', normal: ''};
       }
       const hit = hits[0];
+
       const {x, y, z} = hit.point;
       const hitPosition = `${x}m ${y}m ${z}m`;
-      const hitNormal = '0 0 1';
+
+      let hitNormal = '0 1 0';
+      if (hit.face != null) {
+        const {x: nx, y: ny, z: nz} = hit.face.normal;
+        hitNormal = `${- nx} ${ny} ${- nz}`;
+      }
+
       return {position: hitPosition, normal: hitNormal};
     }
 

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -17,7 +17,7 @@
 import {Matrix4, Raycaster, Vector2, Vector3} from 'three';
 import {CSS2DObject, CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
-import ModelViewerElementBase, {$onResize, $scene, $tick, Vector3D} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$onResize, $scene, $tick, toVector3D} from '../model-viewer-base.js';
 import {normalizeUnit} from '../styles/conversions.js';
 import {NumberNode, parseExpressions} from '../styles/parsers.js';
 import {Constructor} from '../utilities.js';
@@ -112,8 +112,7 @@ export class Hotspot extends CSS2DObject {
 
 export declare interface AnnotationInterface {
   updateHotspot(config: HotspotConfiguration): void;
-  positionAndNormalFromPoint(pixelX: number, pixelY: number):
-      {position?: Vector3D, normal?: Vector3D}
+  positionAndNormalFromPoint(pixelX: number, pixelY: number)
 }
 
 /**
@@ -209,8 +208,7 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
      * data-normal attributes. If the mesh is not hit, position returns the
      * empty string.
      */
-    positionAndNormalFromPoint(pixelX: number, pixelY: number):
-        {position?: Vector3D, normal?: Vector3D} {
+    positionAndNormalFromPoint(pixelX: number, pixelY: number) {
       const {width, height} = this[$scene];
       this[$pixelPosition]
           .set(pixelX / width, pixelY / height)
@@ -221,22 +219,19 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       const hits = raycaster.intersectObject(this[$scene], true);
 
       if (hits.length === 0) {
-        return {};
+        return {position: null, normal: null};
       }
       const hit = hits[0];
       const worldToPivot =
           new Matrix4().getInverse(this[$scene].pivot.matrixWorld);
-      const position = new Vector3D();
-      Object.assign(position, hit.point.applyMatrix4(worldToPivot));
+      const position = toVector3D(hit.point.applyMatrix4(worldToPivot));
 
       if (hit.face == null) {
-        return {position: position};
+        return {position: position, normal: null};
       }
-      const normal = new Vector3D();
-      Object.assign(
-          normal,
-          hit.face.normal.applyMatrix4(hit.object.matrixWorld)
-              .applyMatrix4(worldToPivot));
+      const normal =
+          toVector3D(hit.face.normal.applyMatrix4(hit.object.matrixWorld)
+                         .applyMatrix4(worldToPivot));
       return {position: position, normal: normal};
     }
 

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Raycaster, Vector2, Vector3} from 'three';
+import {Matrix4, Raycaster, Vector2, Vector3} from 'three';
 import {CSS2DObject, CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
 import ModelViewerElementBase, {$onResize, $scene, $tick, Vector3D} from '../model-viewer-base.js';
@@ -225,7 +225,10 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
       const hit = hits[0];
       const position = new Vector3D();
-      Object.assign(position, hit.point);
+      Object.assign(
+          position,
+          hit.point.applyMatrix4(
+              new Matrix4().getInverse(this[$scene].pivot.matrixWorld)));
 
       if (hit.face == null) {
         return {position: position};

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -17,7 +17,7 @@
 import {Matrix4, Raycaster, Vector2, Vector3} from 'three';
 import {CSS2DObject, CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
-import ModelViewerElementBase, {$onResize, $scene, $tick, toVector3D} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$onResize, $scene, $tick, toVector3D, Vector3D} from '../model-viewer-base.js';
 import {normalizeUnit} from '../styles/conversions.js';
 import {NumberNode, parseExpressions} from '../styles/parsers.js';
 import {Constructor} from '../utilities.js';
@@ -112,7 +112,8 @@ export class Hotspot extends CSS2DObject {
 
 export declare interface AnnotationInterface {
   updateHotspot(config: HotspotConfiguration): void;
-  positionAndNormalFromPoint(pixelX: number, pixelY: number)
+  positionAndNormalFromPoint(pixelX: number, pixelY: number):
+      {position: Vector3D|null, normal: Vector3D|null}
 }
 
 /**
@@ -208,7 +209,8 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
      * data-normal attributes. If the mesh is not hit, position returns the
      * empty string.
      */
-    positionAndNormalFromPoint(pixelX: number, pixelY: number) {
+    positionAndNormalFromPoint(pixelX: number, pixelY: number):
+        {position: Vector3D|null, normal: Vector3D|null} {
       const {width, height} = this[$scene];
       this[$pixelPosition]
           .set(pixelX / width, pixelY / height)

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -113,7 +113,7 @@ export class Hotspot extends CSS2DObject {
 export declare interface AnnotationInterface {
   updateHotspot(config: HotspotConfiguration): void;
   positionAndNormalFromPoint(pixelX: number, pixelY: number):
-      {position: Vector3D|null, normal: Vector3D|null}
+      {position: Vector3D, normal: Vector3D}|null
 }
 
 /**
@@ -210,7 +210,7 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
      * empty string.
      */
     positionAndNormalFromPoint(pixelX: number, pixelY: number):
-        {position: Vector3D|null, normal: Vector3D|null} {
+        {position: Vector3D, normal: Vector3D}|null {
       const {width, height} = this[$scene];
       this[$pixelPosition]
           .set(pixelX / width, pixelY / height)
@@ -221,16 +221,17 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       const hits = raycaster.intersectObject(this[$scene], true);
 
       if (hits.length === 0) {
-        return {position: null, normal: null};
+        return null;
       }
+
       const hit = hits[0];
+      if (hit.face == null) {
+        return null;
+      }
+
       const worldToPivot =
           new Matrix4().getInverse(this[$scene].pivot.matrixWorld);
       const position = toVector3D(hit.point.applyMatrix4(worldToPivot));
-
-      if (hit.face == null) {
-        return {position: position, normal: null};
-      }
       const normal =
           toVector3D(hit.face.normal.applyMatrix4(hit.object.matrixWorld)
                          .applyMatrix4(worldToPivot));

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -205,6 +205,14 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       hotspot.updateNormal(config.normal);
     }
 
+    /**
+     * This method returns the world position and normal of the point on the
+     * mesh corresponding to the input pixel coordinates given relative to the
+     * model-viewer element. The position and normal are returned as strings in
+     * the format suitable for putting in a hotspot's data-position and
+     * data-normal attributes. If the mesh is not hit, position returns the
+     * empty string.
+     */
     getHitResult(pixelX: number, pixelY: number): HitResult {
       const {width, height} = this[$scene];
       this[$pixelPosition]

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -17,7 +17,7 @@ import {property} from 'lit-element';
 import {Event, PerspectiveCamera, Spherical, Vector3} from 'three';
 
 import {style} from '../decorators.js';
-import ModelViewerElementBase, {$ariaLabel, $loadedTime, $needsRender, $onModelLoad, $onResize, $scene, $tick} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$ariaLabel, $loadedTime, $needsRender, $onModelLoad, $onResize, $scene, $tick, Vector3D} from '../model-viewer-base.js';
 import {degreesToRadians, normalizeUnit} from '../styles/conversions.js';
 import {EvaluatedStyle, Intrinsics, SphericalIntrinsics, Vector3Intrinsics} from '../styles/evaluators.js';
 import {IdentNode, NumberNode, numberNode, parseExpressions} from '../styles/parsers.js';
@@ -222,7 +222,7 @@ export declare interface ControlsInterface {
   interactionPolicy: InteractionPolicy;
   interactionPromptThreshold: number;
   getCameraOrbit(): SphericalPosition;
-  getCameraTarget(): Vector3;
+  getCameraTarget(): Vector3D;
   getFieldOfView(): number;
   jumpCameraToGoal(): void;
 }
@@ -336,7 +336,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       return {theta, phi, radius};
     }
 
-    getCameraTarget(): Vector3 {
+    getCameraTarget(): Vector3D {
       return this[$controls].getTarget();
     }
 
@@ -511,7 +511,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       this[$controls].update(time, delta);
-      const target = this.getCameraTarget();
+      const target = this[$controls].getTarget();
       if (!this[$scene].pivotCenter.equals(target)) {
         this[$scene].pivotCenter.copy(target);
         this[$scene].setPivotRotation(this[$scene].getPivotRotation());

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -15,7 +15,7 @@
 
 import {property} from 'lit-element';
 import {UpdatingElement} from 'lit-element/lib/updating-element';
-import {Event as ThreeEvent} from 'three';
+import {Event as ThreeEvent, Vector3} from 'three';
 
 import {HAS_INTERSECTION_OBSERVER, HAS_RESIZE_OBSERVER} from './constants.js';
 import {makeTemplate} from './template.js';
@@ -61,13 +61,16 @@ export const $progressTracker = Symbol('progressTracker');
 export const $getLoaded = Symbol('getLoaded');
 export const $getModelIsVisible = Symbol('getModelIsVisible');
 
-export class Vector3D {
-  constructor(public x = 0, public y = 0, public z = 0) {
-  }
-  toString(): string {
-    return `${this.x}m ${this.y}m ${this.z}m`;
-  }
-}
+export const toVector3D = (v: Vector3) => {
+  return {
+    x: v.x,
+    y: v.y,
+    z: v.z,
+    toString() {
+      return `${this.x}m ${this.y}m ${this.z}m`;
+    }
+  };
+};
 
 interface ToBlobOptions {
   mimeType?: string, qualityArgument?: number, idealAspect?: boolean

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -61,6 +61,15 @@ export const $progressTracker = Symbol('progressTracker');
 export const $getLoaded = Symbol('getLoaded');
 export const $getModelIsVisible = Symbol('getModelIsVisible');
 
+export class Vector3D {
+  public x = 0;
+  public y = 0;
+  public z = 0;
+  toString(): string {
+    return `${this.x}m ${this.y}m ${this.z}m`;
+  }
+}
+
 interface ToBlobOptions {
   mimeType?: string, qualityArgument?: number, idealAspect?: boolean
 }

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -62,9 +62,8 @@ export const $getLoaded = Symbol('getLoaded');
 export const $getModelIsVisible = Symbol('getModelIsVisible');
 
 export class Vector3D {
-  public x = 0;
-  public y = 0;
-  public z = 0;
+  constructor(public x = 0, public y = 0, public z = 0) {
+  }
   toString(): string {
     return `${this.x}m ${this.y}m ${this.z}m`;
   }

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -61,6 +61,13 @@ export const $progressTracker = Symbol('progressTracker');
 export const $getLoaded = Symbol('getLoaded');
 export const $getModelIsVisible = Symbol('getModelIsVisible');
 
+export interface Vector3D {
+  x: number
+  y: number
+  z: number
+  toString(): string
+}
+
 export const toVector3D = (v: Vector3) => {
   return {
     x: v.x,

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -101,7 +101,7 @@ canvas.show {
 }
 
 .hide ::slotted(*) {
-  opacity: var(--min-opacity, 0.25);
+  opacity: var(--min-hotspot-opacity, 0.25);
 }
 
 .slot.poster {

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -185,7 +185,7 @@ suite('ModelViewerElementBase with AnnotationMixin', () => {
 
     test('gets expected hit result', () => {
       const {position, normal} =
-          element.positionAndNormalFromPoint(width / 2, height / 2);
+          element.positionAndNormalFromPoint(width / 2, height / 2)!;
       closeToVector3(position!, new Vector3(0, 0, 0.5));
       closeToVector3(normal!, new Vector3(0, 0, 1));
     });
@@ -194,7 +194,7 @@ suite('ModelViewerElementBase with AnnotationMixin', () => {
       element[$scene].setPivotRotation(-Math.PI / 2);
       element[$scene].updateMatrixWorld();
       const {position, normal} =
-          element.positionAndNormalFromPoint(width / 2, height / 2);
+          element.positionAndNormalFromPoint(width / 2, height / 2)!;
       closeToVector3(position!, new Vector3(0.5, 0, 0));
       closeToVector3(normal!, new Vector3(1, 0, 0));
     });

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -40,6 +40,13 @@ const sceneContainsHotspot =
       return false;
     };
 
+const closeToVector3D = (a: Vector3D, b: Vector3D) => {
+  const delta = 0.001;
+  expect(a.x).to.be.closeTo(b.x, delta);
+  expect(a.y).to.be.closeTo(b.y, delta);
+  expect(a.z).to.be.closeTo(b.z, delta);
+};
+
 suite('ModelViewerElementBase with AnnotationMixin', () => {
   let nextId = 0;
   let tagName: string;
@@ -146,17 +153,27 @@ suite('ModelViewerElementBase with AnnotationMixin', () => {
       height = 300;
       element.setAttribute('style', `width: ${width}px; height: ${height}px`);
       element.src = assetPath('models/cube.gltf');
-      await waitForEvent(element, 'load');
-    });
 
-    test('gets expect hit result', async () => {
       const camera = element[$scene].getCamera();
       camera.position.z = 2;
       camera.updateMatrixWorld();
+      await waitForEvent(element, 'load');
+    });
+
+    test('gets expected hit result', async () => {
       const {position, normal} =
           element.positionAndNormalFromPoint(width / 2, height / 2);
       expect(position).to.be.deep.equal(new Vector3D(0, 0, 0.5));
       expect(normal).to.be.deep.equal(new Vector3D(0, 0, 1));
+    });
+
+    test('gets expected hit result when turned', async () => {
+      element[$scene].setPivotRotation(-Math.PI / 2);
+      element[$scene].updateMatrixWorld();
+      const {position, normal} =
+          element.positionAndNormalFromPoint(width / 2, height / 2);
+      closeToVector3D(position!, new Vector3D(0.5, 0, 0));
+      closeToVector3D(normal!, new Vector3D(1, 0, 0));
     });
   });
 });

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -151,10 +151,11 @@ suite('ModelViewerElementBase with AnnotationMixin', () => {
 
     test('gets expect hit result', async () => {
       const camera = element[$scene].getCamera();
-      camera.position.z = -2;
+      camera.position.z = 2;
+      camera.updateMatrixWorld();
       const {position, normal} =
           element.positionAndNormalFromPoint(width / 2, height / 2);
-      expect(position).to.be.deep.equal(new Vector3D(0, 0, 1));
+      expect(position).to.be.deep.equal(new Vector3D(0, 0, 0.5));
       expect(normal).to.be.deep.equal(new Vector3D(0, 0, 1));
     });
   });

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -40,7 +40,7 @@ const sceneContainsHotspot =
       return false;
     };
 
-const closeToVector3D = (a: Vector3D, b: Vector3D) => {
+const closeToVector3 = (a: Vector3D, b: Vector3) => {
   const delta = 0.001;
   expect(a.x).to.be.closeTo(b.x, delta);
   expect(a.y).to.be.closeTo(b.y, delta);
@@ -186,8 +186,8 @@ suite('ModelViewerElementBase with AnnotationMixin', () => {
     test('gets expected hit result', () => {
       const {position, normal} =
           element.positionAndNormalFromPoint(width / 2, height / 2);
-      expect(position).to.be.deep.equal(new Vector3D(0, 0, 0.5));
-      expect(normal).to.be.deep.equal(new Vector3D(0, 0, 1));
+      closeToVector3(position!, new Vector3(0, 0, 0.5));
+      closeToVector3(normal!, new Vector3(0, 0, 1));
     });
 
     test('gets expected hit result when turned', () => {
@@ -195,8 +195,8 @@ suite('ModelViewerElementBase with AnnotationMixin', () => {
       element[$scene].updateMatrixWorld();
       const {position, normal} =
           element.positionAndNormalFromPoint(width / 2, height / 2);
-      closeToVector3D(position!, new Vector3D(0.5, 0, 0));
-      closeToVector3D(normal!, new Vector3D(1, 0, 0));
+      closeToVector3(position!, new Vector3(0.5, 0, 0));
+      closeToVector3(normal!, new Vector3(1, 0, 0));
     });
   });
 });

--- a/packages/modelviewer.dev/examples/annotations.html
+++ b/packages/modelviewer.dev/examples/annotations.html
@@ -57,7 +57,7 @@
           This page showcases how you can add hotspots to your scene. Child elements are hotspots if their slot begins with "hotspot".
           The data-position attribute specifies the 3D position of the hotspot in model coordinates, using the same format as the
           camera-target attribute. The data-normal attribute specifies the normal vector defining the "front" of the hotspot.
-          When this normal is pointed away from the viewer, the hotspot will be reduced to --min-opacity. The 
+          When this normal is pointed away from the viewer, the hotspot's opacity becomes --min-hotspot-opacity. The 
           <a href="tester.html">interactive example</a> lets you drag and drop your own models and add hotspots by clicking
           and displays the corresponding position and normal attributes which you can copy into your own page.</h4>
         <div class="heading">
@@ -75,7 +75,7 @@
     background-color: blue;
   }
   button[slot="hotspot-hand"]{
-    --min-opacity: 0;
+    --min-hotspot-opacity: 0;
     background-color: red;
   }
   #annotation{

--- a/packages/modelviewer.dev/examples/annotations.html
+++ b/packages/modelviewer.dev/examples/annotations.html
@@ -53,7 +53,13 @@
     <div class="content">
       <div class="wrapper">
         <a class="lockup" href="../index.html"><div class="icon-button icon-modelviewer-black"></div><h1>examples</h1></a>
-        <h4 id="intro"><span class="font-medium">Annotations. </span>Use &lt;model-viewer&gt; to make your models interactive. This page showcases how you can add hotspots to your scene.</h4>
+        <h4 id="intro"><span class="font-medium">Annotations. </span>Use &lt;model-viewer&gt; to make your models interactive. 
+          This page showcases how you can add hotspots to your scene. Child elements are hotspots if their slot begins with "hotspot".
+          The data-position attribute specifies the 3D position of the hotspot in model coordinates, using the same format as the
+          camera-target attribute. The data-normal attribute specifies the normal vector defining the "front" of the hotspot.
+          When this normal is pointed away from the viewer, the hotspot will be reduced to --min-opacity. The 
+          <a href="tester.html">interactive example</a> lets you drag and drop your own models and add hotspots by clicking
+          and displays the corresponding position and normal attributes which you can copy into your own page.</h4>
         <div class="heading">
           <h2 class="demo-title">Add hotspots</h2>
           <h4></h4>

--- a/packages/modelviewer.dev/examples/tester.html
+++ b/packages/modelviewer.dev/examples/tester.html
@@ -89,13 +89,30 @@
       margin-bottom: 20px;
     }
 
-		.hotspot{
-			width: 20px;
-			height: 20px;
-			border-radius: 10px;
-			border: none;
-			background-color: blue;
-		}
+    .hotspot{
+      width: 20px;
+      height: 20px;
+      border-radius: 10px;
+      border: none;
+      background-color: blue;
+    }
+
+    .annotation{
+      background-color: #888888;
+      position: absolute;
+      transform: translate(10px, 10px);
+      border-radius: 10px;
+      padding: 10px;
+      text-align: left;
+    }
+
+    .hotspot.selected{
+      background-color: red;
+    }
+
+    .hotspot:not(.selected) > .annotation{
+      display: none;
+    }
 
     @media screen and (max-width: 320px) {
       #instructions {

--- a/packages/modelviewer.dev/examples/tester.html
+++ b/packages/modelviewer.dev/examples/tester.html
@@ -89,6 +89,14 @@
       margin-bottom: 20px;
     }
 
+		.hotspot{
+			width: 20px;
+			height: 20px;
+			border-radius: 10px;
+			border: none;
+			background-color: blue;
+		}
+
     @media screen and (max-width: 320px) {
       #instructions {
         display: none;
@@ -160,7 +168,13 @@
     Click the model to dismiss the poster and interact. To save your poster, click:<br/>
     <button id="download" onclick="downloadPoster()">Download Poster</button><br/>
     camera-orbit:
-    <div id="cameraOrbit"></div>
+		<div id="cameraOrbit"></div><br/><br/>
+		
+		To calculate hotspot locations, click:<br/>
+		<button onclick="addHotspot()">Add Hotspot</button><br/>
+		Then click on the model.<br/>
+		To remove a hotspot, select it, then click:<br/>
+		<button onclick="removeHotspot()">Remove Hotspot</button><br/>
     
     </div> 
     <model-viewer id="loading-demo" autoplay camera-controls interaction-prompt="none"

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -518,8 +518,7 @@
               model-viewer element. The position and normal are returned as
               Vector3D, which has a method toString() that outputs a format
               suitable for putting in a hotspot's data-position and data-normal
-              attributes. If the mesh is not hit, position and normal return
-              null.</p>
+              attributes. Position and normal return null if they are not found.</p>
             </li>
             <li>
               <div>jumpCameraToGoal()</div>

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -512,6 +512,15 @@
               attribute on account of user interaction or camera interpolation.</p>
             </li>
             <li>
+              <div>getHitResult(pixelX, pixelY)</div>
+              <p>Returns the world position and normal of the point on the mesh
+              corresponding to the input pixel coordinates given relative to the
+              model-viewer element. The position and normal are returned as strings in
+              the format suitable for putting in a hotspot's data-position and
+              data-normal attributes. If the mesh is not hit, position returns the
+              empty string.</p>
+            </li>
+            <li>
               <div>jumpCameraToGoal()</div>
               <p>Changes the camera to its last configured goal state immediately on 
               the next update instead of interpolating the motion over time.</p>

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -518,7 +518,7 @@
               model-viewer element. The position and normal are returned as
               Vector3D, which has a method toString() that outputs a format
               suitable for putting in a hotspot's data-position and data-normal
-              attributes. Position and normal return null if they are not found.</p>
+              attributes. The function returns null if no object is hit.</p>
             </li>
             <li>
               <div>jumpCameraToGoal()</div>

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -512,7 +512,7 @@
               attribute on account of user interaction or camera interpolation.</p>
             </li>
             <li>
-              <div>getHitResult(pixelX, pixelY)</div>
+              <div>positionAndNormalFromPoint(pixelX, pixelY)</div>
               <p>Returns the world position and normal of the point on the mesh
               corresponding to the input pixel coordinates given relative to the
               model-viewer element. The position and normal are returned as strings in

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -515,10 +515,11 @@
               <div>positionAndNormalFromPoint(pixelX, pixelY)</div>
               <p>Returns the world position and normal of the point on the mesh
               corresponding to the input pixel coordinates given relative to the
-              model-viewer element. The position and normal are returned as strings in
-              the format suitable for putting in a hotspot's data-position and
-              data-normal attributes. If the mesh is not hit, position returns the
-              empty string.</p>
+              model-viewer element. The position and normal are returned as
+              Vector3D, which has a method toString() that outputs a format
+              suitable for putting in a hotspot's data-position and data-normal
+              attributes. If the mesh is not hit, position and normal return
+              null.</p>
             </li>
             <li>
               <div>jumpCameraToGoal()</div>

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -394,7 +394,7 @@
               to be used to force the prompt to be hidden. Defaults to flex.</p>
             </li>
             <li>
-              <div>--min-opacity</div>
+              <div>--min-hotspot-opacity</div>
               <p>Sets the opacity of hidden hotspots. Defaults to 0.25.</p>
             </li>
             <li>

--- a/packages/modelviewer.dev/src/tester.ts
+++ b/packages/modelviewer.dev/src/tester.ts
@@ -148,12 +148,13 @@ function onClick(event: MouseEvent) {
   const rect = viewer.getBoundingClientRect();
   const x = event.clientX - rect.left;
   const y = event.clientY - rect.top;
-  const {position, normal} = viewer.positionAndNormalFromPoint(x, y);
+  const positionAndNormal = viewer.positionAndNormalFromPoint(x, y);
 
-  if (position == null) {
+  if (positionAndNormal == null) {
     console.log('no hit result: mouse = ', x, ', ', y);
     return;
   }
+  const {position, normal} = positionAndNormal;
 
   const hotspot = document.createElement('button');
   hotspot.slot = `hotspot-${hotspotCounter++}`;

--- a/packages/modelviewer.dev/src/tester.ts
+++ b/packages/modelviewer.dev/src/tester.ts
@@ -119,9 +119,38 @@ export function downloadPoster() {
   a.click();
 }
 
+export function addHotspot() {
+  viewer.addEventListener('click', onClick);
+}
+
+export function removeHotspot() {
+}
+
+let hotspotCounter = 0;
+
+function onClick(event: MouseEvent) {
+  const rect = viewer.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+  const hitResult = viewer.getHitResult(x, y);
+  if (hitResult.position === '') {
+    console.log('no hit result: mouse = ', x, ', ', y);
+    return;
+  }
+  const hotspot = document.createElement('button');
+  hotspot.slot = `hotspot-${hotspotCounter++}`;
+  hotspot.classList.add('hotspot');
+  hotspot.dataset.position = hitResult.position;
+  hotspot.dataset.normal = hitResult.normal;
+  viewer.appendChild(hotspot);
+  viewer.removeEventListener('click', onClick);
+}
+
 (self as any).createPoster = createPoster;
 (self as any).reloadScene = reloadScene;
 (self as any).downloadPoster = downloadPoster;
+(self as any).addHotspot = addHotspot;
+(self as any).removeHotspot = removeHotspot;
 
 function load(fileMap: Map<string, File>) {
   let rootPath: string;

--- a/packages/modelviewer.dev/src/tester.ts
+++ b/packages/modelviewer.dev/src/tester.ts
@@ -148,9 +148,9 @@ function onClick(event: MouseEvent) {
   const rect = viewer.getBoundingClientRect();
   const x = event.clientX - rect.left;
   const y = event.clientY - rect.top;
-  const hitResult = viewer.getHitResult(x, y);
+  const {position, normal} = viewer.positionAndNormalFromPoint(x, y);
 
-  if (hitResult.position === '') {
+  if (position == null) {
     console.log('no hit result: mouse = ', x, ', ', y);
     return;
   }
@@ -158,8 +158,10 @@ function onClick(event: MouseEvent) {
   const hotspot = document.createElement('button');
   hotspot.slot = `hotspot-${hotspotCounter++}`;
   hotspot.classList.add('hotspot');
-  hotspot.dataset.position = hitResult.position;
-  hotspot.dataset.normal = hitResult.normal;
+  hotspot.dataset.position = position.toString();
+  if (normal != null) {
+    hotspot.dataset.normal = normal.toString();
+  }
   viewer.appendChild(hotspot);
 
   select(hotspot);
@@ -167,8 +169,8 @@ function onClick(event: MouseEvent) {
 
   const label = document.createElement('div');
   label.classList.add('annotation');
-  label.textContent = 'data-position:\r\n' + hitResult.position +
-      '\r\ndata-normal:\r\n' + hitResult.normal;
+  label.textContent =
+      'data-position:\r\n' + position + '\r\ndata-normal:\r\n' + normal;
   hotspot.appendChild(label);
 
   viewer.removeEventListener('click', onClick);

--- a/packages/modelviewer.dev/src/tester.ts
+++ b/packages/modelviewer.dev/src/tester.ts
@@ -48,6 +48,10 @@ function resetModel() {
   viewer.dismissPoster();
   downloadButton.disabled = true;
   displayButton.disabled = true;
+  // remove hotspots
+  while (viewer.firstChild) {
+    viewer.removeChild(viewer.firstChild);
+  }
 }
 
 const useSkybox = document.getElementById('useSkybox') as HTMLInputElement;
@@ -123,26 +127,50 @@ export function addHotspot() {
   viewer.addEventListener('click', onClick);
 }
 
+let hotspotCounter = 0;
+let selectedHotspot: HTMLElement|undefined = undefined;
+
 export function removeHotspot() {
+  if (selectedHotspot != null) {
+    viewer.removeChild(selectedHotspot);
+  }
 }
 
-let hotspotCounter = 0;
+function select(hotspot: HTMLElement) {
+  for (let i = 0; i < viewer.children.length; i++) {
+    viewer.children[i].classList.remove('selected');
+  }
+  hotspot.classList.add('selected');
+  selectedHotspot = hotspot;
+}
 
 function onClick(event: MouseEvent) {
   const rect = viewer.getBoundingClientRect();
   const x = event.clientX - rect.left;
   const y = event.clientY - rect.top;
   const hitResult = viewer.getHitResult(x, y);
+
   if (hitResult.position === '') {
     console.log('no hit result: mouse = ', x, ', ', y);
     return;
   }
+
   const hotspot = document.createElement('button');
   hotspot.slot = `hotspot-${hotspotCounter++}`;
   hotspot.classList.add('hotspot');
   hotspot.dataset.position = hitResult.position;
   hotspot.dataset.normal = hitResult.normal;
   viewer.appendChild(hotspot);
+
+  select(hotspot);
+  hotspot.addEventListener('click', () => {select(hotspot)});
+
+  const label = document.createElement('div');
+  label.classList.add('annotation');
+  label.textContent = 'data-position:\r\n' + hitResult.position +
+      '\r\ndata-normal:\r\n' + hitResult.normal;
+  hotspot.appendChild(label);
+
   viewer.removeEventListener('click', onClick);
 }
 


### PR DESCRIPTION
Fixes #977 
Fixes #979 

In the spirit of getting our docs ready for release, I wanted to add a hotspot helper to our tester doc. In order to make this possible, I also had to add an API method, `getHitResult`, but I believe this is pretty generally useful anyway. Try out our interactive example and see how you can add hotspots by clicking on the model and they display the data-position and data-normal attribute values you need to put a hotspot there. 

One bug: I notice that different models are returning normal vectors seemingly in different coordinate systems. I'll resolve this before the PR lands, but I'd like some feedback in the meanwhile.