### PR TITLE
Fix floating promises

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -134,13 +134,15 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
     }
 
-    disconnectedCallback() {
+    async disconnectedCallback() {
       super.disconnectedCallback();
 
       this[$mutationObserver].disconnect();
 
-      if (this[$executionContext] != null) {
-        this[$executionContext]!.terminate();
+      const executionContext = this[$executionContext];
+
+      if (executionContext != null) {
+        await executionContext.terminate();
         this[$executionContext] = null;
       }
     }
@@ -225,7 +227,7 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       let executionContext = this[$executionContext];
 
       if (executionContext != null) {
-        executionContext.terminate();
+        await executionContext.terminate();
       }
 
       this[$executionContext] = executionContext =


### PR DESCRIPTION
This is a style fix to address lint rules applied in google3. I did some investigation to see if we could incorporate a similar check into our linter. The rule we would want to activate is here: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md

Unfortunately, the rule requires that we enable TypeScript type generation in the linter, and doing this caused it to hang and crash. So, I'm punting on that for now.