### PR TITLE
Reset interaction prompt

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -228,6 +228,7 @@ export declare interface ControlsInterface {
   getCameraTarget(): Vector3D;
   getFieldOfView(): number;
   jumpCameraToGoal(): void;
+  resetInteractionPrompt(): void;
 }
 
 export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
@@ -353,6 +354,16 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     jumpCameraToGoal() {
       this[$jumpCamera] = true;
       this.requestUpdate($jumpCamera, false);
+    }
+
+    resetInteractionPrompt() {
+      this[$lastPromptOffset] = 0;
+      this[$promptElementVisibleTime] = Infinity;
+      this[$userPromptedOnce] = false;
+      this[$waitingToPromptUser] =
+          this.interactionPrompt === InteractionPromptStrategy.AUTO &&
+          this.cameraControls;
+      this[$shouldPromptUserToInteract] = true;
     }
 
     connectedCallback() {

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -454,6 +454,32 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
               .to.be.equal(false);
         });
 
+        suite('after it has been dismissed', () => {
+          let promptElement: HTMLElement;
+
+          setup(async () => {
+            promptElement = (element as any)[$promptElement];
+            element.interactionPrompt = 'auto';
+
+            await until(() => promptElement.classList.contains('visible'));
+
+            interactWith(element[$canvas]);
+
+            await until(
+                () => promptElement.classList.contains('visible') === false);
+
+            settleControls(controls);
+          });
+
+          test('can be reset and displayed again', async () => {
+            element.resetInteractionPrompt();
+
+            await timePasses(element.interactionPromptThreshold + 100);
+
+            expect(promptElement.classList.contains('visible')).to.be.true;
+          });
+        });
+
         suite('when configured to be basic', () => {
           setup(async () => {
             element.interactionPromptStyle = 'basic';

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -558,6 +558,16 @@
               render frame.</p>
             </li>
             <li>
+              <div>resetInteractionPrompt()</div>
+              <p>Typically, the interaction prompt will only display once and then
+              stops displaying after the user interacts with the 3D model for the
+              first time. You can invoke this method in order to reset the interaction
+              prompt after it has already been displayed. Doing so will cause it to
+              display once again when the interaction-prompt display conditions have
+              been met.
+              </p>
+            </li>
+            <li>
               <div>toDataURL(type, encoderOptions)</div>
               <p>Returns a screenshot of the current model render in the format
               specified by <i>type</i> (defaults to image/png). The screenshot is


### PR DESCRIPTION
This change proposes an instance method that enables authors to reset the interaction prompt state.

Fixes #792 