### PR TITLE
Add getters for FOV limits

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -363,6 +363,14 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       return this[$controls].getFieldOfView();
     }
 
+    getMinimumFieldOfView(): number {
+      return this[$controls].options.minimumFieldOfView;
+    }
+
+    getMaximumFieldOfView(): number {
+      return this[$controls].options.maximumFieldOfView;
+    }
+
     jumpCameraToGoal() {
       this[$jumpCamera] = true;
       this.requestUpdate($jumpCamera, false);

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -373,10 +373,11 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
             }
           });
 
-          test('respects user-configured maxFieldOfView', async () => {
+          test('respects user-configured min/maxFieldOfView', async () => {
             document.body.insertBefore(
                 initiallyUnloadedElement, document.body.firstChild);
 
+            initiallyUnloadedElement.minFieldOfView = '90deg';
             initiallyUnloadedElement.maxFieldOfView = '100deg';
             initiallyUnloadedElement.src = ASTRONAUT_GLB_PATH;
 
@@ -388,6 +389,12 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
             settleControls(controls);
 
             expect(initiallyUnloadedElement.getFieldOfView())
+                .to.be.closeTo(100, 0.001);
+
+            expect(initiallyUnloadedElement.getMinimumFieldOfView())
+                .to.be.closeTo(90, 0.001);
+
+            expect(initiallyUnloadedElement.getMaximumFieldOfView())
                 .to.be.closeTo(100, 0.001);
           });
         });

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -707,7 +707,7 @@ export class SmoothControls extends EventDispatcher {
   }
 
   /** Returns a copy of the current options */
-  get options() : SmoothControlsOptions {
+  get options(): SmoothControlsOptions {
     return {...this[$options]};
   }
 }

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -705,4 +705,9 @@ export class SmoothControls extends EventDispatcher {
       event.preventDefault();
     }
   }
+
+  /** Returns a copy of the current options */
+  get options() : SmoothControlsOptions {
+    return {...this[$options]};
+  }
 }


### PR DESCRIPTION
It may be useful to know the current FOV limits so user code can change them sensibly. And, to do this without needing to parse the attributes (duplicating work).