### PR TITLE
match webXR spec update

### DIFF
--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -238,7 +238,7 @@ export class ARRenderer extends EventDispatcher {
     const radians = HIT_ANGLE_DEG * Math.PI / 180;
     const ray = new XRRay(
         new DOMPoint(0, 0, 0),
-        new DOMPoint(0, -Math.sin(radians), -Math.cos(radians)));
+        {x: 0, y: -Math.sin(radians), z: -Math.cos(radians)});
     currentSession
         .requestHitTestSource({space: this[$viewerRefSpace]!, offsetRay: ray})
         .then(hitTestSource => {

--- a/packages/model-viewer/src/types/webxr.ts
+++ b/packages/model-viewer/src/types/webxr.ts
@@ -76,12 +76,19 @@ declare interface XRViewerPose {
   readonly views: Array<XRView>
 }
 
+declare interface XRRayDirectionInit {
+  x?: number;
+  y?: number;
+  z?: number;
+  w?: number;
+}
+
 declare class XRRay {
   readonly origin: DOMPointReadOnly;
-  readonly direction: DOMPointReadOnly;
+  readonly direction: XRRayDirectionInit;
   matrix: Float32Array;
 
-  constructor(origin: DOMPointInit, direction: DOMPointInit)
+  constructor(origin: DOMPointInit, direction: XRRayDirectionInit)
 }
 
 declare interface XRPose {
@@ -180,8 +187,7 @@ declare class XRWebGLLayer implements XRLayer {
   public framebufferHeight: number;
 
   constructor(
-      session: XRSession, gl: WebGLRenderingContext,
-      options: XRWebGLLayerInit)
+      session: XRSession, gl: WebGLRenderingContext, options: XRWebGLLayerInit)
 
   getViewport(view: XRView): XRViewport
 }


### PR DESCRIPTION
There was a change that prevented webXR from launching in Chrome Canary due to a small spec change. This fixes it.