### PR TITLE
annotations - allow for pointer events to be controlled on the slotted element

### DIFF
--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -96,6 +96,10 @@ canvas.show {
   transition: opacity 0.5s;
 }
 
+.annotation-wrapper ::slotted(*) {
+  pointer-events: initial;
+}
+
 .hide ::slotted(*) {
   opacity: var(--min-hotspot-opacity, 0.25);
 }

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -47,10 +47,6 @@ template.innerHTML = `
   top: 0;
 }
 
-.annotation-wrapper {
-  pointer-events: auto;
-}
-
 canvas {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
<!-- Instructions: https://github.com/GoogleWebComponents/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Fixes #1019
- defers control of pointer events to slotted elements, similar to opacity
<!-- Example: Fixes #1234 -->
