### PR TITLE
Reduce to unique materials

### DIFF
--- a/packages/3dom/src/api/material-spec.ts
+++ b/packages/3dom/src/api/material-spec.ts
@@ -15,7 +15,7 @@
 
 import {FakeModelKernel} from '../test-helpers.js';
 
-import {defineMaterial} from './material.js';
+import {defineMaterial, MaterialConstructor} from './material.js';
 import {defineThreeDOMElement} from './three-dom-element.js';
 
 const ThreeDOMElement = defineThreeDOMElement();
@@ -32,15 +32,34 @@ suite('api/material', () => {
       expect(instance).to.be.ok;
     });
 
-    test('produces elements with the correct owner model', () => {
-      const kernel = new FakeModelKernel();
-      const GeneratedConstructor = defineMaterial(ThreeDOMElement);
-      const instance = new GeneratedConstructor(kernel, {
-        pbrMetallicRoughness: {id: 1, baseColorFactor: [0, 0, 0, 1]},
-        id: 0
+    suite('the generated class', () => {
+      let kernel: FakeModelKernel;
+      let GeneratedConstructor: MaterialConstructor;
+
+
+      setup(() => {
+        kernel = new FakeModelKernel();
+        GeneratedConstructor = defineMaterial(ThreeDOMElement);
       });
 
-      expect(instance.ownerModel).to.be.equal(kernel.model);
+      test('produces elements with the correct owner model', () => {
+        const instance = new GeneratedConstructor(kernel, {
+          pbrMetallicRoughness: {id: 1, baseColorFactor: [0, 0, 0, 1]},
+          id: 0
+        });
+
+        expect(instance.ownerModel).to.be.equal(kernel.model);
+      });
+
+      test('expresses the material name when available', () => {
+        const instance = new GeneratedConstructor(kernel, {
+          pbrMetallicRoughness: {id: 1, baseColorFactor: [0, 0, 0, 1]},
+          id: 0,
+          name: 'foo'
+        });
+
+        expect(instance.name).to.be.equal('foo');
+      });
     });
   });
 });

--- a/packages/3dom/src/api/material.ts
+++ b/packages/3dom/src/api/material.ts
@@ -65,6 +65,14 @@ export function defineMaterial(ThreeDOMElement: Constructor<ThreeDOMElement>):
     get pbrMetallicRoughness() {
       return this[$pbrMetallicRoughness];
     }
+
+    /**
+     * The name of the material. Note that names are optional and not
+     * guaranteed to be unique.
+     */
+    get name() {
+      return this[$name];
+    }
   }
 
   return Material;

--- a/packages/3dom/src/context.ts
+++ b/packages/3dom/src/context.ts
@@ -161,7 +161,6 @@ export class ThreeDOMExecutionContext extends EventTarget {
     const port = await this[$workerInitializes];
     const {port1, port2} = new MessageChannel();
 
-    console.log(modelGraft?.model.toJSON());
     port.postMessage(
         {
           type: ThreeDOMMessageType.MODEL_CHANGE,

--- a/packages/3dom/src/context.ts
+++ b/packages/3dom/src/context.ts
@@ -161,6 +161,7 @@ export class ThreeDOMExecutionContext extends EventTarget {
     const port = await this[$workerInitializes];
     const {port1, port2} = new MessageChannel();
 
+    console.log(modelGraft?.model.toJSON());
     port.postMessage(
         {
           type: ThreeDOMMessageType.MODEL_CHANGE,

--- a/packages/3dom/src/end-to-end-spec.ts
+++ b/packages/3dom/src/end-to-end-spec.ts
@@ -90,8 +90,9 @@ suite('end-to-end', () => {
     executionContext.eval('self.postMessage(model.materials[0].name)');
 
     const messageEvent = await messageEventArrives;
-    console.log(messageEvent.data);
 
+    expect(messageEvent.data).to.be.ok;
+    expect(messageEvent.data).to.not.be.equal('');
     expect(messageEvent.data).to.be.equal(material.name);
   });
 });

--- a/packages/3dom/src/end-to-end-spec.ts
+++ b/packages/3dom/src/end-to-end-spec.ts
@@ -71,4 +71,27 @@ suite('end-to-end', () => {
     expect(material.color.r).to.be.equal(0);
     expect(material.color.b).to.be.equal(1);
   });
+
+  test('expresses the name of a material in the worklet context', async () => {
+    const gltf = await new Promise<GLTF>((resolve) => {
+      new GLTFLoader().load(ASTRONAUT_GLB_URL, (gltf) => resolve(gltf));
+    });
+
+    const material = (gltf.scene.children[0]!.children[0] as Mesh).material as
+        MeshStandardMaterial;
+    const graft = new ModelGraft(ASTRONAUT_GLB_URL, gltf);
+
+    const executionContext =
+        new ThreeDOMExecutionContext(['messaging', 'material-properties']);
+    executionContext.changeModel(graft);
+
+    const messageEventArrives =
+        waitForEvent<MessageEvent>(executionContext.worker, 'message');
+    executionContext.eval('self.postMessage(model.materials[0].name)');
+
+    const messageEvent = await messageEventArrives;
+    console.log(messageEvent.data);
+
+    expect(messageEvent.data).to.be.equal(material.name);
+  });
 });

--- a/packages/3dom/src/facade/three-js/three-dom-element-spec.ts
+++ b/packages/3dom/src/facade/three-js/three-dom-element-spec.ts
@@ -14,6 +14,7 @@
  */
 
 
+import {Material} from 'three';
 import {Object3D} from 'three/src/core/Object3D.js';
 
 import {createFakeGLTF} from '../../test-helpers.js';
@@ -38,16 +39,16 @@ suite('facade/three-js/three-dom-element', () => {
         object3D.name = 'generated';
 
         const element = new ThreeDOMElement(graft, object3D);
-        expect(element.name).to.be.equal(undefined);
+        expect(element.name).to.be.equal(null);
       });
 
-      test('expresses a name stored in userData', () => {
+      test('expresses a name for a Three.js Material', () => {
         const graft = new ModelGraft('', createFakeGLTF());
-        const object3D = new Object3D();
+        const material = new Material();
 
-        object3D.userData.name = 'original';
+        material.name = 'original';
 
-        const element = new ThreeDOMElement(graft, object3D);
+        const element = new ThreeDOMElement(graft, material);
         expect(element.name).to.be.equal('original');
       });
     });

--- a/packages/3dom/src/facade/three-js/three-dom-element.ts
+++ b/packages/3dom/src/facade/three-js/three-dom-element.ts
@@ -71,12 +71,17 @@ export class ThreeDOMElement implements ThreeDOMElementInterface {
    */
   get name() {
     const relatedObject = this[$relatedObject];
-    if ((relatedObject as Object3D).isObject3D ||
-        (relatedObject as Material).isMaterial) {
-      return (relatedObject as Object3D | Material).userData ?
-          (relatedObject as Object3D | Material).userData.name :
-          null;
+
+    // NOTE: Some Three.js object names are modified from the names found in the
+    // glTF. Special casing is handled here, but might be better moved to
+    // subclasses down the road:
+    if ((relatedObject as Material).isMaterial) {
+      // Material names can be safely referenced directly from the Three.js
+      // object.
+      // @see: https://github.com/mrdoob/three.js/blob/790811db742ea9d7c54fe28f83865d7576f14134/examples/js/loaders/GLTFLoader.js#L2162
+      return (relatedObject as Material).name;
     }
+
     return null;
   }
 

--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -17,6 +17,7 @@ import {property} from 'lit-element';
 
 import ModelViewerElementBase, {$ariaLabel, $canvas, $getLoaded, $getModelIsVisible, $isInRenderTree, $progressTracker, $updateSource} from '../model-viewer-base.js';
 import {$loader, CachingGLTFLoader} from '../three-components/CachingGLTFLoader.js';
+import {ModelViewerGLTFInstance} from '../three-components/gltf-instance/ModelViewerGLTFInstance.js';
 import {Constructor, debounce, deserializeUrl, throttle} from '../utilities.js';
 
 import {LoadingStatusAnnouncer} from './loading/status-announcer.js';
@@ -44,7 +45,7 @@ const PosterDismissalSource: {[index: string]: DismissalSource} = {
   INTERACTION: 'interaction'
 };
 
-const loader = new CachingGLTFLoader();
+const loader = new CachingGLTFLoader(ModelViewerGLTFInstance);
 const loadingStatusAnnouncer = new LoadingStatusAnnouncer();
 
 export const $defaultProgressBarElement = Symbol('defaultProgressBarElement');

--- a/packages/model-viewer/src/test/helpers.ts
+++ b/packages/model-viewer/src/test/helpers.ts
@@ -12,7 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {EventDispatcher, Texture} from 'three';
+import {EventDispatcher, Scene, Texture} from 'three';
+import {GLTFParser} from 'three/examples/jsm/loaders/GLTFLoader.js';
 
 import {ExpressionNode, ExpressionTerm, FunctionNode, HexNode, IdentNode, Operator, OperatorNode} from '../styles/parsers.js';
 import {deserializeUrl} from '../utilities.js';
@@ -207,3 +208,17 @@ export const operatorNode = (value: Operator): OperatorNode =>
 export const functionNode =
     (name: string, args: Array<ExpressionNode>): FunctionNode =>
         ({type: 'function', name: identNode(name), arguments: args});
+
+export const createFakeGLTF = () => {
+  const scene = new Scene();
+
+  return {
+    animations: [],
+    scene,
+    scenes: [scene],
+    cameras: [],
+    asset: {},
+    parser: {} as unknown as GLTFParser,
+    userData: {}
+  };
+};

--- a/packages/model-viewer/src/test/index.ts
+++ b/packages/model-viewer/src/test/index.ts
@@ -24,6 +24,8 @@ import './model-viewer-base-spec.js';
 import './three-components/ModelScene-spec.js';
 import './three-components/Renderer-spec.js';
 import './three-components/ARRenderer-spec.js';
+import './three-components/GLTFInstance-spec.js';
+import './three-components/gltf-instance/ModelViewerGLTFInstance-spec.js';
 import './three-components/SmoothControls-spec.js';
 import './three-components/TextureUtils-spec.js';
 import './three-components/CachingGLTFLoader-spec.js';

--- a/packages/model-viewer/src/test/three-components/CachingGLTFLoader-spec.ts
+++ b/packages/model-viewer/src/test/three-components/CachingGLTFLoader-spec.ts
@@ -12,7 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {$evictionPolicy, $releaseFromCache, CachingGLTFLoader} from '../../three-components/CachingGLTFLoader.js';
+
+import {$evictionPolicy, CachingGLTFLoader} from '../../three-components/CachingGLTFLoader.js';
+import {ModelViewerGLTFInstance} from '../../three-components/gltf-instance/ModelViewerGLTFInstance.js';
 import {assetPath} from '../helpers.js';
 
 const expect = chai.expect;
@@ -24,7 +26,7 @@ suite('CachingGLTFLoader', () => {
     let loader: CachingGLTFLoader;
 
     setup(() => {
-      loader = new CachingGLTFLoader();
+      loader = new CachingGLTFLoader(ModelViewerGLTFInstance);
     });
 
     teardown(() => {
@@ -61,7 +63,7 @@ suite('CachingGLTFLoader', () => {
     });
 
     test('yields a promise that resolves a scene', async () => {
-      const scene = await loader.load(ASTRONAUT_GLB_PATH);
+      const {scene} = await loader.load(ASTRONAUT_GLB_PATH);
       expect(scene).to.be.ok;
       expect(scene!.type).to.be.equal('Scene');
     });
@@ -79,10 +81,10 @@ suite('CachingGLTFLoader', () => {
       });
 
       test('deletinates them when they are fully released', async () => {
-        const scene = await loader.load(ASTRONAUT_GLB_PATH);
+        const gltf = await loader.load(ASTRONAUT_GLB_PATH);
 
         expect(CachingGLTFLoader.has(ASTRONAUT_GLB_PATH)).to.be.true;
-        scene![$releaseFromCache]();
+        gltf.dispose();
         expect(CachingGLTFLoader.has(ASTRONAUT_GLB_PATH)).to.be.false;
       });
     });

--- a/packages/model-viewer/src/test/three-components/GLTFInstance-spec.ts
+++ b/packages/model-viewer/src/test/three-components/GLTFInstance-spec.ts
@@ -1,0 +1,59 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {GLTF} from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+import {$prepared, GLTFInstance, PreparedGLTF} from '../../three-components/GLTFInstance.js';
+import {createFakeGLTF} from '../helpers.js';
+
+
+const expect = chai.expect;
+
+suite('GLTFInstance', () => {
+  suite('with a prepared GLTF', () => {
+    let rawGLTF: GLTF;
+    let preparedGLTF: PreparedGLTF;
+
+    setup(async () => {
+      rawGLTF = createFakeGLTF();
+      preparedGLTF = GLTFInstance.prepare(rawGLTF);
+    });
+
+    test('exposes the same scene as the GLTF', () => {
+      const gltfInstance = new GLTFInstance(preparedGLTF);
+      expect(gltfInstance.scene).to.be.equal(preparedGLTF.scene);
+    });
+
+    suite('when cloned', () => {
+      test('creates a unique scene', () => {
+        const gltfInstance = new GLTFInstance(preparedGLTF);
+        const cloneInstance = gltfInstance.clone();
+
+        expect(cloneInstance.scene).to.be.ok;
+        expect(cloneInstance.scene).to.not.be.equal(gltfInstance.scene);
+      });
+    });
+  });
+
+  suite('preparing the GLTF', () => {
+    test('creates a prepared GLTF', () => {
+      const rawGLTF = createFakeGLTF();
+      const preparedGLTF = GLTFInstance.prepare(rawGLTF);
+
+      expect(preparedGLTF).to.not.be.equal(rawGLTF);
+      expect(preparedGLTF[$prepared]).to.be.equal(true);
+    });
+  });
+});

--- a/packages/model-viewer/src/test/three-components/GLTFInstance-spec.ts
+++ b/packages/model-viewer/src/test/three-components/GLTFInstance-spec.ts
@@ -22,15 +22,15 @@ import {createFakeGLTF} from '../helpers.js';
 const expect = chai.expect;
 
 suite('GLTFInstance', () => {
+  let rawGLTF: GLTF;
+  let preparedGLTF: PreparedGLTF;
+
+  setup(async () => {
+    rawGLTF = createFakeGLTF();
+    preparedGLTF = GLTFInstance.prepare(rawGLTF);
+  });
+
   suite('with a prepared GLTF', () => {
-    let rawGLTF: GLTF;
-    let preparedGLTF: PreparedGLTF;
-
-    setup(async () => {
-      rawGLTF = createFakeGLTF();
-      preparedGLTF = GLTFInstance.prepare(rawGLTF);
-    });
-
     test('exposes the same scene as the GLTF', () => {
       const gltfInstance = new GLTFInstance(preparedGLTF);
       expect(gltfInstance.scene).to.be.equal(preparedGLTF.scene);
@@ -49,9 +49,6 @@ suite('GLTFInstance', () => {
 
   suite('preparing the GLTF', () => {
     test('creates a prepared GLTF', () => {
-      const rawGLTF = createFakeGLTF();
-      const preparedGLTF = GLTFInstance.prepare(rawGLTF);
-
       expect(preparedGLTF).to.not.be.equal(rawGLTF);
       expect(preparedGLTF[$prepared]).to.be.equal(true);
     });

--- a/packages/model-viewer/src/test/three-components/ModelUtils-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ModelUtils-spec.ts
@@ -13,32 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Box3, Material, Scene, Vector3} from 'three';
+import {Box3, Vector3} from 'three';
 import {GLTF, GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader.js';
 
 import {loadWithLoader} from '../../three-components/CachingGLTFLoader.js';
-import {cloneGltf, reduceVertices} from '../../three-components/ModelUtils.js';
+import {reduceVertices} from '../../three-components/ModelUtils.js';
 import {assetPath} from '../helpers.js';
 
 const expect = chai.expect;
 
 const ASTRONAUT_GLB_PATH = assetPath('models/Astronaut.glb');
-
-
-
-const collectMaterials = (scene: Scene): Array<Material> => {
-  const materials: Array<Material> = [];
-
-  scene.traverse((node: any) => {
-    if (Array.isArray(node.material)) {
-      materials.push(...node.material);
-    } else if (node.material != null) {
-      materials.push(node.material);
-    }
-  });
-
-  return materials;
-};
 
 suite('ModelUtils', () => {
   suite('cloneGltf', () => {
@@ -48,20 +32,6 @@ suite('ModelUtils', () => {
     setup(async () => {
       loader = new GLTFLoader();
       gltf = await loadWithLoader(ASTRONAUT_GLB_PATH, loader);
-    });
-
-    test('makes unique copies of all materials', () => {
-      const clonedGltf = cloneGltf(gltf);
-
-      const sourceMaterials = collectMaterials(gltf.scene!);
-      const clonedMaterials = collectMaterials(clonedGltf.scene!);
-
-      expect(sourceMaterials.length).to.be.greaterThan(0);
-      expect(sourceMaterials.length).to.be.equal(clonedMaterials.length);
-
-      sourceMaterials.forEach((material, index) => {
-        expect(clonedMaterials[index]).to.not.be.eql(material);
-      });
     });
 
     test('reduceVertices matches boundingBox', () => {

--- a/packages/model-viewer/src/test/three-components/gltf-instance/ModelViewerGLTFInstance-spec.ts
+++ b/packages/model-viewer/src/test/three-components/gltf-instance/ModelViewerGLTFInstance-spec.ts
@@ -1,0 +1,101 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BufferGeometry, DoubleSide, Mesh, MeshStandardMaterial} from 'three';
+import {GLTF} from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+import {ModelViewerGLTFInstance} from '../../../three-components/gltf-instance/ModelViewerGLTFInstance.js';
+import {PreparedGLTF} from '../../../three-components/GLTFInstance.js';
+import {createFakeGLTF} from '../../helpers.js';
+
+
+const expect = chai.expect;
+
+suite('ModelViewerGLTFInstance', () => {
+  let rawGLTF: GLTF;
+  let preparedGLTF: PreparedGLTF;
+
+  setup(async () => {
+    rawGLTF = createFakeGLTF();
+
+    const materialOne = new MeshStandardMaterial();
+    const materialTwo = new MeshStandardMaterial();
+
+    materialTwo.transparent = true;
+    materialTwo.side = DoubleSide;
+
+    const meshOne = new Mesh(new BufferGeometry(), materialOne);
+    const meshTwo = new Mesh(new BufferGeometry(), materialOne);
+    const meshThree = new Mesh(new BufferGeometry(), materialTwo);
+
+    rawGLTF.scene.add(meshOne, meshTwo, meshThree);
+
+    preparedGLTF = ModelViewerGLTFInstance.prepare(rawGLTF);
+  });
+
+  suite('with a prepared GLTF', () => {
+    suite('when cloned', () => {
+      let cloneInstance: ModelViewerGLTFInstance;
+      let gltfInstance: ModelViewerGLTFInstance;
+
+      setup(() => {
+        gltfInstance = new ModelViewerGLTFInstance(preparedGLTF);
+        cloneInstance = gltfInstance.clone();
+      });
+
+      teardown(() => {
+        gltfInstance.dispose();
+        cloneInstance.dispose();
+      });
+
+      test('clones materials in a mesh', () => {
+        const [originalMeshOne, originalMeshTwo, originalMeshThree] =
+            gltfInstance.scene.children as [Mesh, Mesh, Mesh];
+        const [meshOne, meshTwo, meshThree] =
+            cloneInstance.scene.children as [Mesh, Mesh, Mesh];
+
+        expect(originalMeshOne.material).to.not.be.equal(meshOne.material);
+        expect(originalMeshTwo.material).to.not.be.equal(meshTwo.material);
+        expect(originalMeshThree.material).to.not.be.equal(meshThree.material);
+      });
+
+      test('only clones a discrete material once', () => {
+        const [meshOne, meshTwo, meshThree] =
+            cloneInstance.scene.children as [Mesh, Mesh, Mesh];
+
+        expect(meshOne.material).to.be.equal(meshTwo.material);
+        expect(meshOne.material).to.not.be.equal(meshThree.material);
+      });
+    });
+  });
+
+  suite('preparing the GLTF', () => {
+    test('duplicates a transparent, double-sided mesh', () => {
+      const meshThree = preparedGLTF.scene.children[2] as Mesh;
+      expect(meshThree.children[0]).to.be.ok;
+      expect((meshThree.children[0] as Mesh).isMesh).to.be.ok;
+    });
+
+    test('sets meshes to cast shadows', () => {
+      (preparedGLTF.scene.children as [Mesh, Mesh, Mesh])
+          .forEach(mesh => expect(mesh.castShadow).to.be.true);
+    });
+
+    test('disables frustum culling on meshes', () => {
+      (preparedGLTF.scene.children as [Mesh, Mesh, Mesh])
+          .forEach(mesh => expect(mesh.frustumCulled).to.be.false);
+    });
+  });
+});

--- a/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
+++ b/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
@@ -155,12 +155,8 @@ export class CachingGLTFLoader<T extends GLTFInstanceConstructor =
     await this.preload(url, progressCallback);
 
     const gltf = await cache.get(url)!;
-
-
     const clone = gltf.clone() as InstanceType<T>;
-    // const model = clone.scene;
 
-    // model.userData.animations = clone.animations;  // save animations
     this[$evictionPolicy].retain(url);
 
     clone.dispose = (() => {

--- a/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
+++ b/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
@@ -159,6 +159,8 @@ export class CachingGLTFLoader<T extends GLTFInstanceConstructor =
 
     this[$evictionPolicy].retain(url);
 
+    // Patch dispose so that we can properly account for instance use
+    // in the caching layer:
     clone.dispose = (() => {
       const originalDispose = clone.dispose;
       let disposed = false;
@@ -177,5 +179,3 @@ export class CachingGLTFLoader<T extends GLTFInstanceConstructor =
     return clone;
   }
 }
-
-(self as any).CachingGLTFLoader = CachingGLTFLoader;

--- a/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
+++ b/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
@@ -13,15 +13,12 @@
  * limitations under the License.
  */
 
-import {BackSide, DoubleSide, FrontSide, Mesh, MeshStandardMaterial, Object3D, Scene} from 'three';
 import {DRACOLoader} from 'three/examples/jsm/loaders/DRACOLoader.js';
 import {GLTF, GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader.js';
-import {RoughnessMipmapper} from 'three/examples/jsm/utils/RoughnessMipmapper.js';
 
 import {CacheEvictionPolicy} from '../utilities/cache-eviction-policy.js';
 
-import {cloneGltf} from './ModelUtils.js';
-import {Renderer} from './Renderer.js';
+import {GLTFInstance, GLTFInstanceConstructor} from './GLTFInstance.js';
 
 export type ProgressCallback = (progress: number) => void;
 
@@ -40,21 +37,18 @@ export const loadWithLoader =
       });
     };
 
-export const $releaseFromCache = Symbol('releaseFromCache');
-export interface CacheRetainedScene extends Scene {
-  [$releaseFromCache]: () => void;
-}
-
-const cache = new Map<string, Promise<GLTF>>();
+const cache = new Map<string, Promise<GLTFInstance>>();
 const preloaded = new Map<string, boolean>();
-
-export const $evictionPolicy = Symbol('evictionPolicy');
 
 let dracoDecoderLocation: string;
 const dracoLoader = new DRACOLoader();
-export const $loader = Symbol('loader');
 
-export class CachingGLTFLoader {
+export const $loader = Symbol('loader');
+export const $evictionPolicy = Symbol('evictionPolicy');
+const $GLTFInstance = Symbol('GLTFInstance');
+
+export class CachingGLTFLoader<T extends GLTFInstanceConstructor =
+                                             GLTFInstanceConstructor> {
   static setDRACODecoderLocation(url: string) {
     dracoDecoderLocation = url;
     dracoLoader.setDecoderPath(url);
@@ -95,20 +89,8 @@ export class CachingGLTFLoader {
 
     const gltf = await gltfLoads;
     // Dispose of the cached glTF's materials and geometries:
-    gltf!.scenes.forEach(scene => {
-      scene.traverse(object3D => {
-        if (!(object3D as Mesh).isMesh) {
-          return;
-        }
-        const mesh = object3D as Mesh;
-        const materials =
-            Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-        materials.forEach(material => {
-          material.dispose();
-        });
-        mesh.geometry.dispose();
-      });
-    });
+
+    gltf!.dispose();
   }
 
   /**
@@ -119,11 +101,13 @@ export class CachingGLTFLoader {
     return !!preloaded.get(url);
   }
 
-  constructor() {
+  constructor(GLTFInstance: T) {
+    this[$GLTFInstance] = GLTFInstance;
     this[$loader].setDRACOLoader(dracoLoader);
   }
 
   protected[$loader]: GLTFLoader = new GLTFLoader();
+  protected[$GLTFInstance]: T;
 
   protected get[$evictionPolicy](): CacheEvictionPolicy {
     return (this.constructor as typeof CachingGLTFLoader)[$evictionPolicy];
@@ -135,9 +119,21 @@ export class CachingGLTFLoader {
    */
   async preload(url: string, progressCallback: ProgressCallback = () => {}) {
     if (!cache.has(url)) {
-      cache.set(url, loadWithLoader(url, this[$loader], (progress: number) => {
-                  progressCallback(progress * 0.9);
-                }));
+      const rawGLTFLoads =
+          loadWithLoader(url, this[$loader], (progress: number) => {
+            progressCallback(progress * 0.8);
+          });
+
+      const gltfInstanceLoads = rawGLTFLoads.then((rawGLTF: GLTF) => {
+        const GLTFInstance = this[$GLTFInstance];
+        const preparedGLTF = GLTFInstance.prepare(rawGLTF);
+
+        progressCallback(0.9);
+
+        return new GLTFInstance(preparedGLTF);
+      });
+
+      cache.set(url, gltfInstanceLoads);
     }
 
     await cache.get(url);
@@ -149,119 +145,41 @@ export class CachingGLTFLoader {
     preloaded.set(url, true);
   }
 
-  protected roughnessMipmapper =
-      new RoughnessMipmapper(Renderer.singleton.threeRenderer);
-
   /**
    * Loads a glTF from the specified url and resolves a unique clone of the
    * glTF. If the glTF has already been loaded, makes a clone of the cached
    * copy.
    */
   async load(url: string, progressCallback: ProgressCallback = () => {}):
-      Promise<CacheRetainedScene|null> {
+      Promise<InstanceType<T>> {
     await this.preload(url, progressCallback);
 
     const gltf = await cache.get(url)!;
 
-    const meshesToDuplicate: Mesh[] = [];
-    if (gltf.scene != null) {
-      gltf.scene.traverse((node: Object3D) => {
-        // Three.js seems to cull some animated models incorrectly. Since we
-        // expect to view our whole scene anyway, we turn off the frustum
-        // culling optimization here.
-        node.frustumCulled = false;
-        // Animations for objects without names target their UUID instead. When
-        // objects are cloned, they get new UUIDs which the animation can't
-        // find. To fix this, we assign their UUID as their name.
-        if (!node.name) {
-          node.name = node.uuid;
-        }
-        if (!(node as Mesh).isMesh) {
+
+    const clone = gltf.clone() as InstanceType<T>;
+    // const model = clone.scene;
+
+    // model.userData.animations = clone.animations;  // save animations
+    this[$evictionPolicy].retain(url);
+
+    clone.dispose = (() => {
+      const originalDispose = clone.dispose;
+      let disposed = false;
+
+      return () => {
+        if (disposed) {
           return;
         }
-        node.castShadow = true;
-        const mesh = node as Mesh;
-        let transparent = false;
-        const materials =
-            Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-        materials.forEach(material => {
-          if ((material as any).isMeshStandardMaterial) {
-            if (material.transparent && material.side === DoubleSide) {
-              transparent = true;
-              material.side = FrontSide;
-            }
-            this.roughnessMipmapper.generateMipmaps(
-                material as MeshStandardMaterial);
-          }
-        });
 
-        if (transparent) {
-          meshesToDuplicate.push(mesh);
-        }
-      });
-    }
+        disposed = true;
+        originalDispose.apply(clone);
+        this[$evictionPolicy].release(url);
+      };
+    })();
 
-    // We duplicate transparent, double-sided meshes and render the back face
-    // before the front face. This creates perfect triangle sorting for all
-    // convex meshes. Sorting artifacts can still appear when you can see
-    // through more than two layers of a given mesh, but this can usually be
-    // mitigated by the author splitting the mesh into mostly convex regions.
-    // The performance cost is not too great as the same shader is reused and
-    // the same number of fragments are processed; only the vertex shader is run
-    // twice. @see https://threejs.org/examples/webgl_materials_physical_transparency.html
-    for (const mesh of meshesToDuplicate) {
-      const materials =
-          Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-      const duplicateMaterials = materials.map((material) => {
-        const backMaterial = material.clone();
-        backMaterial.side = BackSide;
-        return backMaterial;
-      });
-      const duplicateMaterial = Array.isArray(mesh.material) ?
-          duplicateMaterials :
-          duplicateMaterials[0];
-      const meshBack = new Mesh(mesh.geometry, duplicateMaterial);
-      meshBack.renderOrder = -1;
-      mesh.add(meshBack);
-    }
-
-    const clone = cloneGltf(gltf);
-    const model = clone.scene ? clone.scene : null;
-
-    if (model != null) {
-      model.userData.animations = clone.animations;  // save animations
-
-      this[$evictionPolicy].retain(url);
-
-      (model as CacheRetainedScene)[$releaseFromCache] = (() => {
-        let released = false;
-        return () => {
-          if (released) {
-            return;
-          }
-
-          // We manually dispose cloned materials because Three.js keeps
-          // an internal count of materials using the same program, so it's
-          // safe to dispose of them incrementally. Geometry clones are not
-          // accounted for, so they cannot be disposed of incrementally.
-          model.traverse((object3D) => {
-            if (!(object3D as Mesh).isMesh) {
-              return;
-            }
-            const mesh = object3D as Mesh;
-            const materials =
-                Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-            materials.forEach(material => {
-              material.dispose();
-            });
-          });
-
-          this[$evictionPolicy].release(url);
-          released = true;
-        };
-      })();
-    }
-
-    return model as CacheRetainedScene | null;
+    return clone;
   }
 }
+
+(self as any).CachingGLTFLoader = CachingGLTFLoader;

--- a/packages/model-viewer/src/three-components/GLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/GLTFInstance.ts
@@ -1,0 +1,157 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Mesh, Object3D, Scene} from 'three';
+import {GLTF} from 'three/examples/jsm/loaders/GLTFLoader.js';
+import {SkeletonUtils} from 'three/examples/jsm/utils/SkeletonUtils.js';
+
+export const $prepared = Symbol('prepared');
+
+export interface PreparedGLTF extends GLTF {
+  [$prepared]?: boolean;
+}
+
+export const $prepare = Symbol('prepare');
+export const $preparedGLTF = Symbol('preparedGLTF');
+export const $clone = Symbol('clone');
+
+/**
+ * Represents the preparation and enhancement of the output of a Three.js
+ * GLTFLoader (a Three.js-flavor "GLTF"), to make it suitable for optimal,
+ * correct viewing in a given presentation context and also make the cloning
+ * process more explicit and legible.
+ *
+ * A GLTFInstance is API-compatible with a Three.js-flavor "GLTF", so it should
+ * be considered to be interchangeable with the loaded result of a GLTFLoader.
+ *
+ * This basic implementation only implements trivial preparation and enhancement
+ * of a GLTF. These operations are intended to be enhanced by inheriting
+ * classes.
+ */
+export class GLTFInstance implements GLTF {
+  /**
+   * Prepares a given GLTF for presentation and future cloning. A GLTF that is
+   * prepared can safely have this method invoked on it multiple times; it will
+   * only be prepared once, including after being cloned.
+   */
+  static prepare(source: GLTF): PreparedGLTF {
+    if (source.scene == null) {
+      throw new Error('Model does not have a scene');
+    }
+
+    if ((source as PreparedGLTF)[$prepared]) {
+      return source;
+    }
+
+    const prepared = this[$prepare](source);
+
+    return {...prepared, [$prepared]: true};
+  }
+
+  /**
+   * Override in an inheriting class to apply specialty one-time preparations
+   * for a given input GLTF.
+   */
+  protected static[$prepare](source: GLTF): GLTF {
+    // TODO(#195,#1003): We don't currently support multiple scenes, so we don't
+    // bother preparing extra scenes for now:
+    const {scene} = source;
+    const scenes = [scene];
+
+    return {...source, scene, scenes};
+  }
+
+  protected[$preparedGLTF]: PreparedGLTF;
+
+  get parser() {
+    return this[$preparedGLTF].parser;
+  }
+
+  get animations() {
+    return this[$preparedGLTF].animations;
+  }
+
+  get scene() {
+    return this[$preparedGLTF].scene;
+  }
+
+  get scenes() {
+    return this[$preparedGLTF].scenes;
+  }
+
+  get cameras() {
+    return this[$preparedGLTF].cameras;
+  }
+
+  get asset() {
+    return this[$preparedGLTF].asset;
+  }
+
+  get userData() {
+    return this[$preparedGLTF].userData;
+  }
+
+  constructor(preparedGLTF: PreparedGLTF) {
+    this[$preparedGLTF] = preparedGLTF;
+  }
+
+  /**
+   * Creates and returns a copy of this instance.
+   */
+  clone<T extends GLTFInstance>(): T {
+    const GLTFInstanceConstructor = this.constructor as Constructor<T>;
+
+    const clonedGLTF = this[$clone]();
+
+    return new GLTFInstanceConstructor(clonedGLTF);
+  }
+
+  /**
+   * Cleans up any retained memory that might not otherwise be released when
+   * this instance is done being used.
+   */
+  dispose(): void {
+    this.scenes.forEach((scene: Scene) => {
+      scene.traverse((object: Object3D) => {
+        if (!(object as Mesh).isMesh) {
+          return;
+        }
+        const mesh = object as Mesh;
+        const materials =
+            Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+        materials.forEach(material => {
+          material.dispose();
+        });
+        mesh.geometry.dispose();
+      });
+    });
+  }
+
+  /**
+   * Override in an inheriting class to implement specialized cloning strategies
+   */
+  protected[$clone](): PreparedGLTF {
+    const source = this[$preparedGLTF];
+    // TODO(#195,#1003): We don't currently support multiple scenes, so we don't
+    // bother cloning extra scenes for now:
+    const scene = SkeletonUtils.clone(this.scene) as Scene;
+    const scenes = [scene];
+    const userData = source.userData ? {...source.userData} : {};
+    return {...source, scene, scenes, userData};
+  }
+}
+
+export type GLTFInstanceConstructor =
+    Constructor<GLTFInstance>&{prepare: typeof GLTFInstance['prepare']};

--- a/packages/model-viewer/src/three-components/GLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/GLTFInstance.ts
@@ -56,9 +56,13 @@ export class GLTFInstance implements GLTF {
       return source;
     }
 
-    const prepared = this[$prepare](source);
+    const prepared = this[$prepare](source) as Partial<PreparedGLTF>;
 
-    return {...prepared, [$prepared]: true};
+    // NOTE: ES5 Symbol polyfill is not compatible with spread operator
+    // so {...prepared, [$prepared]: true} does not work
+    prepared[$prepared] = true;
+
+    return prepared as PreparedGLTF;
   }
 
   /**

--- a/packages/model-viewer/src/three-components/GLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/GLTFInstance.ts
@@ -16,6 +16,7 @@
 import {Mesh, Object3D, Scene} from 'three';
 import {GLTF} from 'three/examples/jsm/loaders/GLTFLoader.js';
 import {SkeletonUtils} from 'three/examples/jsm/utils/SkeletonUtils.js';
+import {Constructor} from '../utilities.js';
 
 export const $prepared = Symbol('prepared');
 
@@ -154,4 +155,4 @@ export class GLTFInstance implements GLTF {
 }
 
 export type GLTFInstanceConstructor =
-    Constructor<GLTFInstance>&{prepare: typeof GLTFInstance['prepare']};
+    Constructor<GLTFInstance, {prepare: typeof GLTFInstance['prepare']}>;

--- a/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
@@ -1,0 +1,189 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {BackSide, DoubleSide, FrontSide, Material, Mesh, MeshStandardMaterial, Object3D, Shader} from 'three';
+import {GLTF} from 'three/examples/jsm/loaders/GLTFLoader.js';
+import {RoughnessMipmapper} from 'three/examples/jsm/utils/RoughnessMipmapper.js';
+
+import {$clone, $prepare, GLTFInstance, PreparedGLTF} from '../GLTFInstance.js';
+import {Renderer} from '../Renderer.js';
+import {alphaChunk} from '../shader-chunk/alphatest_fragment.glsl.js';
+
+
+const $roughnessMipmapper = Symbol('roughnessMipmapper');
+const $cloneAndPatchMaterial = Symbol('cloneAndPatchMaterial');
+
+/**
+ * This specialization of GLTFInstance collects all of the processing needed
+ * to prepare a model and to clone it making special considerations for
+ * <model-viewer> use cases.
+ */
+export class ModelViewerGLTFInstance extends GLTFInstance {
+  protected static[$roughnessMipmapper]: RoughnessMipmapper =
+      new RoughnessMipmapper(Renderer.singleton.threeRenderer);
+
+  /**
+   * @override
+   */
+  protected static[$prepare](source: GLTF) {
+    const prepared = super[$prepare](source);
+    const {scene} = prepared;
+
+    const meshesToDuplicate: Mesh[] = [];
+
+    scene.traverse((node: Object3D) => {
+      // Set a high renderOrder while we're here to ensure the model
+      // always renders on top of the skysphere
+      node.renderOrder = 1000;
+
+      // Three.js seems to cull some animated models incorrectly. Since we
+      // expect to view our whole scene anyway, we turn off the frustum
+      // culling optimization here.
+      node.frustumCulled = false;
+      // Animations for objects without names target their UUID instead. When
+      // objects are cloned, they get new UUIDs which the animation can't
+      // find. To fix this, we assign their UUID as their name.
+      if (!node.name) {
+        node.name = node.uuid;
+      }
+      if (!(node as Mesh).isMesh) {
+        return;
+      }
+      node.castShadow = true;
+      const mesh = node as Mesh;
+      let transparent = false;
+      const materials =
+          Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+      materials.forEach(material => {
+        if ((material as any).isMeshStandardMaterial) {
+          if (material.transparent && material.side === DoubleSide) {
+            transparent = true;
+            material.side = FrontSide;
+          }
+          this[$roughnessMipmapper].generateMipmaps(
+              material as MeshStandardMaterial);
+        }
+      });
+
+      if (transparent) {
+        meshesToDuplicate.push(mesh);
+      }
+    });
+
+    // We duplicate transparent, double-sided meshes and render the back face
+    // before the front face. This creates perfect triangle sorting for all
+    // convex meshes. Sorting artifacts can still appear when you can see
+    // through more than two layers of a given mesh, but this can usually be
+    // mitigated by the author splitting the mesh into mostly convex regions.
+    // The performance cost is not too great as the same shader is reused and
+    // the same number of fragments are processed; only the vertex shader is run
+    // twice. @see https://threejs.org/examples/webgl_materials_physical_transparency.html
+    for (const mesh of meshesToDuplicate) {
+      const materials =
+          Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+      const duplicateMaterials = materials.map((material) => {
+        const backMaterial = material.clone();
+        backMaterial.side = BackSide;
+        return backMaterial;
+      });
+      const duplicateMaterial = Array.isArray(mesh.material) ?
+          duplicateMaterials :
+          duplicateMaterials[0];
+      const meshBack = new Mesh(mesh.geometry, duplicateMaterial);
+      meshBack.renderOrder = -1;
+      mesh.add(meshBack);
+    }
+
+    return prepared;
+  }
+
+  /**
+   * @override
+   */
+  [$clone](): PreparedGLTF {
+    const clone = super[$clone]();
+    const sourceUUIDToClonedMaterial = new Map<string, Material>();
+
+    clone.scene.traverse((node: any) => {
+      // Materials aren't cloned when cloning meshes; geometry
+      // and materials are copied by reference. This is necessary
+      // for the same model to be used twice with different
+      // environment maps.
+      if ((node as Mesh).isMesh) {
+        const mesh = node as Mesh;
+        if (Array.isArray(mesh.material)) {
+          mesh.material = mesh.material.map(
+              (material) => this[$cloneAndPatchMaterial](
+                  material, sourceUUIDToClonedMaterial));
+        } else if (mesh.material != null) {
+          mesh.material = this[$cloneAndPatchMaterial](
+              mesh.material, sourceUUIDToClonedMaterial);
+        }
+      }
+    });
+
+    return clone;
+  }
+
+  /**
+   * Creates a clone of the given material, and applies a patch to the
+   * shader program.
+   */
+  [$cloneAndPatchMaterial](
+      material: Material, sourceUUIDToClonedMaterial: Map<string, Material>) {
+    // If we already cloned this material (determined by tracking the UUID of
+    // source materials that have been cloned), then return that previously
+    // cloned instance:
+    if (sourceUUIDToClonedMaterial.has(material.uuid)) {
+      return sourceUUIDToClonedMaterial.get(material.uuid)!;
+    }
+
+    const clone = material.clone();
+
+    // This allows us to patch three's materials, on top of patches already
+    // made, for instance GLTFLoader patches SpecularGlossiness materials.
+    // Unfortunately, three's program cache differentiates SpecGloss materials
+    // via onBeforeCompile.toString(), so these two functions do the same
+    // thing but look different in order to force a proper recompile.
+    const oldOnBeforeCompile = material.onBeforeCompile;
+    clone.onBeforeCompile = (material as any).isGLTFSpecularGlossinessMaterial ?
+        (shader: Shader) => {
+          oldOnBeforeCompile(shader, undefined as any);
+          shader.fragmentShader = shader.fragmentShader.replace(
+              '#include <alphatest_fragment>', alphaChunk);
+        } :
+        (shader: Shader) => {
+          shader.fragmentShader = shader.fragmentShader.replace(
+              '#include <alphatest_fragment>', alphaChunk);
+          oldOnBeforeCompile(shader, undefined as any);
+        };
+    // This makes shadows better for non-manifold meshes
+    clone.shadowSide = FrontSide;
+    // This improves transparent rendering and can be removed whenever
+    // https://github.com/mrdoob/three.js/pull/18235 finally lands.
+    if (clone.transparent) {
+      clone.depthWrite = false;
+    }
+    // This little hack ignores alpha for opaque materials, in order to comply
+    // with the glTF spec.
+    if (!clone.alphaTest && !clone.transparent) {
+      clone.alphaTest = -0.5;
+    }
+
+    sourceUUIDToClonedMaterial.set(material.uuid, clone);
+
+    return clone;
+  }
+}

--- a/packages/modelviewer.dev/rollup.config.js
+++ b/packages/modelviewer.dev/rollup.config.js
@@ -25,6 +25,8 @@ const onwarn = (warning, warn) => {
 
 const plugins = [resolve(), replace({'Reflect.decorate': 'undefined'})];
 
+const watchFiles = ['lib/**', '../3dom/lib/**', '../model-viewer/lib/**'];
+
 const outputOptions = [
   {
     input: './lib/components/example-snippet.js',
@@ -54,15 +56,18 @@ const outputOptions = [
       format: 'esm',
       name: 'Tester'
     },
+    watch: {
+      include: watchFiles,
+    },
     plugins,
     onwarn
   },
   {
     input: './lib/tester.js',
-    output: {
-      file: './examples/built/tester-umd.js',
-      format: 'umd',
-      name: 'Tester'
+    output:
+        {file: './examples/built/tester-umd.js', format: 'umd', name: 'Tester'},
+    watch: {
+      include: watchFiles,
     },
     plugins,
     onwarn,


### PR DESCRIPTION
This started out as a fix for the problem where 3DOM scene graphs expressed a unique material for every location in the scene graph where a material occurred. It turned out that this was an implementation problem caused in `CachingGLTFLoader` and related to how models are cloned. So, to address the issue I made a light refactor of the related code (which was overdue anyway). Some highlights from the change:

 - Refactored `CachingGLTFLoader` and `cloneGltf`
   - Separate loading/caching from model preparation/cloning
   - Introduced `GLTFInstance`, a conveniently clone-able, dispose-able, API-compatible alternative to `GLTF`
   - `CachingGLTFLoader` now loads a full GLTF-like, rather than just a scene
   - `RoughnessMipmapper` is created once, rather than per-instance of `CachingGLTFLoader`
   - Ensure that discrete materials are only cloned once

Depends on #1063 

Fixes #1061 