### PR TITLE
Small URL updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # The `<model-viewer>` project
 
 This is the main Github repository for the `<model-viewer>` web component and
-all of its related projects.
+all of its related projects. Getting started? Check out the
+[`<model-viewer>`](packages/model-viewer) project!
 
 The repository is organized into sub-directories containing the various projects.
 Check out the README.md files for specific projects to get more details:
@@ -42,7 +43,7 @@ Node.js and npm.
 Then, perform the following steps to get set up for development:
 
 ```sh
-git clone git@github.com:GoogleWebComponents/model-viewer.git
+git clone git@github.com:google/model-viewer.git
 cd model-viewer
 npm install
 npm run bootstrap

--- a/packages/model-viewer/README.md
+++ b/packages/model-viewer/README.md
@@ -20,7 +20,7 @@ As new standards and APIs become available `<model-viewer>` will be improved
 to take advantage of them. If possible, fallbacks and polyfills will be
 supported to provide a seamless development experience.
 
-[Demo](https://model-viewer.glitch.me) • [Documentation](https://googlewebcomponents.github.io/model-viewer/index.html) • [Kanban](https://github.com/GoogleWebComponents/model-viewer/projects/1) • [Quality Tests](https://googlewebcomponents.github.io/model-viewer/test/fidelity/results-viewer.html)
+[Demo](https://model-viewer.glitch.me) • [Documentation](https://modelviewer.dev/) • [Kanban](https://github.com/google/model-viewer/projects/1) • [Quality Tests](https://google.github.io/model-viewer/test/fidelity/results-viewer.html)
 
 
 ## Installing

--- a/packages/model-viewer/README.md
+++ b/packages/model-viewer/README.md
@@ -20,7 +20,7 @@ As new standards and APIs become available `<model-viewer>` will be improved
 to take advantage of them. If possible, fallbacks and polyfills will be
 supported to provide a seamless development experience.
 
-[Demo](https://model-viewer.glitch.me) • [Documentation](https://modelviewer.dev/) • [Kanban](https://github.com/google/model-viewer/projects/1) • [Quality Tests](https://google.github.io/model-viewer/test/fidelity/results-viewer.html)
+[Demo](https://model-viewer.glitch.me) • [Documentation](https://modelviewer.dev/) • [Kanban](https://github.com/google/model-viewer/projects/1) • [Quality Tests](https://modelviewer.dev/fidelity/)
 
 
 ## Installing


### PR DESCRIPTION
- GoogleWebComponents -> google in a few spots
- Update links to our docs site (now https://modelviewer.dev) and fidelity testing (https://modelviewer.dev/fidelity/)
- Add a "getting started" link to the main page

Fixes #1123