### PR TITLE
Update the links to CONTRIBUTING.md in issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Instructions For Filing a Bug: https://github.com/GoogleWebComponents/model-viewer/blob/master/CONTRIBUTING.md#filing-bugs -->
+<!-- Instructions For Filing a Bug: https://github.com/google/model-viewer/blob/master/packages/model-viewer/CONTRIBUTING.md#filing-bugs -->
 ### Description
 
 Please provide a detailed description of the bug, how to reproduce it, and the

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
-<!-- Instructions: https://github.com/GoogleWebComponents/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
+<!-- Instructions: https://github.com/google/model-viewer/blob/master/packages/model-viewer/CONTRIBUTING.md#code-reviews -->
 ### Reference Issue
 <!-- Example: Fixes #1234 -->


### PR DESCRIPTION
The links to `CONTRIBUTING.md` in issue and PR templates look old. This PR updates the links.