### PR TITLE
AR button size is now variable

### DIFF
--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -265,6 +265,8 @@ canvas.show {
   position: absolute;
   bottom: 16px;
   right: 16px;
+  transform: scale(var(--ar-button-scale, 1));
+  transform-origin: bottom right;
 }
 
 :not(.fullscreen) .slot.exit-fullscreen-button {


### PR DESCRIPTION
### Solves or temporarily fixes issue #556 
I have received feedback that the AR button is really difficult to push on mobile devices since it is too small. So I have just made the button size variable and the SVG image is scaled to 60% (which keeps the original ratio since 24px is 60% from 40px).