### PR TITLE
Add recommendations regarding verifying glTF->USDZ output

### DIFF
--- a/packages/modelviewer.dev/examples/augmented-reality.html
+++ b/packages/modelviewer.dev/examples/augmented-reality.html
@@ -90,7 +90,9 @@
           </li>
           <li>
             <div>ios-src</div>
-            <p>Provides augmented reality on supported iOS 12+ devices via AR Quick Look, but requires an additional USDZ model.</p>
+            <p>Provides augmented reality on supported iOS 12+ devices via AR Quick Look, but requires
+            an additional USDZ model (glTF->USDZ converters are available, but keep in mind that settings
+            such as units may need to be changed).</p>
           </li>
           <li>
             <div>quick-look-browsers</div>

--- a/packages/modelviewer.dev/examples/augmented-reality.html
+++ b/packages/modelviewer.dev/examples/augmented-reality.html
@@ -91,8 +91,8 @@
           <li>
             <div>ios-src</div>
             <p>Provides augmented reality on supported iOS 12+ devices via AR Quick Look, but requires
-            an additional USDZ model (glTF->USDZ converters are available, but keep in mind that settings
-            such as units may need to be changed).</p>
+            an additional USDZ model. It's possible to convert from glTF to USDZ, but keep in mind that
+            the output (including settings such as units) should be verified.</p>
           </li>
           <li>
             <div>quick-look-browsers</div>

--- a/packages/modelviewer.dev/examples/augmented-reality.html
+++ b/packages/modelviewer.dev/examples/augmented-reality.html
@@ -92,7 +92,7 @@
             <div>ios-src</div>
             <p>Provides augmented reality on supported iOS 12+ devices via AR Quick Look, but requires
             an additional USDZ model. It's possible to convert from glTF to USDZ, but keep in mind that
-            the output (including settings such as units) should be verified.</p>
+            the output (including settings such as size units) should be verified.</p>
           </li>
           <li>
             <div>quick-look-browsers</div>


### PR DESCRIPTION
This is a reminder to test things like size units, although without going into too much detail as a recommendation depends on target use case (including if you need to support only iOS 13).
 
Fixes #559