### PR TITLE
Attempt to shard BrowserStack via project/build name

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,7 +45,7 @@ jobs:
       env:
         BROWSER_STACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}
         BROWSER_STACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
-        BROWSER_STACK_BUILD_NAME: ${{ github.ref + '/' + github.run_id }}
+        BROWSER_STACK_BUILD_NAME: ${{ format('{0} / {1}', github.ref, github.run_id) }}
       run: npm run test:ci
 
     - name: Generate legacy bundles
@@ -55,5 +55,5 @@ jobs:
       env:
         BROWSER_STACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}
         BROWSER_STACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
-        BROWSER_STACK_BUILD_NAME: ${{ github.ref + '/' + github.run_id }}
+        BROWSER_STACK_BUILD_NAME: ${{ format('{0} / {1}', github.ref, github.run_id) }}
       run: npm run test:ci:legacy

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,6 +45,7 @@ jobs:
       env:
         BROWSER_STACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}
         BROWSER_STACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
+        BROWSER_STACK_BUILD_NAME: ${{ github.ref + '/' + github.run_id }}
       run: npm run test:ci
 
     - name: Generate legacy bundles
@@ -54,4 +55,5 @@ jobs:
       env:
         BROWSER_STACK_USERNAME: ${{ secrets.BROWSER_STACK_USERNAME }}
         BROWSER_STACK_ACCESS_KEY: ${{ secrets.BROWSER_STACK_ACCESS_KEY }}
+        BROWSER_STACK_BUILD_NAME: ${{ github.ref + '/' + github.run_id }}
       run: npm run test:ci:legacy

--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -13,7 +13,11 @@
  * limitations under the License.
  */
 
+const {applyKarmaHacks} = require('./shared-assets/scripts/karma-hacks.js');
+
 const buildIdentifier = process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`;
+
+applyKarmaHacks(buildIdentifier);
 
 // This terrible hack needed in order to specify a custom BrowserStack
 // tunnel identifier. Failures to do so results in overlapping tunnels when
@@ -110,34 +114,6 @@ module.exports = function(config) {
       throw new Error(
           'BROWSER_STACK_USERNAME and BROWSER_STACK_ACCESS_KEY must be set with USE_BROWSER_STACK');
     }
-
-    // This terrible hack brought to you by a combination of two things:
-    //  1. BrowserStack drops the server port when redirecting from localhost
-    //     to bs-local.com on iOS
-    //  2. karma-browserstack-launcher drops the test-specific browser ID if
-    //     you configure the browser with a custom URL
-    // A support request to BrowserStack has been filed.
-    // A related bug has been filed againts karma-browserstack-launcher
-    // @see https://github.com/karma-runner/karma-browserstack-launcher/issues/172
-    const assign = Object.assign;
-    const newAssign = function(...args) {
-      // If we know this to be one very specific Object.assign call, then grab
-      // the test-specific browser ID and append it to our URL:
-      // @see https://github.com/karma-runner/karma-browserstack-launcher/blob/76dbfd0db6db46f4f85012cfe3c1f4c3accd2e44/index.js#L143
-      if (args[2] != null && args[2].url === 'http://bs-local.com:9876') {
-        const config = args[0];
-        const browser = args[2];
-        const query = config.url.split('?')[1];
-        browser.url = `${browser.url}?${query}`;
-
-        console.warn('Patching test URL to add Karma ID:', browser.url);
-      }
-      return assign.apply(this, args);
-    };
-    // Something in Karma deps actually asserts the sub-keys of Object.assign,
-    // so make sure to copy those over too:
-    assign.call(Object, newAssign, assign);
-    Object.assign = newAssign;
 
     const browserStackLaunchers = {
       'Edge (latest)': {

--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -165,6 +165,8 @@ module.exports = function(config) {
       browserStack: {
         idleTimeout: 600,
         name: '3DOM Unit Tests',
+        project: '3DOM',
+        build: process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`,
       },
 
       reporters: ['BrowserStack', 'mocha'],

--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -13,6 +13,50 @@
  * limitations under the License.
  */
 
+const buildIdentifier = process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`;
+
+// This terrible hack needed in order to specify a custom BrowserStack
+// tunnel identifier. Failures to do so results in overlapping tunnels when
+// builds run in parallel:
+{
+  // Patch global require so that we can intercept a resolved module by name. It
+  // isn't sufficient to require the module ourselves because it is a transitive
+  // dependency and we might not resolve the correct version:
+  const Module = module.constructor;
+  const require = Module.prototype.require;
+  Module.prototype.require = function(...args) {
+    const resolvedModule = require.apply(this, args);
+    if (args[0] === 'browserstack-local') {
+      const {Local} = resolvedModule;
+      // Annoyingly, browserstack-local populates methods using assignment on
+      // the instance rather than decorating the prototype, so we have to wrap
+      // the constructor in order to patch anything:
+      // @see https://github.com/browserstack/browserstack-local-nodejs/blob/d238484416e7ea6dfb51aede7d84d09339a8032a/lib/Local.js#L28
+      const WrappedLocal = function(...args) {
+        // Create an instance of the canonical class and patch its method post
+        // hoc before it is handed off to the invoking user:
+        const local = new Local(...args);
+        const start = local.start;
+        local.start = function(...args) {
+          const config = args[0];
+          // If the config is lacking a specified identifier for the tunnel,
+          // make sure to populate it with the one we want:
+          if (config && config.localIdentifier == null) {
+            console.warn(
+                'Patching BrowserStack tunnel configuration to specify unique ID:',
+                buildIdentifier);
+            config.localIdentifier = buildIdentifier;
+          }
+          return start.apply(this, args);
+        };
+        return local;
+      };
+      resolvedModule.Local = WrappedLocal;
+    }
+    return resolvedModule;
+  };
+}
+
 module.exports = function(config) {
   // @see http://karma-runner.github.io/4.0/config/configuration-file.html
   config.set({
@@ -81,11 +125,12 @@ module.exports = function(config) {
       // the test-specific browser ID and append it to our URL:
       // @see https://github.com/karma-runner/karma-browserstack-launcher/blob/76dbfd0db6db46f4f85012cfe3c1f4c3accd2e44/index.js#L143
       if (args[2] != null && args[2].url === 'http://bs-local.com:9876') {
-        console.warn('PATCHING URL TO ADD ID');
         const config = args[0];
         const browser = args[2];
         const query = config.url.split('?')[1];
         browser.url = `${browser.url}?${query}`;
+
+        console.warn('Patching test URL to add Karma ID:', browser.url);
       }
       return assign.apply(this, args);
     };
@@ -161,12 +206,14 @@ module.exports = function(config) {
       },
     };
 
+
     config.set({
       browserStack: {
         idleTimeout: 600,
         name: '3DOM Unit Tests',
         project: '3DOM',
-        build: process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`,
+        build: buildIdentifier,
+        tunnelIdentifier: buildIdentifier
       },
 
       reporters: ['BrowserStack', 'mocha'],

--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -106,6 +106,9 @@ module.exports = function(config) {
         os_version: 'Catalina',
         browser: 'safari',
         browser_version: 'latest',
+        // BrowserStack occassionally fails to tunnel localhost for Safari
+        // instances, causing them to time out:
+        url: 'http://127.0.0.1:9876'
       },
       'Safari 12.1': {
         base: 'BrowserStack',
@@ -113,6 +116,9 @@ module.exports = function(config) {
         os_version: 'Mojave',
         browser: 'safari',
         browser_version: '12.1',
+        // BrowserStack occassionally fails to tunnel localhost for Safari
+        // instances, causing them to time out:
+        url: 'http://127.0.0.1:9876'
       },
       'iOS Safari (iOS 13)': {
         base: 'BrowserStack',

--- a/packages/model-viewer/karma-legacy.conf.js
+++ b/packages/model-viewer/karma-legacy.conf.js
@@ -93,6 +93,8 @@ module.exports = function(config) {
       browserStack: {
         idleTimeout: 600,
         name: '<model-viewer> Unit Tests',
+        project: '<model-viewer>',
+        build: process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`,
       },
 
       reporters: ['BrowserStack', 'mocha'],

--- a/packages/model-viewer/karma-legacy.conf.js
+++ b/packages/model-viewer/karma-legacy.conf.js
@@ -100,8 +100,8 @@ module.exports = function(config) {
         idleTimeout: 600,
         name: '<model-viewer> Unit Tests',
         project: '<model-viewer>',
-        build: buildIdentifier,
-        tunnelIdentifier: buildIdentifier
+        build: process.env.BROWSER_STACK_BUILD_NAME || browserStackTunnelID,
+        tunnelIdentifier: browserStackTunnelID
       },
 
       reporters: ['BrowserStack', 'mocha'],

--- a/packages/model-viewer/karma-legacy.conf.js
+++ b/packages/model-viewer/karma-legacy.conf.js
@@ -15,9 +15,7 @@
 
 const {applyKarmaHacks} = require('./shared-assets/scripts/karma-hacks.js');
 
-const buildIdentifier = process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`;
-
-applyKarmaHacks(buildIdentifier);
+const browserStackTunnelID = applyKarmaHacks();
 
 module.exports = function(config) {
   // @see http://karma-runner.github.io/4.0/config/configuration-file.html

--- a/packages/model-viewer/karma-legacy.conf.js
+++ b/packages/model-viewer/karma-legacy.conf.js
@@ -13,6 +13,12 @@
  * limitations under the License.
  */
 
+const {applyKarmaHacks} = require('./shared-assets/scripts/karma-hacks.js');
+
+const buildIdentifier = process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`;
+
+applyKarmaHacks(buildIdentifier);
+
 module.exports = function(config) {
   // @see http://karma-runner.github.io/4.0/config/configuration-file.html
   config.set({
@@ -94,7 +100,8 @@ module.exports = function(config) {
         idleTimeout: 600,
         name: '<model-viewer> Unit Tests',
         project: '<model-viewer>',
-        build: process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`,
+        build: buildIdentifier,
+        tunnelIdentifier: buildIdentifier
       },
 
       reporters: ['BrowserStack', 'mocha'],

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -13,6 +13,12 @@
  * limitations under the License.
  */
 
+const {applyKarmaHacks} = require('./shared-assets/scripts/karma-hacks.js');
+
+const buildIdentifier = process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`;
+
+applyKarmaHacks(buildIdentifier);
+
 module.exports = function(config) {
   // @see http://karma-runner.github.io/4.0/config/configuration-file.html
   config.set({
@@ -96,33 +102,6 @@ module.exports = function(config) {
           'BROWSER_STACK_USERNAME and BROWSER_STACK_ACCESS_KEY must be set with USE_BROWSER_STACK');
     }
 
-    // This terrible hack brought to you by a combination of two things:
-    //  1. BrowserStack drops the server port when redirecting from localhost
-    //     to bs-local.com on iOS
-    //  2. karma-browserstack-launcher drops the test-specific browser ID if
-    //     you configure the browser with a custom URL
-    // A support request to BrowserStack has been filed.
-    // A related bug has been filed againts karma-browserstack-launcher
-    // @see https://github.com/karma-runner/karma-browserstack-launcher/issues/172
-    const assign = Object.assign;
-    const newAssign = function(...args) {
-      // If we know this to be one very specific Object.assign call, then grab
-      // the test-specific browser ID and append it to our URL:
-      // @see https://github.com/karma-runner/karma-browserstack-launcher/blob/76dbfd0db6db46f4f85012cfe3c1f4c3accd2e44/index.js#L143
-      if (args[2] != null && args[2].url === 'http://bs-local.com:9876') {
-        console.warn('PATCHING URL TO ADD ID');
-        const config = args[0];
-        const browser = args[2];
-        const query = config.url.split('?')[1];
-        browser.url = `${browser.url}?${query}`;
-      }
-      return assign.apply(this, args);
-    };
-    // Something in Karma deps actually asserts the sub-keys of Object.assign,
-    // so make sure to copy those over too:
-    assign.call(Object, newAssign, assign);
-    Object.assign = newAssign;
-
     const browserStackLaunchers = {
       'Edge (latest)': {
         base: 'BrowserStack',
@@ -196,7 +175,8 @@ module.exports = function(config) {
         idleTimeout: 600,
         name: '<model-viewer> Unit Tests',
         project: '<model-viewer>',
-        build: process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`,
+        build: buildIdentifier,
+        tunnelIdentifier: buildIdentifier
       },
 
       reporters: ['BrowserStack', 'mocha'],

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -135,6 +135,9 @@ module.exports = function(config) {
         os_version: 'Catalina',
         browser: 'safari',
         browser_version: 'latest',
+        // BrowserStack occassionally fails to tunnel localhost for Safari
+        // instances, causing them to time out:
+        url: 'http://127.0.0.1:9876'
       },
       'Safari 12.1': {
         base: 'BrowserStack',
@@ -142,6 +145,9 @@ module.exports = function(config) {
         os_version: 'Mojave',
         browser: 'safari',
         browser_version: '12.1',
+        // BrowserStack occassionally fails to tunnel localhost for Safari
+        // instances, causing them to time out:
+        url: 'http://127.0.0.1:9876'
       },
       'iOS Safari (iOS 13)': {
         base: 'BrowserStack',

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -15,9 +15,7 @@
 
 const {applyKarmaHacks} = require('./shared-assets/scripts/karma-hacks.js');
 
-const buildIdentifier = process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`;
-
-applyKarmaHacks(buildIdentifier);
+const browserStackTunnelID = applyKarmaHacks();
 
 module.exports = function(config) {
   // @see http://karma-runner.github.io/4.0/config/configuration-file.html
@@ -148,7 +146,7 @@ module.exports = function(config) {
       'iOS Safari (iOS 13)': {
         base: 'BrowserStack',
         os: 'iOS',
-        os_version: '12',
+        os_version: '13',
         device: 'iPhone 8',
         browser: 'iPhone',
         real_mobile: 'true',
@@ -175,8 +173,8 @@ module.exports = function(config) {
         idleTimeout: 600,
         name: '<model-viewer> Unit Tests',
         project: '<model-viewer>',
-        build: buildIdentifier,
-        tunnelIdentifier: buildIdentifier
+        build: process.env.BROWSER_STACK_BUILD_NAME || browserStackTunnelID,
+        tunnelIdentifier: browserStackTunnelID
       },
 
       reporters: ['BrowserStack', 'mocha'],

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -195,6 +195,8 @@ module.exports = function(config) {
       browserStack: {
         idleTimeout: 600,
         name: '<model-viewer> Unit Tests',
+        project: '<model-viewer>',
+        build: process.env.BROWSER_STACK_BUILD_NAME || `${Date.now()}`,
       },
 
       reporters: ['BrowserStack', 'mocha'],

--- a/packages/shared-assets/scripts/karma-hacks.js
+++ b/packages/shared-assets/scripts/karma-hacks.js
@@ -4,6 +4,7 @@ module.exports.applyKarmaHacks = () => {
   // This terrible hack needed in order to specify a custom BrowserStack
   // tunnel identifier. Failures to do so results in overlapping tunnels when
   // builds run in parallel.
+  // @see https://github.com/karma-runner/karma-browserstack-launcher/issues/155
 
   // Patch global require so that we can intercept a resolved module by name. It
   // isn't sufficient to require the module ourselves because it is a transitive

--- a/packages/shared-assets/scripts/karma-hacks.js
+++ b/packages/shared-assets/scripts/karma-hacks.js
@@ -55,7 +55,11 @@ module.exports.applyKarmaHacks = () => {
     // If we know this to be one very specific Object.assign call, then grab
     // the test-specific browser ID and append it to our URL:
     // @see https://github.com/karma-runner/karma-browserstack-launcher/blob/76dbfd0db6db46f4f85012cfe3c1f4c3accd2e44/index.js#L143
-    if (args[2] != null && args[2].url === 'http://bs-local.com:9876') {
+    const url = args[2] && args[2].url;
+
+    if (url != null &&
+        (url === 'http://bs-local.com:9876' ||
+         url === 'http://127.0.0.1:9876')) {
       const config = args[0];
       const browser = args[2];
       const query = config.url.split('?')[1];

--- a/packages/shared-assets/scripts/karma-hacks.js
+++ b/packages/shared-assets/scripts/karma-hacks.js
@@ -1,4 +1,6 @@
-module.exports.applyKarmaHacks = (buildIdentiifer) => {
+module.exports.applyKarmaHacks = () => {
+  const uniqueTunnelID = `${Date.now()}-${Math.random().toString().slice(2)}`;
+
   // This terrible hack needed in order to specify a custom BrowserStack
   // tunnel identifier. Failures to do so results in overlapping tunnels when
   // builds run in parallel.
@@ -28,8 +30,8 @@ module.exports.applyKarmaHacks = (buildIdentiifer) => {
           if (config && config.localIdentifier == null) {
             console.warn(
                 'Patching BrowserStack tunnel configuration to specify unique ID:',
-                buildIdentifier);
-            config.localIdentifier = buildIdentifier;
+                uniqueTunnelID);
+            config.localIdentifier = uniqueTunnelID;
           }
           return start.apply(this, args);
         };
@@ -67,4 +69,6 @@ module.exports.applyKarmaHacks = (buildIdentiifer) => {
   // so make sure to copy those over too:
   assign.call(Object, newAssign, assign);
   Object.assign = newAssign;
-}
+
+  return uniqueTunnelID;
+};

--- a/packages/shared-assets/scripts/karma-hacks.js
+++ b/packages/shared-assets/scripts/karma-hacks.js
@@ -1,0 +1,70 @@
+module.exports.applyKarmaHacks = (buildIdentiifer) => {
+  // This terrible hack needed in order to specify a custom BrowserStack
+  // tunnel identifier. Failures to do so results in overlapping tunnels when
+  // builds run in parallel.
+
+  // Patch global require so that we can intercept a resolved module by name. It
+  // isn't sufficient to require the module ourselves because it is a transitive
+  // dependency and we might not resolve the correct version:
+  const Module = module.constructor;
+  const require = Module.prototype.require;
+  Module.prototype.require = function(...args) {
+    const resolvedModule = require.apply(this, args);
+    if (args[0] === 'browserstack-local') {
+      const {Local} = resolvedModule;
+      // Annoyingly, browserstack-local populates methods using assignment on
+      // the instance rather than decorating the prototype, so we have to wrap
+      // the constructor in order to patch anything:
+      // @see https://github.com/browserstack/browserstack-local-nodejs/blob/d238484416e7ea6dfb51aede7d84d09339a8032a/lib/Local.js#L28
+      const WrappedLocal = function(...args) {
+        // Create an instance of the canonical class and patch its method post
+        // hoc before it is handed off to the invoking user:
+        const local = new Local(...args);
+        const start = local.start;
+        local.start = function(...args) {
+          const config = args[0];
+          // If the config is lacking a specified identifier for the tunnel,
+          // make sure to populate it with the one we want:
+          if (config && config.localIdentifier == null) {
+            console.warn(
+                'Patching BrowserStack tunnel configuration to specify unique ID:',
+                buildIdentifier);
+            config.localIdentifier = buildIdentifier;
+          }
+          return start.apply(this, args);
+        };
+        return local;
+      };
+      resolvedModule.Local = WrappedLocal;
+    }
+    return resolvedModule;
+  };
+
+  // This terrible hack brought to you by a combination of two things:
+  //  1. BrowserStack drops the server port when redirecting from localhost
+  //     to bs-local.com on iOS
+  //  2. karma-browserstack-launcher drops the test-specific browser ID if
+  //     you configure the browser with a custom URL
+  // A support request to BrowserStack has been filed.
+  // A related bug has been filed againts karma-browserstack-launcher
+  // @see https://github.com/karma-runner/karma-browserstack-launcher/issues/172
+  const assign = Object.assign;
+  const newAssign = function(...args) {
+    // If we know this to be one very specific Object.assign call, then grab
+    // the test-specific browser ID and append it to our URL:
+    // @see https://github.com/karma-runner/karma-browserstack-launcher/blob/76dbfd0db6db46f4f85012cfe3c1f4c3accd2e44/index.js#L143
+    if (args[2] != null && args[2].url === 'http://bs-local.com:9876') {
+      const config = args[0];
+      const browser = args[2];
+      const query = config.url.split('?')[1];
+      browser.url = `${browser.url}?${query}`;
+
+      console.warn('Patching test URL to add Karma ID:', browser.url);
+    }
+    return assign.apply(this, args);
+  };
+  // Something in Karma deps actually asserts the sub-keys of Object.assign,
+  // so make sure to copy those over too:
+  assign.call(Object, newAssign, assign);
+  Object.assign = newAssign;
+}


### PR DESCRIPTION
Browser stack builds appear to be establishing overlapping tunnels. This may be due to misconfiguration on our part. I'm testing out amendments to our configuration in this PR.

We landed on forcing a unique tunnel ID into each `karma-browserstack-launcher` run. This ID is required to run BrowserStack tunnels in parallel, according to all documentation that I can find on the topic. This appears to work as described, but we'll need to keep our eyes on the build after landing this change just in case.

Original approach:

The new approach creates a distinct BrowserStack build (which, for the sake of pedantry, is different but related to the Github Actions build) for each group of connections we make during a Github Actions run. In theory, this will result in two BrowserStack builds for each full unit test run. You can see the difference between the original approach and this new approach here:

![image](https://user-images.githubusercontent.com/240083/76643804-09b71980-6513-11ea-8338-8cd823e4a334.png)

In the original approach, we weren't specifying a build name or a project name, and all BrowserStack browsers were lumped into the same build.

My naive hope is that now that the builds are split apart, individual builds will be isolated from each other.