### PR TITLE
Support external 3DOM scripts

### DIFF
--- a/packages/3dom/src/context-spec.ts
+++ b/packages/3dom/src/context-spec.ts
@@ -40,6 +40,34 @@ suite('context', () => {
       }
     });
 
+    test('can import external script', async () => {
+      const context = new ThreeDOMExecutionContext(['messaging']);
+      const scriptText = 'self.postMessage("hello")';
+      const blob = new Blob([scriptText], {type: 'text/javascript'});
+      const url = URL.createObjectURL(blob);
+
+      try {
+        const scriptEvaluates = new Promise((resolve) => {
+          context.worker.addEventListener('message', (event) => {
+            expect(event.data).to.be.equal('hello');
+            resolve();
+          }, {once: true});
+        });
+
+        context.import(url);
+
+        await scriptEvaluates;
+      } finally {
+        if (context != null) {
+          context.terminate();
+        }
+
+        if (url != null) {
+          URL.revokeObjectURL(url);
+        }
+      }
+    });
+
     suite('when the model changes', () => {
       test('dispatches an event in the worker', async () => {
         const modelGraft = new ModelGraft('', createFakeGLTF());

--- a/packages/3dom/src/context.ts
+++ b/packages/3dom/src/context.ts
@@ -193,9 +193,17 @@ export class ThreeDOMExecutionContext extends EventTarget {
    * Workers, so for now all scripts must be valid non-module scripts.
    */
   async eval(scriptSource: string): Promise<void> {
+    await this.import(URL.createObjectURL(
+        new Blob([scriptSource], {type: 'text/javascript'})));
+  }
+
+  /**
+   * Load a script by URL in the scene graph execution context. Generally works
+   * the same as eval, but is generally safer because it allows you full control
+   * of the script text. Like eval, does not support module scripts.
+   */
+  async import(url: string): Promise<void> {
     const port = await this[$workerInitializes];
-    const url = URL.createObjectURL(
-        new Blob([scriptSource], {type: 'text/javascript'}));
     port.postMessage({type: ThreeDOMMessageType.IMPORT_SCRIPT, url});
   }
 

--- a/packages/3dom/src/context.ts
+++ b/packages/3dom/src/context.ts
@@ -195,7 +195,7 @@ export class ThreeDOMExecutionContext extends EventTarget {
   async eval(scriptSource: string): Promise<void> {
     await this.import(URL.createObjectURL(
         new Blob([scriptSource], {type: 'text/javascript'})));
-  }
+  } /* end eval marker (do not remove) */
 
   /**
    * Load a script by URL in the scene graph execution context. Generally works

--- a/packages/model-viewer/src/test/features/scene-graph-spec.ts
+++ b/packages/model-viewer/src/test/features/scene-graph-spec.ts
@@ -93,6 +93,30 @@ suite('ModelViewerElementBase with SceneGraphMixin', () => {
       expect(element.worklet).to.be.ok;
     });
 
+    suite('in an external script file', () => {
+      test('eventually creates a new worklet', async () => {
+        const scriptText = 'console.log("Hello, worklet!");';
+        const url = URL.createObjectURL(
+            new Blob([scriptText], {type: 'text/javascript'}));
+
+        const script = document.createElement('script');
+        script.type = 'experimental-scene-graph-worklet';
+        script.src = url;
+
+        try {
+          element.appendChild(script);
+
+          await waitForEvent(element, 'worklet-created');
+
+          expect(element.worklet).to.be.ok;
+        } finally {
+          if (url != null) {
+            URL.revokeObjectURL(url);
+          }
+        }
+      });
+    });
+
     suite('with a loaded model', () => {
       setup(async () => {
         element.src = ASTRONAUT_GLB_PATH;


### PR DESCRIPTION
Currently, we support inline 3DOM scripts in `<model-viewer>`:

```html
<script type="experimental-scene-graph-worklet">
console.log('Hello, world!');
</script>
```

This change proposes the addition of _external_ script support:

```html
<script type="experimental-scene-graph-worklet" src="./external-script.js"></script>
```

In support of this feature in `<model-viewer>`, a new method has been introduced to the `ThreeDOMExecutionContext`: `import`, which takes an external script URL and loads it into a running context.

In practice, the implementation of `import` is just a small refactor, because `eval` performed all the steps of `import` on a dynamically generated URL.