### PR TITLE
WebXR update

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -16,7 +16,7 @@
 import {property} from 'lit-element';
 
 import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
-import ModelViewerElementBase, {$container, $renderer, $scene} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$renderer, $scene} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
 import {Constructor, deserializeUrl} from '../utilities.js';
 
@@ -98,12 +98,12 @@ export type QuickLookBrowser = 'safari'|'chrome';
 const deserializeQuickLookBrowsers =
     enumerationDeserializer<QuickLookBrowser>(['safari', 'chrome']);
 
-export type ARMode = 'quick-look'|'scene-viewer'|'webxr'|'fallback'|'none';
+export type ARMode = 'quick-look'|'scene-viewer'|'webxr'|'none';
 
 const deserializeARModes = enumerationDeserializer<ARMode>(
-    ['quick-look', 'scene-viewer', 'webxr', 'fallback', 'none']);
+    ['quick-look', 'scene-viewer', 'webxr', 'none']);
 
-const DEFAULT_AR_MODES = 'scene-viewer quick-look fallback';
+const DEFAULT_AR_MODES = 'webxr scene-viewer quick-look';
 
 const ARMode: {[index: string]: ARMode} = {
   QUICK_LOOK: 'quick-look',
@@ -112,9 +112,9 @@ const ARMode: {[index: string]: ARMode} = {
   NONE: 'none'
 };
 
-const $exitFullscreenButtonContainer = Symbol('exitFullscreenButtonContainer');
+const $exitWebXRButtonContainer = Symbol('exitWebXRButtonContainer');
 const $arButtonContainer = Symbol('arButtonContainer');
-const $defaultExitFullscreenButton = Symbol('defaultExitFullscreenButton');
+const $defaultExitWebXRButton = Symbol('defaultExitWebXRButton');
 const $enterARWithWebXR = Symbol('enterARWithWebXR');
 const $canActivateAR = Symbol('canActivateAR');
 const $arMode = Symbol('arMode');
@@ -122,19 +122,12 @@ const $arModes = Symbol('arModes');
 const $canLaunchQuickLook = Symbol('canLaunchQuickLook');
 const $quickLookBrowsers = Symbol('quickLookBrowsers');
 
-const $arButtonContainerFallbackClickHandler =
-    Symbol('arButtonContainerFallbackClickHandler');
-const $onARButtonContainerFallbackClick =
-    Symbol('onARButtonContainerFallbackClick');
 const $arButtonContainerClickHandler = Symbol('arButtonContainerClickHandler');
 const $onARButtonContainerClick = Symbol('onARButtonContainerClick');
 
-const $exitFullscreenButtonContainerClickHandler =
-    Symbol('exitFullscreenButtonContainerClickHandler');
-const $onExitFullscreenButtonClick = Symbol('onExitFullscreenButtonClick');
-
-const $fullscreenchangeHandler = Symbol('fullscreenHandler');
-const $onFullscreenchange = Symbol('onFullscreen');
+const $exitWebXRButtonContainerClickHandler =
+    Symbol('exitWebXRButtonContainerClickHandler');
+const $onExitWebXR = Symbol('onExitWebXR');
 
 export declare interface ARInterface {
   ar: boolean;
@@ -174,31 +167,18 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
     protected[$arButtonContainer]: HTMLElement =
         this.shadowRoot!.querySelector('.ar-button') as HTMLElement;
 
-    protected[$exitFullscreenButtonContainer]: HTMLElement =
-        this.shadowRoot!.querySelector('.slot.exit-fullscreen-button') as
+    protected[$exitWebXRButtonContainer]: HTMLElement =
+        this.shadowRoot!.querySelector('.slot.exit-webxr-button') as
         HTMLElement;
-    protected[$defaultExitFullscreenButton]: HTMLElement =
-        this.shadowRoot!.querySelector('#default-exit-fullscreen-button') as
+    protected[$defaultExitWebXRButton]: HTMLElement =
+        this.shadowRoot!.querySelector('#default-exit-webxr-button') as
         HTMLElement;
-
-    // NOTE(cdata): We use a second, separate "fallback" click handler in
-    // order to work around a regression in how Chrome on Android behaves
-    // when requesting fullscreen at the same time as triggering an intent.
-    // As of m76, intents could no longer be triggered successfully if they
-    // were dispatched in the same handler as the fullscreen request. The
-    // workaround is to split both effects into their own event handlers.
-    // @see https://github.com/GoogleWebComponents/model-viewer/issues/693
-    protected[$arButtonContainerFallbackClickHandler] = (event: Event) =>
-        this[$onARButtonContainerFallbackClick](event);
 
     protected[$arButtonContainerClickHandler]: (event: Event) => void =
         (event) => this[$onARButtonContainerClick](event);
 
-    protected[$exitFullscreenButtonContainerClickHandler]:
-        () => void = () => this[$onExitFullscreenButtonClick]();
-
-    protected[$fullscreenchangeHandler]:
-        () => void = () => this[$onFullscreenchange]();
+    protected[$exitWebXRButtonContainerClickHandler]:
+        () => void = () => this[$onExitWebXR]();
 
     protected[$arModes]: Set<ARMode> = new Set();
     protected[$arMode]: ARMode = ARMode.NONE;
@@ -230,39 +210,10 @@ configuration or device capabilities');
       }
     }
 
-    connectedCallback() {
-      super.connectedCallback();
-      document.addEventListener(
-          'fullscreenchange', this[$fullscreenchangeHandler]);
-    }
-
-    disconnectedCallback() {
-      super.disconnectedCallback();
-      document.removeEventListener(
-          'fullscreenchange', this[$fullscreenchangeHandler]);
-    }
-
-    [$onExitFullscreenButtonClick]() {
-      if (document.fullscreenElement === this) {
-        document.exitFullscreen();
-      }
-    }
-
-    [$onFullscreenchange]() {
-      if (this[$arMode] !== ARMode.AR_VIEWER) {
-        return;
-      }
-      const scene = this[$scene];
-      const isFullscreen = document.fullscreenElement === this;
-
-      if (isFullscreen) {
-        this[$container].classList.add('fullscreen');
-      } else {
-        this[$container].classList.remove('fullscreen');
-      }
-
-      if (!isFullscreen && this[$renderer].presentedScene === scene) {
+    [$onExitWebXR]() {
+      if (this[$renderer].isPresenting) {
         try {
+          this[$exitWebXRButtonContainer].classList.remove('enabled');
           this[$renderer].stopPresenting();
         } catch (error) {
           console.warn('Unexpected error while stopping AR presentation');
@@ -275,10 +226,12 @@ configuration or device capabilities');
       console.log('Attempting to present in AR...');
 
       try {
+        this[$exitWebXRButtonContainer].classList.add('enabled');
         await this[$renderer].present(this[$scene]);
       } catch (error) {
         console.warn('Error while trying to present to AR');
         console.error(error);
+        this[$exitWebXRButtonContainer].classList.remove('enabled');
       }
     }
 
@@ -328,32 +281,16 @@ configuration or device capabilities');
 
       if (this.canActivateAR) {
         this[$arButtonContainer].classList.add('enabled');
-        // NOTE(cdata): The order of the two click handlers on the "ar
-        // button container" is important, vital to the workaround described
-        // earlier in this file. Reversing their order will cause our Scene
-        // Viewer integration to break.
-        // @see https://github.com/GoogleWebComponents/model-viewer/issues/693
         this[$arButtonContainer].addEventListener(
             'click', this[$arButtonContainerClickHandler]);
-        this[$arButtonContainer].addEventListener(
-            'click', this[$arButtonContainerFallbackClickHandler]);
-        this[$exitFullscreenButtonContainer].addEventListener(
-            'click', this[$exitFullscreenButtonContainerClickHandler]);
+        this[$exitWebXRButtonContainer].addEventListener(
+            'click', this[$exitWebXRButtonContainerClickHandler]);
       } else {
         this[$arButtonContainer].removeEventListener(
             'click', this[$arButtonContainerClickHandler]);
-        this[$arButtonContainer].removeEventListener(
-            'click', this[$arButtonContainerFallbackClickHandler]);
-        this[$exitFullscreenButtonContainer].removeEventListener(
-            'click', this[$exitFullscreenButtonContainerClickHandler]);
+        this[$exitWebXRButtonContainer].removeEventListener(
+            'click', this[$exitWebXRButtonContainerClickHandler]);
         this[$arButtonContainer].classList.remove('enabled');
-      }
-    }
-
-    [$onARButtonContainerFallbackClick](_event: Event) {
-      if (this[$arMode] === ARMode.SCENE_VIEWER &&
-          this[$arModes].has('fallback')) {
-        this.requestFullscreen();
       }
     }
 

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -112,9 +112,7 @@ const ARMode: {[index: string]: ARMode} = {
   NONE: 'none'
 };
 
-const $exitWebXRButtonContainer = Symbol('exitWebXRButtonContainer');
 const $arButtonContainer = Symbol('arButtonContainer');
-const $defaultExitWebXRButton = Symbol('defaultExitWebXRButton');
 const $enterARWithWebXR = Symbol('enterARWithWebXR');
 const $canActivateAR = Symbol('canActivateAR');
 const $arMode = Symbol('arMode');
@@ -125,8 +123,7 @@ const $quickLookBrowsers = Symbol('quickLookBrowsers');
 const $arButtonContainerClickHandler = Symbol('arButtonContainerClickHandler');
 const $onARButtonContainerClick = Symbol('onARButtonContainerClick');
 
-const $exitWebXRButtonContainerClickHandler =
-    Symbol('exitWebXRButtonContainerClickHandler');
+
 const $onExitWebXR = Symbol('onExitWebXR');
 
 export declare interface ARInterface {
@@ -167,18 +164,8 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
     protected[$arButtonContainer]: HTMLElement =
         this.shadowRoot!.querySelector('.ar-button') as HTMLElement;
 
-    protected[$exitWebXRButtonContainer]: HTMLElement =
-        this.shadowRoot!.querySelector('.slot.exit-webxr-button') as
-        HTMLElement;
-    protected[$defaultExitWebXRButton]: HTMLElement =
-        this.shadowRoot!.querySelector('#default-exit-webxr-button') as
-        HTMLElement;
-
     protected[$arButtonContainerClickHandler]: (event: Event) => void =
         (event) => this[$onARButtonContainerClick](event);
-
-    protected[$exitWebXRButtonContainerClickHandler]:
-        () => void = () => this[$onExitWebXR]();
 
     protected[$arModes]: Set<ARMode> = new Set();
     protected[$arMode]: ARMode = ARMode.NONE;
@@ -213,7 +200,6 @@ configuration or device capabilities');
     [$onExitWebXR]() {
       if (this[$renderer].isPresenting) {
         try {
-          this[$exitWebXRButtonContainer].classList.remove('enabled');
           this[$renderer].stopPresenting();
         } catch (error) {
           console.warn('Unexpected error while stopping AR presentation');
@@ -226,12 +212,10 @@ configuration or device capabilities');
       console.log('Attempting to present in AR...');
 
       try {
-        this[$exitWebXRButtonContainer].classList.add('enabled');
         await this[$renderer].present(this[$scene]);
       } catch (error) {
         console.warn('Error while trying to present to AR');
         console.error(error);
-        this[$exitWebXRButtonContainer].classList.remove('enabled');
       }
     }
 
@@ -283,13 +267,9 @@ configuration or device capabilities');
         this[$arButtonContainer].classList.add('enabled');
         this[$arButtonContainer].addEventListener(
             'click', this[$arButtonContainerClickHandler]);
-        this[$exitWebXRButtonContainer].addEventListener(
-            'click', this[$exitWebXRButtonContainerClickHandler]);
       } else {
         this[$arButtonContainer].removeEventListener(
             'click', this[$arButtonContainerClickHandler]);
-        this[$exitWebXRButtonContainer].removeEventListener(
-            'click', this[$exitWebXRButtonContainerClickHandler]);
         this[$arButtonContainer].classList.remove('enabled');
       }
     }

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -123,9 +123,6 @@ const $quickLookBrowsers = Symbol('quickLookBrowsers');
 const $arButtonContainerClickHandler = Symbol('arButtonContainerClickHandler');
 const $onARButtonContainerClick = Symbol('onARButtonContainerClick');
 
-
-const $onExitWebXR = Symbol('onExitWebXR');
-
 export declare interface ARInterface {
   ar: boolean;
   arModes: string;
@@ -194,17 +191,6 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
               'No AR Mode can be activated. This is probably due to missing \
 configuration or device capabilities');
           break;
-      }
-    }
-
-    [$onExitWebXR]() {
-      if (this[$renderer].isPresenting) {
-        try {
-          this[$renderer].stopPresenting();
-        } catch (error) {
-          console.warn('Unexpected error while stopping AR presentation');
-          console.error(error);
-        }
       }
     }
 

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -272,15 +272,15 @@ canvas.show {
   pointer-events: none;
 }
 
-.slot.exit-webxr-button {
+.slot.exit-webxr-ar-button {
   pointer-events: none;
 }
 
-.slot.exit-webxr-button:not(.enabled) {
+.slot.exit-webxr-ar-button:not(.enabled) {
   display: none;
 }
 
-#default-exit-webxr-button {
+#default-exit-webxr-ar-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -292,7 +292,7 @@ canvas.show {
   box-sizing: border-box;
 }
 
-#default-exit-webxr-button > svg {
+#default-exit-webxr-ar-button > svg {
   fill: #fff;
 }
 </style>
@@ -341,9 +341,9 @@ canvas.show {
   <div class="slot default">
     <slot></slot>
     
-    <div class="slot exit-webxr-button">
-      <slot name="exit-webxr-button">
-        <a id="default-exit-webxr-button"
+    <div class="slot exit-webxr-ar-button">
+      <slot name="exit-webxr-ar-button">
+        <a id="default-exit-webxr-ar-button"
             tabindex="3"
             aria-label="Exit fullscreen"
             aria-hidden="true">

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -239,8 +239,7 @@ canvas.show {
   display: var(--ar-button-display, block);
 }
 
-.slot.ar-button:not(.enabled),
-.fullscreen .slot.ar-button {
+.slot.ar-button:not(.enabled) {
   display: none;
 }
 
@@ -269,11 +268,19 @@ canvas.show {
   transform-origin: bottom right;
 }
 
-:not(.fullscreen) .slot.exit-fullscreen-button {
+.slot.default {
+  pointer-events: none;
+}
+
+.slot.exit-webxr-button {
+  pointer-events: none;
+}
+
+.slot.exit-webxr-button:not(.enabled) {
   display: none;
 }
 
-#default-exit-fullscreen-button {
+#default-exit-webxr-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -285,7 +292,7 @@ canvas.show {
   box-sizing: border-box;
 }
 
-#default-exit-fullscreen-button > svg {
+#default-exit-webxr-button > svg {
   fill: #fff;
 }
 </style>
@@ -323,17 +330,6 @@ canvas.show {
     </slot>
   </div>
 
-  <div class="slot exit-fullscreen-button">
-    <slot name="exit-fullscreen-button">
-      <a id="default-exit-fullscreen-button"
-          tabindex="3"
-          aria-label="Exit fullscreen"
-          aria-hidden="true">
-        ${CloseIcon}
-      </a>
-    </slot>
-  </div>
-
   <div class="slot interaction-prompt">
     <div class="animated-container" part="interaction-prompt">
       <slot name="interaction-prompt" aria-hidden="true">
@@ -344,6 +340,17 @@ canvas.show {
 
   <div class="slot default">
     <slot></slot>
+    
+    <div class="slot exit-webxr-button">
+      <slot name="exit-webxr-button">
+        <a id="default-exit-webxr-button"
+            tabindex="3"
+            aria-label="Exit fullscreen"
+            aria-hidden="true">
+          ${CloseIcon}
+        </a>
+      </slot>
+    </div>
   </div>
 </div>`;
 

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -316,12 +316,6 @@ export class ARRenderer extends EventDispatcher {
     session.removeEventListener('selectstart', this[$selectStartHandler]);
     session.removeEventListener('selectend', this[$selectEndHandler]);
 
-    const exitButton = this[$exitWebXRButtonContainer]!;
-    exitButton.classList.remove('enabled');
-    exitButton.removeEventListener(
-        'click', this[$exitWebXRButtonContainerClickHandler]);
-    this[$exitWebXRButtonContainer] = null;
-
     this[$currentSession] = null;
     session.cancelAnimationFrame(this[$rafId]!);
 
@@ -340,6 +334,14 @@ export class ARRenderer extends EventDispatcher {
       model.orientHotspots(0);
       element.requestUpdate('cameraTarget');
       element[$onResize](element.getBoundingClientRect());
+    }
+
+    const exitButton = this[$exitWebXRButtonContainer];
+    if (exitButton != null) {
+      exitButton.classList.remove('enabled');
+      exitButton.removeEventListener(
+          'click', this[$exitWebXRButtonContainerClickHandler]);
+      this[$exitWebXRButtonContainer] = null;
     }
 
     const hitSource = this[$transientHitTestSource];

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -189,7 +189,7 @@ export class ARRenderer extends EventDispatcher {
     this.threeRenderer.setSize(framebufferWidth, framebufferHeight, false);
 
     const exitButton = scene.element.shadowRoot!.querySelector(
-                           '.slot.exit-webxr-button') as HTMLElement;
+                           '.slot.exit-webxr-ar-button') as HTMLElement;
     exitButton.classList.add('enabled');
     exitButton.addEventListener(
         'click', this[$exitWebXRButtonContainerClickHandler]);

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -279,14 +279,7 @@ export class ARRenderer extends EventDispatcher {
     });
 
     try {
-      const session = this[$currentSession]!;
-      session.removeEventListener('selectstart', this[$selectStartHandler]);
-      session.removeEventListener('selectend', this[$selectEndHandler]);
-
-      this[$currentSession] = null;
-      session.cancelAnimationFrame(this[$rafId]!);
-
-      await session.end();
+      await this[$currentSession]!.end();
       await cleanupPromise;
     } catch (error) {
       console.warn('Error while trying to end AR session');
@@ -301,6 +294,17 @@ export class ARRenderer extends EventDispatcher {
     // back to the default framebuffer for canvas output.
     // TODO: this method should be added to three.js's exported interface.
     (this.threeRenderer as any).setFramebuffer(null);
+    const hitSource = this[$transientHitTestSource];
+    if (hitSource != null) {
+      hitSource.cancel();
+    }
+
+    const session = this[$currentSession]!;
+    session.removeEventListener('selectstart', this[$selectStartHandler]);
+    session.removeEventListener('selectend', this[$selectEndHandler]);
+
+    this[$currentSession] = null;
+    session.cancelAnimationFrame(this[$rafId]!);
 
     const scene = this[$presentedScene];
     if (scene != null) {


### PR DESCRIPTION
Fixes #519 
Fixes #1098 

This adds the X exit button to the top-left of webXR; it takes the place of the exit fullscreen button as I've also removed the fullscreen fallback, which was broken anyway. It also switches webxr to the default ar experience. There is also some cleanup of vestigial codepaths and more complete post-session state reset.

A breaking change (though it was never documented) is that the `exit-fullscreen-button` slot is now the `exit-webxr-button` slot.