### PR TITLE
Refinements to annotations feature

### DIFF
--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {Matrix4, Raycaster, Vector2, Vector3} from 'three';
-import {CSS2DObject, CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
+import {Matrix4, Raycaster, Vector2} from 'three';
+import {CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
 import ModelViewerElementBase, {$onResize, $scene, $tick, toVector3D, Vector3D} from '../model-viewer-base.js';
-import {normalizeUnit} from '../styles/conversions.js';
-import {NumberNode, parseExpressions} from '../styles/parsers.js';
 import {Constructor} from '../utilities.js';
+
+import {Hotspot, HotspotConfiguration} from './annotation/hotspot.js';
 
 const $annotationRenderer = Symbol('annotationRenderer');
 const $updateHotspots = Symbol('updateHotspots');
@@ -32,83 +32,6 @@ const $addHotspot = Symbol('addHotspot');
 const $removeHotspot = Symbol('removeHotspot');
 
 const raycaster = new Raycaster();
-
-/**
- * Hotspots are configured by slot name, and this name must begin with "hotspot"
- * to be recognized. The position and normal strings are in the form of the
- * camera-target attribute and default to "0m 0m 0m" and "0m 1m 0m",
- * respectively.
- */
-interface HotspotConfiguration {
-  name: string;
-  position?: string;
-  normal?: string;
-}
-
-/**
- * The Hotspot object is a reference-counted slot. If decrement() returns true,
- * it should be removed from the tree so it can be garbage-collected.
- */
-export class Hotspot extends CSS2DObject {
-  public normal: Vector3;
-  private referenceCount: number;
-
-  constructor(config: HotspotConfiguration) {
-    const wrapper = document.createElement('div');
-    wrapper.classList.add('annotation-wrapper');
-    const slot = document.createElement('slot');
-    slot.name = config.name;
-    wrapper.appendChild(slot);
-    super(wrapper);
-    this.normal = new Vector3(0, 1, 0);
-    this.updatePosition(config.position);
-    this.updateNormal(config.normal);
-    this.referenceCount = 1;
-  }
-
-  /**
-   * Call this when adding elements to the same slot to keep track.
-   */
-  increment() {
-    ++this.referenceCount;
-  }
-
-  /**
-   * Call this when removing elements from the slot; returns true when the slot
-   * is unused.
-   */
-  decrement(): boolean {
-    return --this.referenceCount <= 0;
-  }
-
-  /**
-   * Change the position of the hotspot to the input string, in the same format
-   * as the data-position attribute.
-   */
-  updatePosition(position?: string) {
-    if (position == null)
-      return;
-    const positionNodes = parseExpressions(position)[0].terms;
-    for (let i = 0; i < 3; ++i) {
-      this.position.setComponent(
-          i, normalizeUnit(positionNodes[i] as NumberNode<'m'>).number);
-    }
-  }
-
-  /**
-   * Change the hotspot's normal to the input string, in the same format as the
-   * data-normal attribute.
-   */
-  updateNormal(normal?: string) {
-    if (normal == null)
-      return;
-    const normalNodes = parseExpressions(normal)[0].terms;
-    for (let i = 0; i < 3; ++i) {
-      this.normal.setComponent(
-          i, normalizeUnit(normalNodes[i] as NumberNode<'m'>).number);
-    }
-  }
-}
 
 export declare interface AnnotationInterface {
   updateHotspot(config: HotspotConfiguration): void;
@@ -259,9 +182,9 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
           const normalWorld = hotspot.normal.clone().transformDirection(
               this[$scene].pivot.matrixWorld);
           if (view.dot(normalWorld) < 0) {
-            hotspot.element.classList.add('hide');
+            hotspot.hide();
           } else {
-            hotspot.element.classList.remove('hide');
+            hotspot.show();
           }
         }
       }
@@ -281,7 +204,8 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
         hotspot = new Hotspot({
           name: node.slot,
           position: node.dataset.position,
-          normal: node.dataset.normal
+          normal: node.dataset.normal,
+          visibilityAttribute: node.dataset.visibilityAttribute
         });
         this[$hotspotMap].set(node.slot, hotspot);
         this[$scene].pivot.add(hotspot);
@@ -302,6 +226,7 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       if (hotspot.decrement()) {
         this[$scene].pivot.remove(hotspot);
         this[$hotspotMap].delete(node.slot);
+        hotspot.dispose();
       }
     }
   }

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -205,7 +205,6 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
           name: node.slot,
           position: node.dataset.position,
           normal: node.dataset.normal,
-          visibilityAttribute: node.dataset.visibilityAttribute
         });
         this[$hotspotMap].set(node.slot, hotspot);
         this[$scene].pivot.add(hotspot);

--- a/packages/model-viewer/src/features/annotation/hotspot.ts
+++ b/packages/model-viewer/src/features/annotation/hotspot.ts
@@ -142,7 +142,14 @@ export class Hotspot extends CSS2DObject {
       const visibilityAttribute = element.dataset.visibilityAttribute;
 
       if (visibilityAttribute != null) {
-        element.toggleAttribute(`data-${visibilityAttribute}`, this[$visible]);
+        const attributeName = `data-${visibilityAttribute}`;
+
+        // NOTE: IE11 doesn't support toggleAttribute
+        if (this[$visible]) {
+          element.setAttribute(attributeName, '');
+        } else {
+          element.removeAttribute(attributeName);
+        }
       }
 
       if (notify) {

--- a/packages/model-viewer/src/features/annotation/hotspot.ts
+++ b/packages/model-viewer/src/features/annotation/hotspot.ts
@@ -17,7 +17,6 @@ export interface HotspotConfiguration {
   name: string;
   position?: string;
   normal?: string;
-  visibilityAttribute?: string;
 }
 
 const $slot = Symbol('slot');
@@ -144,6 +143,7 @@ export class Hotspot extends CSS2DObject {
       }
 
       const element = node as HTMLElement;
+      // Visibility attribute can be configured per-node in the hotspot:
       const visibilityAttribute = element.dataset.visibilityAttribute;
 
       if (visibilityAttribute != null) {

--- a/packages/model-viewer/src/features/annotation/hotspot.ts
+++ b/packages/model-viewer/src/features/annotation/hotspot.ts
@@ -1,3 +1,18 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {Vector3} from 'three';
 import {CSS2DObject} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 import {normalizeUnit} from '../../styles/conversions.js';

--- a/packages/model-viewer/src/features/annotation/hotspot.ts
+++ b/packages/model-viewer/src/features/annotation/hotspot.ts
@@ -1,0 +1,161 @@
+import {Vector3} from 'three';
+import {CSS2DObject} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
+import {normalizeUnit} from '../../styles/conversions.js';
+import {NumberNode, parseExpressions} from '../../styles/parsers.js';
+
+export interface HotspotVisibilityDetails {
+  visible: boolean;
+}
+
+/**
+ * Hotspots are configured by slot name, and this name must begin with "hotspot"
+ * to be recognized. The position and normal strings are in the form of the
+ * camera-target attribute and default to "0m 0m 0m" and "0m 1m 0m",
+ * respectively.
+ */
+export interface HotspotConfiguration {
+  name: string;
+  position?: string;
+  normal?: string;
+  visibilityAttribute?: string;
+}
+
+const $slot = Symbol('slot');
+const $referenceCount = Symbol('referenceCount');
+const $updateVisibility = Symbol('updateVisibility');
+const $visible = Symbol('visible');
+
+const $onSlotchange = Symbol('onSlotchange');
+const $slotchangeHandler = Symbol('slotchangeHandler');
+
+/**
+ * The Hotspot object is a reference-counted slot. If decrement() returns true,
+ * it should be removed from the tree so it can be garbage-collected.
+ */
+export class Hotspot extends CSS2DObject {
+  public normal: Vector3 = new Vector3(0, 1, 0);
+  private[$visible] = false;
+  private[$referenceCount] = 1;
+  private[$slot]: HTMLSlotElement = document.createElement('slot');
+  private[$slotchangeHandler] = () => this[$onSlotchange]();
+
+  constructor(config: HotspotConfiguration) {
+    super(document.createElement('div'));
+
+    this.element.classList.add('annotation-wrapper');
+
+    this[$slot].name = config.name;
+    this[$slot].addEventListener('slotchange', this[$slotchangeHandler]);
+
+    this.element.appendChild(this[$slot]);
+
+    this.updatePosition(config.position);
+    this.updateNormal(config.normal);
+
+    this.show();
+  }
+
+  /**
+   * Sets the hotspot to be in the highly visible foreground state.
+   */
+  show() {
+    if (!this[$visible]) {
+      this[$visible] = true;
+      this[$updateVisibility]({notify: true});
+    }
+  }
+
+  /**
+   * Sets the hotspot to be in the diminished background state.
+   */
+  hide() {
+    if (this[$visible]) {
+      this[$visible] = false;
+      this[$updateVisibility]({notify: true});
+    }
+  }
+
+  /**
+   * Cleans up the held references of this Hotspot when it is done being used.
+   */
+  dispose() {
+    this[$slot].removeEventListener('slotchange', this[$slotchangeHandler]);
+  }
+
+  /**
+   * Call this when adding elements to the same slot to keep track.
+   */
+  increment() {
+    this[$referenceCount]++;
+  }
+
+  /**
+   * Call this when removing elements from the slot; returns true when the slot
+   * is unused.
+   */
+  decrement(): boolean {
+    if (this[$referenceCount] > 0) {
+      --this[$referenceCount];
+    }
+    return this[$referenceCount] === 0;
+  }
+
+  /**
+   * Change the position of the hotspot to the input string, in the same format
+   * as the data-position attribute.
+   */
+  updatePosition(position?: string) {
+    if (position == null)
+      return;
+    const positionNodes = parseExpressions(position)[0].terms;
+    for (let i = 0; i < 3; ++i) {
+      this.position.setComponent(
+          i, normalizeUnit(positionNodes[i] as NumberNode<'m'>).number);
+    }
+  }
+
+  /**
+   * Change the hotspot's normal to the input string, in the same format as the
+   * data-normal attribute.
+   */
+  updateNormal(normal?: string) {
+    if (normal == null)
+      return;
+    const normalNodes = parseExpressions(normal)[0].terms;
+    for (let i = 0; i < 3; ++i) {
+      this.normal.setComponent(
+          i, normalizeUnit(normalNodes[i] as NumberNode<'m'>).number);
+    }
+  }
+
+  protected[$updateVisibility]({notify}: {notify: boolean}) {
+    this.element.classList.toggle('hide', !this[$visible]);
+
+    // NOTE: ShadyDOM doesn't support slot.assignedElements, otherwise we could
+    // use that here.
+    this[$slot].assignedNodes().forEach((node) => {
+      if (node.nodeType !== Node.ELEMENT_NODE) {
+        return;
+      }
+
+      const element = node as HTMLElement;
+      const visibilityAttribute = element.dataset.visibilityAttribute;
+
+      if (visibilityAttribute != null) {
+        element.toggleAttribute(`data-${visibilityAttribute}`, this[$visible]);
+      }
+
+      if (notify) {
+        element.dispatchEvent(new CustomEvent('hotspot-visibility', {
+          detail: {
+            visible: this[$visible],
+          },
+        }));
+      }
+    });
+  }
+
+  protected[$onSlotchange]() {
+    this[$updateVisibility]({notify: false});
+  }
+}

--- a/packages/model-viewer/src/features/annotation/hotspot.ts
+++ b/packages/model-viewer/src/features/annotation/hotspot.ts
@@ -129,7 +129,12 @@ export class Hotspot extends CSS2DObject {
   }
 
   protected[$updateVisibility]({notify}: {notify: boolean}) {
-    this.element.classList.toggle('hide', !this[$visible]);
+    // NOTE: IE11 doesn't support a second arg for classList.toggle
+    if (this[$visible]) {
+      this.element.classList.remove('hide');
+    } else {
+      this.element.classList.add('hide');
+    }
 
     // NOTE: ShadyDOM doesn't support slot.assignedElements, otherwise we could
     // use that here.

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -171,7 +171,7 @@ export default class ModelViewerElementBase extends UpdatingElement {
 
     // NOTE(cdata): The canonical ShadyCSS examples suggest that the Shadow Root
     // should be created after the invocation of ShadyCSS.styleElement
-    this.attachShadow({mode: 'open', delegatesFocus: true});
+    this.attachShadow({mode: 'open'});
 
     const shadowRoot = this.shadowRoot!;
 

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -91,16 +91,20 @@ canvas.show {
   pointer-events: initial;
 }
 
-::slotted(*) {
-  opacity: 1;
-  transition: opacity 0.5s;
+.annotation-wrapper ::slotted(*) {
+  opacity: var(--max-hotspot-opacity, 1);
+  transition: opacity 0.3s;
+}
+
+.pointer-tumbling .annotation-wrapper ::slotted(*) {
+  pointer-events: none;
 }
 
 .annotation-wrapper ::slotted(*) {
   pointer-events: initial;
 }
 
-.hide ::slotted(*) {
+.annotation-wrapper.hide ::slotted(*) {
   opacity: var(--min-hotspot-opacity, 0.25);
 }
 

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -131,23 +131,33 @@ suite('ModelViewerElementBase with AnnotationMixin', () => {
       suite('with a camera', () => {
         let wrapper: HTMLElement;
 
-        setup(() => {
+        setup(async () => {
+          const hotspotObject2D = scene.pivot.children[numSlots - 1] as Hotspot;
+          hotspotObject2D.hide();
+
+          await rafPasses();
+
           const camera = element[$scene].getCamera();
           camera.position.z = 2;
           camera.updateMatrixWorld();
-          wrapper = (scene.pivot.children[numSlots - 1] as Hotspot).element;
+
+          wrapper = hotspotObject2D.element;
         });
 
         test('the hotspot is visible', async () => {
-          await rafPasses();
+          await waitForEvent(hotspot2, 'hotspot-visibility');
           expect(wrapper.classList.contains('hide')).to.be.false;
         });
 
         test('the hotspot is hidden after turning', async () => {
+          await waitForEvent(hotspot2, 'hotspot-visibility');
+
           element[$scene].setPivotRotation(Math.PI);
           element[$scene].updateMatrixWorld();
-          await rafPasses();
-          expect(wrapper.classList.contains('hide')).to.be.true;
+
+          await waitForEvent(hotspot2, 'hotspot-visibility');
+
+          expect(!!wrapper.classList.contains('hide')).to.be.true;
         });
       });
 

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -15,7 +15,8 @@
 
 import {Vector3} from 'three';
 
-import {AnnotationInterface, AnnotationMixin, Hotspot} from '../../features/annotation';
+import {AnnotationInterface, AnnotationMixin} from '../../features/annotation';
+import {Hotspot} from '../../features/annotation/hotspot.js';
 import ModelViewerElementBase, {$scene, Vector3D} from '../../model-viewer-base';
 import {ModelScene} from '../../three-components/ModelScene';
 import {assetPath, rafPasses, timePasses, waitForEvent} from '../helpers';

--- a/packages/model-viewer/src/test/features/annotation/hotspot-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation/hotspot-spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import {Hotspot, HotspotVisibilityDetails} from '../../../features/annotation/hotspot.js';
-import {timePasses, waitForEvent} from '../../helpers.js';
+import {waitForEvent} from '../../helpers.js';
 
 const expect = chai.expect;
 
@@ -51,7 +51,6 @@ suite('Hotspot', () => {
         host.shadowRoot!.appendChild(hotspot.element);
         assigned.slot = 'foo';
         assigned.setAttribute('data-visibility-attribute', 'bar');
-        await timePasses(500);
       });
 
       suite('when shown', () => {

--- a/packages/model-viewer/src/test/features/annotation/hotspot-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation/hotspot-spec.ts
@@ -1,0 +1,114 @@
+/* @license
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Hotspot, HotspotVisibilityDetails} from '../../../features/annotation/hotspot.js';
+import {timePasses, waitForEvent} from '../../helpers.js';
+
+const expect = chai.expect;
+
+suite('Hotspot', () => {
+  suite('with only a name', () => {
+    test('has a DOM element', () => {
+      expect(new Hotspot({name: 'foo'}).element).to.be.ok;
+    });
+  });
+
+
+  suite('with assigned nodes', () => {
+    let host: HTMLElement;
+    let assigned: HTMLElement;
+
+    setup(() => {
+      host = document.createElement('div');
+      host.attachShadow({mode: 'open'});
+
+      assigned = document.createElement('div');
+      host.appendChild(assigned);
+
+      document.body.appendChild(host);
+    });
+
+    teardown(() => {
+      document.body.removeChild(host);
+    });
+
+    suite('with a configured visibilityAttribute', () => {
+      let hotspot: Hotspot;
+
+      setup(async () => {
+        hotspot = new Hotspot({name: 'foo'});
+        host.shadowRoot!.appendChild(hotspot.element);
+        assigned.slot = 'foo';
+        assigned.setAttribute('data-visibility-attribute', 'bar');
+        await timePasses(500);
+      });
+
+      suite('when shown', () => {
+        test('adds a corresponding data-* attribute to assigned nodes', () => {
+          expect(assigned.hasAttribute('data-bar')).to.be.true;
+        });
+
+        suite('and then hidden', () => {
+          setup(() => {
+            hotspot.hide();
+          });
+
+          test('removes the corresponding data-* attribute', () => {
+            expect(assigned.hasAttribute('data-bar')).to.be.false;
+          });
+        });
+      });
+    });
+
+    suite('when hidden', () => {
+      let event: CustomEvent<HotspotVisibilityDetails>;
+      let hotspot: Hotspot;
+
+      setup(async () => {
+        hotspot = new Hotspot({name: 'foo'});
+        host.shadowRoot!.appendChild(hotspot.element);
+
+        assigned.slot = 'foo';
+
+        const assignedNodeHides = waitForEvent(assigned, 'hotspot-visibility');
+
+        hotspot.hide();
+
+        event = await (
+            assignedNodeHides as
+            Promise<CustomEvent<HotspotVisibilityDetails>>);
+      });
+
+      test('dispatches a "visibility-change" on assigned nodes', async () => {
+        expect(event.detail.visible).to.be.false;
+      });
+
+
+      suite('and then shown', () => {
+        test('dispatches a "visibility-change" on assigned nodes', async () => {
+          const assignedNodeHides =
+              waitForEvent(assigned, 'hotspot-visibility');
+
+          hotspot.show();
+
+          const event = await (
+              assignedNodeHides as
+              Promise<CustomEvent<HotspotVisibilityDetails>>);
+
+          expect(event.detail.visible).to.be.true;
+        });
+      });
+    });
+  });
+});

--- a/packages/model-viewer/src/test/index.ts
+++ b/packages/model-viewer/src/test/index.ts
@@ -35,6 +35,7 @@ import './utilities/progress-tracker-spec.js';
 import './utilities/timer-spec.js';
 import './features/animation-spec.js';
 import './features/annotation-spec.js';
+import './features/annotation/hotspot-spec.js';
 import './features/staging-spec.js';
 import './features/controls-spec.js';
 import './features/environment-spec.js';

--- a/packages/modelviewer.dev/examples/annotations.html
+++ b/packages/modelviewer.dev/examples/annotations.html
@@ -53,13 +53,25 @@
     <div class="content">
       <div class="wrapper">
         <a class="lockup" href="../index.html"><div class="icon-button icon-modelviewer-black"></div><h1>examples</h1></a>
-        <h4 id="intro"><span class="font-medium">Annotations. </span>Use &lt;model-viewer&gt; to make your models interactive. 
+        <h4 id="intro"><span class="font-medium">Annotations. </span></h4>
+        <p>
+          Use &lt;model-viewer&gt; to make your models interactive. 
           This page showcases how you can add hotspots to your scene. Child elements are hotspots if their slot begins with "hotspot".
           The data-position attribute specifies the 3D position of the hotspot in model coordinates, using the same format as the
           camera-target attribute. The data-normal attribute specifies the normal vector defining the "front" of the hotspot.
           When this normal is pointed away from the viewer, the hotspot's opacity becomes --min-hotspot-opacity. The 
           <a href="tester.html">interactive example</a> lets you drag and drop your own models and add hotspots by clicking
-          and displays the corresponding position and normal attributes which you can copy into your own page.</h4>
+          and displays the corresponding position and normal attributes which you can copy into your own page.
+        </p>
+        <p>
+          You can also specify an attribute to be toggled when the hotspot changes between hidden and visible with data-visibility-attribute.
+          For example, if you set data-visibility-attribute="visible", then &lt;model-viewer&gt; will toggle the data-visible attribute on
+          that hotspot element. This makes it easier to write CSS that styles a hotspot based on its visibility.
+        </p>
+        <p>
+          When a hotspot's visibility changes, it will dispatch a "hotspot-visibility" event, and event.detail.visible will be true or false
+          depending on whether the hotspot is facing the camera.
+        </p>
         <div class="heading">
           <h2 class="demo-title">Add hotspots</h2>
           <h4></h4>
@@ -68,16 +80,25 @@
           <template>
 <style>
   button{
+    display: block;
     width: 20px;
     height: 20px;
     border-radius: 10px;
     border: none;
     background-color: blue;
+    box-sizing: border-box;
   }
+
   button[slot="hotspot-hand"]{
     --min-hotspot-opacity: 0;
     background-color: red;
   }
+
+  button[slot="hotspot-foot"]:not([data-visible]) {
+    background-color: transparent;
+    border: 3px solid blue;
+  }
+
   #annotation{
     background-color: #888888;
     position: absolute;
@@ -95,7 +116,7 @@
   <button slot="hotspot-hand" data-position="-0.55 0.95 0.1" data-normal="-1 0 1">
     <div id="annotation">This hotspot disappears completely</div>
   </button>
-  <button slot="hotspot-foot" data-position="0.16 0.11 0.15" data-normal="0 1 0.3"></button>
+  <button slot="hotspot-foot" data-position="0.16 0.11 0.15" data-normal="0 1 0.75" data-visibility-attribute="visible"></button>
 </model-viewer>
           </template>
         </example-snippet>

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -398,6 +398,10 @@
               <p>Sets the opacity of hidden hotspots. Defaults to 0.25.</p>
             </li>
             <li>
+              <div>--max-hotspot-opacity</div>
+              <p>Sets the opacity of visible hotspots. Defaults to 1.</p>
+            </li>
+            <li>
               <div>--poster-color</div>
               <p>Sets the background-color of the poster. Falls back to
               --background-color if set. Defaults to #fff.</p>


### PR DESCRIPTION
This change proposes a handful of refinement tasks for the hotspots:

 - Hotspots are now `pointer-events: none` when user is tumbling the model with a pointer (#981)
 - Introduces support for `data-visibility-attribute` to enable easier CSS styling w/o requiring script (#989)
 - Introduces a `hotspot-visibility` event that is dispatched on assigned hotspot nodes when their visibility changes (also #989)
 - Adds a `--max-hotspot-opacity`, which is the "visible" counterpart to `--min-hotspot-opacity`

Thanks to #1020 the user can combine the above improvements to implement #980 for themselves until we have time to address it properly.

Fixes #981 
Fixes #989 