### PR TITLE
handle non-positive damper normalizer

### DIFF
--- a/packages/model-viewer/src/test/index.ts
+++ b/packages/model-viewer/src/test/index.ts
@@ -27,6 +27,7 @@ import './three-components/ARRenderer-spec.js';
 import './three-components/GLTFInstance-spec.js';
 import './three-components/gltf-instance/ModelViewerGLTFInstance-spec.js';
 import './three-components/SmoothControls-spec.js';
+import './three-components/Damper-spec.js';
 import './three-components/TextureUtils-spec.js';
 import './three-components/CachingGLTFLoader-spec.js';
 import './three-components/ModelUtils-spec.js';

--- a/packages/model-viewer/src/test/three-components/Damper-spec.ts
+++ b/packages/model-viewer/src/test/three-components/Damper-spec.ts
@@ -1,0 +1,52 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Damper} from '../../three-components/Damper.js';
+
+const expect = chai.expect;
+
+const ONE_FRAME_DELTA = 1000.0 / 60.0;
+const FIFTY_FRAME_DELTA = 50 * ONE_FRAME_DELTA;
+
+suite('Damper', () => {
+  let damper: Damper;
+  const initial = 5;
+  const goal = 2;
+
+  setup(() => {
+    damper = new Damper();
+  });
+
+  test('converges to goal with large time step without overshoot', () => {
+    const moving = damper.update(initial, goal, ONE_FRAME_DELTA, initial);
+    const final = damper.update(moving, goal, FIFTY_FRAME_DELTA, initial);
+    expect(final).to.be.eql(goal);
+  });
+
+  test('stays at initial value for negative time step', () => {
+    const final = damper.update(initial, goal, -1 * FIFTY_FRAME_DELTA, initial);
+    expect(final).to.be.eql(initial);
+  });
+
+  test('converges to goal when normalization is zero', () => {
+    const final = damper.update(initial, goal, FIFTY_FRAME_DELTA, 0);
+    expect(final).to.be.eql(goal);
+  });
+
+  test('negative normalization is the same as positive', () => {
+    const final = damper.update(initial, goal, FIFTY_FRAME_DELTA, -initial);
+    expect(final).to.be.eql(goal);
+  });
+});

--- a/packages/model-viewer/src/test/three-components/SmoothControls-spec.ts
+++ b/packages/model-viewer/src/test/three-components/SmoothControls-spec.ts
@@ -15,7 +15,6 @@
 
 import {PerspectiveCamera, Vector3} from 'three';
 
-import {Damper} from '../../three-components/Damper.js';
 import {ChangeSource, DEFAULT_OPTIONS, KeyCode, SmoothControls} from '../../three-components/SmoothControls.js';
 import {dispatchSyntheticEvent, waitForEvent} from '../helpers.js';
 
@@ -36,26 +35,6 @@ const DEFAULT_INTERACTION_CHANGE_SOURCE = 'none';
  */
 export const settleControls = (controls: SmoothControls) =>
     controls.update(performance.now(), FIFTY_FRAME_DELTA);
-
-suite('Damper', () => {
-  let damper: Damper;
-  const initial = 5;
-  const goal = 2;
-
-  setup(() => {
-    damper = new Damper();
-  });
-
-  test('converges to goal with large time step without overshoot', () => {
-    const final = damper.update(initial, goal, FIFTY_FRAME_DELTA, initial);
-    expect(final).to.be.eql(goal);
-  });
-
-  test('stays at initial value for negative time step', () => {
-    const final = damper.update(initial, goal, -1 * FIFTY_FRAME_DELTA, initial);
-    expect(final).to.be.eql(initial);
-  });
-});
 
 suite('SmoothControls', () => {
   let controls: SmoothControls;

--- a/packages/model-viewer/src/three-components/Damper.ts
+++ b/packages/model-viewer/src/three-components/Damper.ts
@@ -35,7 +35,7 @@ export class Damper {
   update(
       x: number, xGoal: number, timeStepMilliseconds: number,
       xNormalization: number): number {
-    if (x == null) {
+    if (x == null || xNormalization === 0) {
       return xGoal;
     }
     if (x === xGoal && this[$velocity] === 0) {
@@ -55,7 +55,7 @@ export class Damper {
         (intermediateVelocity - NATURAL_FREQUENCY * intermediateX) * decay;
     const acceleration =
         -NATURAL_FREQUENCY * (newVelocity + intermediateVelocity * decay);
-    if (Math.abs(newVelocity) < NIL_SPEED * xNormalization &&
+    if (Math.abs(newVelocity) < NIL_SPEED * Math.abs(xNormalization) &&
         acceleration * deltaX >= 0) {
       // This ensures the controls settle and stop calling this function instead
       // of asymptotically approaching their goal.


### PR DESCRIPTION
Fixes #1210

The issue is that with no `src`, the ideal camera distance is zero, which makes maximum radius zero, which is the normalization factor for the radius damper. That made it asymptotically approach zero forever because it was never close enough to stop. Fixed it by making the damper handle non-positive normalization values, which should be a general fix. I believe this problem could also have come up if someone set max-camera-orbit to zero or negative radius, but this'll handle those cases as well.