### PR TITLE
fixed multiple webXR issues

### DIFF
--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -15,7 +15,7 @@
 
 import {EventDispatcher, Matrix4, PerspectiveCamera, Ray, Vector3, WebGLRenderer} from 'three';
 
-import {$needsRender, $onResize} from '../model-viewer-base.js';
+import {$onResize} from '../model-viewer-base.js';
 import {assertIsArCandidate} from '../utilities.js';
 
 import {Damper} from './Damper.js';
@@ -150,8 +150,8 @@ export class ARRenderer extends EventDispatcher {
           requiredFeatures: ['hit-test'],
           optionalFeatures: ['dom-overlay'],
           domOverlay: {
-            root: document.querySelector('model-viewer')!.shadowRoot!
-                      .querySelector('div.annotation-container')
+            root: scene.element.shadowRoot!.querySelector(
+                'div.annotation-container')
           }
         });
 
@@ -175,7 +175,7 @@ export class ARRenderer extends EventDispatcher {
     // TODO: this method should be added to three.js's exported interface.
     (this.threeRenderer as any)
         .setFramebuffer(session.renderState.baseLayer!.framebuffer);
-    (scene.element)[$onResize](window.screen);
+    scene.element[$onResize](window.screen);
 
     return session;
   }
@@ -304,7 +304,7 @@ export class ARRenderer extends EventDispatcher {
       scene.background = this[$oldBackground];
       model.orientHotspots(0);
       element.requestUpdate('cameraTarget');
-      element[$needsRender]();
+      element[$onResize](element.getBoundingClientRect());
 
       this.renderer.expandTo(scene.width, scene.height);
     }


### PR DESCRIPTION
Fixes #1190 

The first problem was caused by a line of code I didn't write, but I'm ashamed I read it so many times without noticing the fairly glaring error. The second problem was that we were failing to call resize when cleaning up webXR. I think I missed this because our examples all use a %width CSS which causes the resize observer to fire when leaving fullscreen, but it does not for fixed-width elements. 