### PR TITLE
Webxr scale

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -18,6 +18,7 @@ import {property} from 'lit-element';
 import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
 import ModelViewerElementBase, {$container, $renderer, $scene} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
+import {$arRenderer} from '../three-components/Renderer.js';
 import {Constructor, deserializeUrl} from '../utilities.js';
 
 /**
@@ -306,6 +307,11 @@ configuration or device capabilities');
 
       if (changedProperties.has('arModes')) {
         this[$arModes] = deserializeARModes(this.arModes);
+      }
+
+      if (changedProperties.has('arScale')) {
+        this[$renderer][$arRenderer].canScale =
+            this.arScale === 'fixed' ? false : true;
       }
 
       this[$arMode] = ARMode.NONE;

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -18,7 +18,6 @@ import {property} from 'lit-element';
 import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
 import ModelViewerElementBase, {$container, $renderer, $scene} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
-import {$arRenderer} from '../three-components/Renderer.js';
 import {Constructor, deserializeUrl} from '../utilities.js';
 
 /**
@@ -310,8 +309,7 @@ configuration or device capabilities');
       }
 
       if (changedProperties.has('arScale')) {
-        this[$renderer][$arRenderer].canScale =
-            this.arScale === 'fixed' ? false : true;
+        this[$scene].canScale = this.arScale !== 'fixed';
       }
 
       this[$arMode] = ARMode.NONE;

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -21,7 +21,6 @@ import ModelViewerElementBase, {$ariaLabel, $container, $loadedTime, $needsRende
 import {degreesToRadians, normalizeUnit} from '../styles/conversions.js';
 import {EvaluatedStyle, Intrinsics, SphericalIntrinsics, StyleEvaluator, Vector3Intrinsics} from '../styles/evaluators.js';
 import {IdentNode, NumberNode, numberNode, parseExpressions} from '../styles/parsers.js';
-import {Damper} from '../three-components/Damper.js';
 import {SAFE_RADIUS_RATIO} from '../three-components/Model.js';
 import {ChangeEvent, ChangeSource, PointerChangeEvent, SmoothControls} from '../three-components/SmoothControls.js';
 import {Constructor} from '../utilities.js';
@@ -216,11 +215,6 @@ const $focusedTime = Symbol('focusedTime');
 const $zoomAdjustedFieldOfView = Symbol('zoomAdjustedFieldOfView');
 const $lastSpherical = Symbol('lastSpherical');
 const $jumpCamera = Symbol('jumpCamera');
-const $target = Symbol('target');
-const $goalTarget = Symbol('goalTarget');
-const $targetDamperX = Symbol('targetDamperX');
-const $targetDamperY = Symbol('targetDamperY');
-const $targetDamperZ = Symbol('targetDamperZ');
 
 const $syncCameraOrbit = Symbol('syncCameraOrbit');
 const $syncFieldOfView = Symbol('syncFieldOfView');
@@ -348,11 +342,6 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     protected[$zoomAdjustedFieldOfView] = 0;
     protected[$lastSpherical] = new Spherical();
     protected[$jumpCamera] = false;
-    private[$target] = new Vector3();
-    private[$goalTarget] = new Vector3();
-    private[$targetDamperX] = new Damper();
-    private[$targetDamperY] = new Damper();
-    private[$targetDamperZ] = new Damper();
 
     protected[$changeHandler] = (event: Event) =>
         this[$onChange](event as ChangeEvent);
@@ -369,7 +358,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     getCameraTarget(): Vector3D {
-      return this[$target];
+      return this[$scene].getTarget();
     }
 
     getFieldOfView(): number {
@@ -460,9 +449,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       if (this[$jumpCamera] === true) {
         Promise.resolve().then(() => {
           this[$controls].jumpToGoal();
-          const goal = this[$goalTarget];
-          this[$target].copy(goal);
-          this[$scene].setTarget(goal.x, goal.y, goal.z);
+          this[$scene].jumpToGoal();
           this[$jumpCamera] = false;
         });
       }
@@ -509,7 +496,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     [$syncCameraTarget](style: EvaluatedStyle<Vector3Intrinsics>) {
       const [x, y, z] = style;
-      this[$goalTarget].set(x, y, z);
+      this[$scene].setTarget(x, y, z);
     }
 
     [$tick](time: number, delta: number) {
@@ -568,18 +555,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         this[$needsRender]();
       }
 
-      const goal = this[$goalTarget];
-      if (!goal.equals(this[$target])) {
-        const radius = this[$scene].model.idealCameraDistance;
-        let {x, y, z} = this[$target];
-        x = this[$targetDamperX].update(x, goal.x, delta, radius);
-        y = this[$targetDamperY].update(y, goal.y, delta, radius);
-        z = this[$targetDamperZ].update(z, goal.z, delta, radius);
-        this[$target].set(x, y, z);
-        this[$scene].setTarget(x, y, z);
-      }
-
       this[$controls].update(time, delta);
+      this[$scene].updateTarget(delta);
     }
 
     [$deferInteractionPrompt]() {

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -296,6 +296,7 @@ export class ARRenderer extends EventDispatcher {
 
       scene.position.set(0, 0, 0);
       scene.scale.set(1, 1, 1);
+      model.setShadowScaleAndOffset(1, 0);
       scene.yaw = this[$turntableRotation]!;
       scene.setShadowIntensity(this[$oldShadowIntensity]!);
       scene.background = this[$oldBackground];
@@ -554,9 +555,8 @@ export class ARRenderer extends EventDispatcher {
         // When a lower floor is found, keep the model at the same height, but
         // drop the placement box to the floor. The model falls on select end.
         if (offset < 0) {
-          const modelOffset = offset / scale;
-          this[$placementBox]!.offsetHeight = modelOffset;
-          this[$presentedScene]!.model.setShadowOffset(modelOffset);
+          this[$placementBox]!.offsetHeight = offset / scale;
+          this[$presentedScene]!.model.setShadowScaleAndOffset(scale, offset);
           // Interpolate hit ray up to drag plane
           const cameraPosition = vector3.copy(this.camera.position);
           const alpha = -offset / (cameraPosition.y - hit.y);
@@ -592,10 +592,10 @@ export class ARRenderer extends EventDispatcher {
       const box = this[$placementBox]!;
       box.updateOpacity(delta);
       if (!this[$isTranslating]) {
-        const offset = (goal.y - y) / newScale;
+        const offset = goal.y - y;
         if (this[$placementComplete]) {
-          box.offsetHeight = offset;
-          model.setShadowOffset(offset);
+          box.offsetHeight = offset / newScale;
+          model.setShadowScaleAndOffset(newScale, offset);
         } else if (offset === 0) {
           this[$placementComplete] = true;
           box.show = false;

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -582,9 +582,12 @@ export class ARRenderer extends EventDispatcher {
     const scene = this[$presentedScene]!;
     const {model, position, yaw} = scene;
     const radius = model.idealCameraDistance;
+    const goal = this[$goalPosition];
+    const oldScale = scene.scale.x;
+    const box = this[$placementBox]!;
 
-    if (this[$initialHitSource] == null) {
-      const goal = this[$goalPosition];
+    if (this[$initialHitSource] == null &&
+        (!goal.equals(position) || this[$goalScale] !== oldScale)) {
       let {x, y, z} = position;
       delta *= this[$damperRate];
       x = this[$xDamper].update(x, goal.x, delta, radius);
@@ -592,13 +595,10 @@ export class ARRenderer extends EventDispatcher {
       z = this[$zDamper].update(z, goal.z, delta, radius);
       position.set(x, y, z);
 
-      const oldScale = scene.scale.x;
       const newScale =
           this[$scaleDamper].update(oldScale, this[$goalScale], delta, 1);
       scene.scale.set(newScale, newScale, newScale);
 
-      const box = this[$placementBox]!;
-      box.updateOpacity(delta);
       if (!this[$isTranslating]) {
         const offset = goal.y - y;
         if (this[$placementComplete]) {
@@ -612,6 +612,7 @@ export class ARRenderer extends EventDispatcher {
         }
       }
     }
+    box.updateOpacity(delta);
     scene.updateTarget(delta);
     // This updates the model's position, which the shadow is based on.
     scene.updateMatrixWorld(true);

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -95,7 +95,6 @@ export class ARRenderer extends EventDispatcher {
   public threeRenderer: WebGLRenderer;
 
   public camera: PerspectiveCamera = new PerspectiveCamera();
-  public canScale = true;
 
   private[$placementBox]: PlacementBox|null = null;
   private[$lastTick]: number|null = null;
@@ -470,6 +469,7 @@ export class ARRenderer extends EventDispatcher {
       return;
     }
     const fingers = this[$frame]!.getHitTestResultsForTransientInput(hitSource);
+    const scene = this[$presentedScene]!;
     const box = this[$placementBox]!;
 
     if (fingers.length === 1) {
@@ -486,11 +486,10 @@ export class ARRenderer extends EventDispatcher {
         this[$isRotating] = true;
         this[$lastScalar] = axes[0];
       }
-    } else if (fingers.length === 2 && this.canScale) {
+    } else if (fingers.length === 2 && scene.canScale) {
       box.show = true;
       this[$isScaling] = true;
-      this[$lastScalar] =
-          this[$fingerSeparation](fingers) / this[$presentedScene]!.scale.x;
+      this[$lastScalar] = this[$fingerSeparation](fingers) / scene.scale.x;
     }
   }
 
@@ -521,7 +520,8 @@ export class ARRenderer extends EventDispatcher {
       return;
     }
     const fingers = frame.getHitTestResultsForTransientInput(hitSource);
-    const scale = this[$presentedScene]!.scale.x;
+    const scene = this[$presentedScene]!;
+    const scale = scene.scale.x;
 
     if (this[$isScaling]) {
       if (fingers.length < 2) {
@@ -533,7 +533,7 @@ export class ARRenderer extends EventDispatcher {
             (scale < SCALE_SNAP && scale > SCALE_SNAP_LOW) ? 1 : scale;
       }
       return;
-    } else if (fingers.length === 2 && this.canScale) {
+    } else if (fingers.length === 2 && scene.canScale) {
       this[$isTranslating] = false;
       this[$isRotating] = false;
       this[$isScaling] = true;

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -37,7 +37,7 @@ const ROTATION_RATE = 1.5;
 const HIT_ANGLE_DEG = 20;
 // Slow down the dampers for initial placement.
 const INTRO_RATE = 0.4;
-const SCALE_SNAP = 1.1;
+const SCALE_SNAP = 1.2;
 const SCALE_SNAP_LOW = 1 / SCALE_SNAP;
 
 const $presentedScene = Symbol('presentedScene');
@@ -232,6 +232,8 @@ export class ARRenderer extends EventDispatcher {
     scene.setCamera(this.camera);
     this[$initialized] = false;
     this[$damperRate] = INTRO_RATE;
+    this[$goalYaw] = 0;
+    this[$goalScale] = 1;
 
     this[$oldBackground] = scene.background;
     scene.background = null;
@@ -423,6 +425,7 @@ export class ARRenderer extends EventDispatcher {
     const scene = this[$presentedScene]!;
     const {model} = scene;
     const {min, max} = model.boundingBox;
+
     this[$placementBox]!.show = true;
 
     const goal = this[$goalPosition];
@@ -453,7 +456,8 @@ export class ARRenderer extends EventDispatcher {
     }
 
     // Move the scene's target to the model's floor height.
-    model.position.y = -min.y;
+    const target = scene.getTarget();
+    scene.setTarget(target.x, min.y, target.z);
     // Ignore the y-coordinate and set on the floor instead.
     goal.y = floor;
 
@@ -608,6 +612,7 @@ export class ARRenderer extends EventDispatcher {
         }
       }
     }
+    scene.updateTarget(delta);
     // This updates the model's position, which the shadow is based on.
     scene.updateMatrixWorld(true);
     // yaw must be updated last, since this also updates the shadow position.

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -37,6 +37,8 @@ const ROTATION_RATE = 1.5;
 const HIT_ANGLE_DEG = 20;
 // Slow down the dampers for initial placement.
 const INTRO_RATE = 0.4;
+const SCALE_SNAP = 1.1;
+const SCALE_SNAP_LOW = 1 / SCALE_SNAP;
 
 const $presentedScene = Symbol('presentedScene');
 const $placementBox = Symbol('placementBox');
@@ -522,7 +524,9 @@ export class ARRenderer extends EventDispatcher {
         this[$isScaling] = false;
       } else {
         const separation = this[$fingerSeparation](fingers);
-        this[$goalScale] = separation / this[$lastScalar];
+        const scale = separation / this[$lastScalar];
+        this[$goalScale] =
+            (scale < SCALE_SNAP && scale > SCALE_SNAP_LOW) ? 1 : scale;
       }
       return;
     } else if (fingers.length === 2 && this.canScale) {

--- a/packages/model-viewer/src/three-components/Model.ts
+++ b/packages/model-viewer/src/three-components/Model.ts
@@ -348,10 +348,10 @@ export default class Model extends Object3D {
    * Shift the floor vertically from the bottom of the model's bounding box by
    * offset (should generally be negative).
    */
-  setShadowOffset(offset: number) {
+  setShadowScaleAndOffset(scale: number, offset: number) {
     const shadow = this[$shadow];
     if (shadow != null) {
-      shadow.setOffset(offset);
+      shadow.setScaleAndOffset(scale, offset);
     }
   }
 

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -66,6 +66,7 @@ export class ModelScene extends Scene {
       null;
   public exposure = 1;
   public model: Model;
+  public canScale = true;
   public framedFieldOfView = DEFAULT_FOV_DEG;
   public activeCamera: Camera;
   // These default camera values are never used, as they are reset once the

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -18,6 +18,7 @@ import {Camera, Event as ThreeEvent, Object3D, PerspectiveCamera, Raycaster, Sce
 import {USE_OFFSCREEN_CANVAS} from '../constants.js';
 import ModelViewerElementBase, {$renderer} from '../model-viewer-base.js';
 
+import {Damper} from './Damper.js';
 import Model, {DEFAULT_FOV_DEG} from './Model.js';
 
 export interface ModelLoadEvent extends ThreeEvent {
@@ -41,6 +42,7 @@ export const IlluminationRole: {[index: string]: IlluminationRole} = {
 const DEFAULT_TAN_FOV = Math.tan((DEFAULT_FOV_DEG / 2) * Math.PI / 180);
 
 const raycaster = new Raycaster();
+const vector3 = new Vector3();
 
 const $paused = Symbol('paused');
 
@@ -69,6 +71,11 @@ export class ModelScene extends Scene {
   // These default camera values are never used, as they are reset once the
   // model is loaded and framing is computed.
   public camera = new PerspectiveCamera(45, 1, 0.1, 100);
+
+  private goalTarget = new Vector3();
+  private targetDamperX = new Damper();
+  private targetDamperY = new Damper();
+  private targetDamperZ = new Damper();
 
   constructor({canvas, element, width, height}: ModelSceneConfig) {
     super();
@@ -147,6 +154,8 @@ export class ModelScene extends Scene {
 
       const renderer = this.element[$renderer];
       renderer.expandTo(this.width, this.height);
+      this.canvas.width = renderer.width;
+      this.canvas.height = renderer.height;
 
       // Immediately queue a render to happen at microtask timing. This is
       // necessary because setting the width and height of the canvas has the
@@ -209,8 +218,29 @@ export class ModelScene extends Scene {
    * Sets the point in model coordinates the model should orbit/pivot around.
    */
   setTarget(modelX: number, modelY: number, modelZ: number) {
-    this.model.position.set(-modelX, -modelY, -modelZ);
-    this.isDirty = true;
+    this.goalTarget.set(-modelX, -modelY, -modelZ);
+  }
+
+  getTarget(): Vector3 {
+    return vector3.copy(this.goalTarget).multiplyScalar(-1);
+  }
+
+  jumpToGoal() {
+    this.updateTarget(10000);
+  }
+
+  updateTarget(delta: number) {
+    const goal = this.goalTarget;
+    const target = this.model.position;
+    if (!goal.equals(target)) {
+      const radius = this.model.idealCameraDistance;
+      let {x, y, z} = target;
+      x = this.targetDamperX.update(x, goal.x, delta, radius);
+      y = this.targetDamperY.update(y, goal.y, delta, radius);
+      z = this.targetDamperZ.update(z, goal.z, delta, radius);
+      this.model.position.set(x, y, z);
+      this.isDirty = true;
+    }
   }
 
   /**

--- a/packages/model-viewer/src/three-components/Shadow.ts
+++ b/packages/model-viewer/src/three-components/Shadow.ts
@@ -171,7 +171,6 @@ export class Shadow extends DirectionalLight {
     camera.near = 0;
     camera.far = sizeY * scale - offset;
 
-    this.updateMatrixWorld();
     camera.projectionMatrix.makeOrthographic(
         camera.left * scale,
         camera.right * scale,

--- a/packages/model-viewer/src/three-components/Shadow.ts
+++ b/packages/model-viewer/src/three-components/Shadow.ts
@@ -132,7 +132,7 @@ export class Shadow extends DirectionalLight {
     camera.bottom = boundingBox.min.z - heightPad;
     camera.top = boundingBox.max.z + heightPad;
 
-    this.setOffset(0);
+    this.setScaleAndOffset(camera.zoom, 0);
     this.shadow.updateMatrices(this);
 
     this.floor.scale.set(size.x + 2 * widthPad, size.z + 2 * heightPad, 1);
@@ -159,16 +159,26 @@ export class Shadow extends DirectionalLight {
     this.shadow.updateMatrices(this);
   }
 
-  setOffset(offset: number) {
+  setScaleAndOffset(scale: number, offset: number) {
     const sizeY = this.size.y;
+    const inverseScale = 1 / scale;
     // Floor plane is up slightly from the bottom of the bounding box to avoid
     // Z-fighting with baked-in shadows and to stay inside the shadow camera.
     const shadowOffset = sizeY * OFFSET;
-    this.floor.position.y = 2 * shadowOffset - sizeY + offset;
+    this.floor.position.y = 2 * shadowOffset - sizeY + offset * inverseScale;
     const {camera} = this.shadow;
+    camera.zoom = scale;
     camera.near = 0;
-    camera.far = sizeY - offset;
+    camera.far = sizeY * scale - offset;
+
     this.updateMatrixWorld();
-    camera.updateProjectionMatrix();
+    camera.projectionMatrix.makeOrthographic(
+        camera.left * scale,
+        camera.right * scale,
+        camera.top * scale,
+        camera.bottom * scale,
+        camera.near,
+        camera.far);
+    camera.projectionMatrixInverse.getInverse(camera.projectionMatrix);
   }
 }


### PR DESCRIPTION
Adds two-finger scaling to the webXR UX, based on the ar-scale attribute. This involved moving the target dampers from controls to ModelScene so that they could be used by ARRenderer as well (they were moved to controls from SmoothControls in the first UX PR). 