### PR TITLE
Ensure built-in poster has default background color

### DIFF
--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -146,7 +146,7 @@ canvas.show {
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  background-color: var(--poster-color, inherit);
+  background-color: var(--poster-color, #fff);
   background-image: var(--poster-image, none);
 }
 

--- a/packages/modelviewer.dev/examples/lazy-loading.html
+++ b/packages/modelviewer.dev/examples/lazy-loading.html
@@ -81,6 +81,11 @@
           <h4></h4>
         </div>
         <example-snippet stamp-to="demo-container-1" highlight-as="html">
+          <style>
+            model-viewer#reveal {
+              --poster-color: transparent;
+            }
+          </style>
           <template>
 <model-viewer id="reveal" preload camera-controls auto-rotate poster="../assets/poster-shishkebab.png" src="../shared-assets/models/shishkebab.glb" alt="A 3D model of a shishkebab"></model-viewer>
           </template>

--- a/packages/modelviewer.dev/examples/lazy-loading.html
+++ b/packages/modelviewer.dev/examples/lazy-loading.html
@@ -81,12 +81,13 @@
           <h4></h4>
         </div>
         <example-snippet stamp-to="demo-container-1" highlight-as="html">
-          <style>
-            model-viewer#reveal {
-              --poster-color: transparent;
-            }
-          </style>
+          
           <template>
+<style>
+  model-viewer#reveal {
+    --poster-color: transparent;
+  }
+</style>
 <model-viewer id="reveal" preload camera-controls auto-rotate poster="../assets/poster-shishkebab.png" src="../shared-assets/models/shishkebab.glb" alt="A 3D model of a shishkebab"></model-viewer>
           </template>
         </example-snippet>

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -327,16 +327,18 @@
             </li>
             <li>
               <div>poster</div>
-              <p>Displays an image instead of the model. See <a
-              href="https://github.com/GoogleWebComponents/model-viewer#on-loading">On
-              Loading</a> for more information.</p>
+              <p>Displays an image instead of the model, useful for showing the
+                user something before a model is loaded and ready to render. If
+                you use a poster with transparency, you may also want to set
+                --poster-color to transparent so that the background shows
+                through. See <a href="./examples/lazy-loading.html">our section
+                on lazy loading</a> for examples.</p>
             </li>
             <li>
               <div>preload</div>
               <p>When poster is also enabled, the model will be downloaded
-              before user action. See <a
-              href="https://github.com/GoogleWebComponents/model-viewer#on-loading">On
-              Loading</a> for more information.</p>
+              before user action. See <a href="./examples/lazy-loading.html">our
+              section on lazy loading</a> for examples.</p>
             </li>
             <li>
               <div>quick-look-browsers</div>
@@ -401,8 +403,10 @@
             </li>
             <li>
               <div>--poster-color</div>
-              <p>Sets the background-color of the poster. Falls back to
-              --background-color if set. Defaults to #fff.</p>
+              <p>Sets the background-color of the poster. You may wish to set
+                this to transparent if you are using a seamless poster with
+                transparency (so that the background color of
+                &lt;model-viewer&gt; shows through). Defaults to #fff.</p>
             </li>
             <li>
               <div>--poster-image</div>


### PR DESCRIPTION
I think this may have regressed as part of the seamless poster change in #890 . I don't think it's necessary for the poster to have a fallback color of `inherit` for seamless poster transitions to work, and also it means that in most cases, the built-in poster won't have any background color at all.