### PR TITLE
disable iOS13 tests

### DIFF
--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -120,17 +120,18 @@ module.exports = function(config) {
         // instances, causing them to time out:
         url: 'http://127.0.0.1:9876'
       },
-      'iOS Safari (iOS 13)': {
-        base: 'BrowserStack',
-        os: 'iOS',
-        os_version: '13',
-        device: 'iPhone 8',
-        browser: 'iPhone',
-        real_mobile: 'true',
-        // BrowserStack seems to drop the port when redirecting to this special
-        // domain so we go there directly instead:
-        url: 'http://bs-local.com:9876'
-      },
+      // 'iOS Safari (iOS 13)': {
+      //   base: 'BrowserStack',
+      //   os: 'iOS',
+      //   os_version: '13',
+      //   device: 'iPhone 8',
+      //   browser: 'iPhone',
+      //   real_mobile: 'true',
+      //   // BrowserStack seems to drop the port when redirecting to this
+      //   special
+      //   // domain so we go there directly instead:
+      //   url: 'http://bs-local.com:9876'
+      // },
       'iOS Safari (iOS 12)': {
         base: 'BrowserStack',
         os: 'iOS',

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -149,17 +149,18 @@ module.exports = function(config) {
         // instances, causing them to time out:
         url: 'http://127.0.0.1:9876'
       },
-      'iOS Safari (iOS 13)': {
-        base: 'BrowserStack',
-        os: 'iOS',
-        os_version: '13',
-        device: 'iPhone 8',
-        browser: 'iPhone',
-        real_mobile: 'true',
-        // BrowserStack seems to drop the port when redirecting to this special
-        // domain so we go there directly instead:
-        url: 'http://bs-local.com:9876'
-      },
+      // 'iOS Safari (iOS 13)': {
+      //   base: 'BrowserStack',
+      //   os: 'iOS',
+      //   os_version: '13',
+      //   device: 'iPhone 8',
+      //   browser: 'iPhone',
+      //   real_mobile: 'true',
+      //   // BrowserStack seems to drop the port when redirecting to this
+      //   special
+      //   // domain so we go there directly instead:
+      //   url: 'http://bs-local.com:9876'
+      // },
       'iOS Safari (iOS 12)': {
         base: 'BrowserStack',
         os: 'iOS',


### PR DESCRIPTION
Something is very wrong with iOS13 on BrowserStack this week, so disabling until they get it working again.