### PR TITLE
Rendering fix for degenerate UVs

### DIFF
--- a/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
@@ -20,6 +20,7 @@ import {RoughnessMipmapper} from 'three/examples/jsm/utils/RoughnessMipmapper.js
 import {$clone, $prepare, GLTFInstance, PreparedGLTF} from '../GLTFInstance.js';
 import {Renderer} from '../Renderer.js';
 import {alphaChunk} from '../shader-chunk/alphatest_fragment.glsl.js';
+import {normalmapChunk} from '../shader-chunk/normalmap_pars_fragment.glsl.js';
 
 
 const $roughnessMipmapper = Symbol('roughnessMipmapper');
@@ -158,15 +159,19 @@ export class ModelViewerGLTFInstance extends GLTFInstance {
     // via onBeforeCompile.toString(), so these two functions do the same
     // thing but look different in order to force a proper recompile.
     const oldOnBeforeCompile = material.onBeforeCompile;
+    const patchFragment = (shader: Shader) => {
+      shader.fragmentShader =
+          shader.fragmentShader
+              .replace('#include <alphatest_fragment>', alphaChunk)
+              .replace('#include <normalmap_pars_fragment>', normalmapChunk);
+    };
     clone.onBeforeCompile = (material as any).isGLTFSpecularGlossinessMaterial ?
         (shader: Shader) => {
           oldOnBeforeCompile(shader, undefined as any);
-          shader.fragmentShader = shader.fragmentShader.replace(
-              '#include <alphatest_fragment>', alphaChunk);
+          patchFragment(shader);
         } :
         (shader: Shader) => {
-          shader.fragmentShader = shader.fragmentShader.replace(
-              '#include <alphatest_fragment>', alphaChunk);
+          patchFragment(shader);
           oldOnBeforeCompile(shader, undefined as any);
         };
     // This makes shadows better for non-manifold meshes

--- a/packages/model-viewer/src/three-components/shader-chunk/normalmap_pars_fragment.glsl.ts
+++ b/packages/model-viewer/src/three-components/shader-chunk/normalmap_pars_fragment.glsl.ts
@@ -1,0 +1,56 @@
+/**
+ * @license MIT
+ * @see https://github.com/mrdoob/three.js/blob/dev/LICENSE
+ */
+
+export const normalmapChunk = /* glsl */ `
+#ifdef USE_NORMALMAP
+
+	uniform sampler2D normalMap;
+	uniform vec2 normalScale;
+
+#endif
+
+#ifdef OBJECTSPACE_NORMALMAP
+
+	uniform mat3 normalMatrix;
+
+#endif
+
+#if ! defined ( USE_TANGENT ) && ( defined ( TANGENTSPACE_NORMALMAP ) || defined ( USE_CLEARCOAT_NORMALMAP ) )
+
+	// Per-Pixel Tangent Space Normal Mapping
+	// http://hacksoflife.blogspot.ch/2009/11/per-pixel-tangent-space-normal-mapping.html
+
+	vec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 mapN ) {
+
+		// Workaround for Adreno 3XX dFd*( vec3 ) bug. See #9988
+
+		vec3 q0 = vec3( dFdx( eye_pos.x ), dFdx( eye_pos.y ), dFdx( eye_pos.z ) );
+		vec3 q1 = vec3( dFdy( eye_pos.x ), dFdy( eye_pos.y ), dFdy( eye_pos.z ) );
+		vec2 st0 = dFdx( vUv.st );
+		vec2 st1 = dFdy( vUv.st );
+
+        float scale = sign( st1.t * st0.s - st0.t * st1.s ); // we do not care about the magnitude
+
+        // This avoids NaNs with degenerate UV coordinates
+        if ( scale == 0.0 ) {
+
+            return normalize( surf_norm );
+
+        }
+
+		vec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );
+		vec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );
+		vec3 N = normalize( surf_norm );
+
+		mat3 tsn = mat3( S, T, N );
+
+		mapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+
+		return normalize( tsn * mapN );
+
+	}
+
+#endif
+`;


### PR DESCRIPTION
This fixes a bug that was reported through a different channel. I had actually noticed before getting occasional triangles that would either be completely black or covered with random black noise, and traced it down to triangles with degenerate UV coordinates (different vertices with the same UV coords). It will only manifest if tangent vectors are not supplied.

I had assumed at first this was a problem with the authoring software, but it turns out this happens pretty often during compression by quantization, as happens with DRACO, etc. The problem is just NaNs creeping into the normal vector computation, so I've fixed that here.