### PR TITLE
Add getters for FOV limits

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -363,6 +363,14 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       return this[$controls].getFieldOfView();
     }
 
+    getMinimumFieldOfView(): number {
+      return this[$controls].options.minimumFieldOfView;
+    }
+
+    getMaximumFieldOfView(): number {
+      return this[$controls].options.maximumFieldOfView;
+    }
+
     jumpCameraToGoal() {
       this[$jumpCamera] = true;
       this.requestUpdate($jumpCamera, false);

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -367,19 +367,11 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     // Provided so user code does not have to parse these from attributes.
     getMinimumFieldOfView(): number {
-      const value = this[$controls].options.minimumFieldOfView;
-      if(value === undefined) {
-        throw new Error('minimumFieldOfView was undefined');
-      }
-      return value;
+      return this[$controls].options.minimumFieldOfView!;
     }
 
     getMaximumFieldOfView(): number {
-      const value = this[$controls].options.maximumFieldOfView;
-      if(value === undefined) {
-        throw new Error('maximumFieldOfView was undefined');
-      }
-      return value;
+      return this[$controls].options.maximumFieldOfView!;
     }
 
     jumpCameraToGoal() {

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -240,8 +240,8 @@ export declare interface ControlsInterface {
   getCameraOrbit(): SphericalPosition;
   getCameraTarget(): Vector3D;
   getFieldOfView(): number;
-  getMinimumFieldOfView(): number|undefined;
-  getMaximumFieldOfView(): number|undefined;
+  getMinimumFieldOfView(): number;
+  getMaximumFieldOfView(): number;
   jumpCameraToGoal(): void;
   resetInteractionPrompt(): void;
 }
@@ -366,12 +366,20 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     // Provided so user code does not have to parse these from attributes.
-    getMinimumFieldOfView(): number|undefined {
-      return this[$controls].options.minimumFieldOfView;
+    getMinimumFieldOfView(): number {
+      const value = this[$controls].options.minimumFieldOfView;
+      if(value === undefined) {
+        throw new Error('minimumFieldOfView was undefined');
+      }
+      return value;
     }
 
-    getMaximumFieldOfView(): number|undefined {
-      return this[$controls].options.maximumFieldOfView;
+    getMaximumFieldOfView(): number {
+      const value = this[$controls].options.maximumFieldOfView;
+      if(value === undefined) {
+        throw new Error('maximumFieldOfView was undefined');
+      }
+      return value;
     }
 
     jumpCameraToGoal() {

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -365,6 +365,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       return this[$controls].getFieldOfView();
     }
 
+    // Provided so user code does not have to parse these from attributes.
     getMinimumFieldOfView(): number|undefined {
       return this[$controls].options.minimumFieldOfView;
     }

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -373,10 +373,11 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
             }
           });
 
-          test('respects user-configured maxFieldOfView', async () => {
+          test('respects user-configured min/maxFieldOfView', async () => {
             document.body.insertBefore(
                 initiallyUnloadedElement, document.body.firstChild);
 
+            initiallyUnloadedElement.minFieldOfView = '90deg';
             initiallyUnloadedElement.maxFieldOfView = '100deg';
             initiallyUnloadedElement.src = ASTRONAUT_GLB_PATH;
 
@@ -388,6 +389,12 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
             settleControls(controls);
 
             expect(initiallyUnloadedElement.getFieldOfView())
+                .to.be.closeTo(100, 0.001);
+
+            expect(initiallyUnloadedElement.getMinimumFieldOfView())
+                .to.be.closeTo(90, 0.001);
+
+            expect(initiallyUnloadedElement.getMaximumFieldOfView())
                 .to.be.closeTo(100, 0.001);
           });
         });

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -27,6 +27,8 @@ import {settleControls} from '../three-components/SmoothControls-spec.js';
 
 const expect = chai.expect;
 const DEFAULT_FOV = 45;
+const DEFAULT_MIN_FOV = 10;
+const DEFAULT_MAX_FOV = 45;
 const ASTRONAUT_GLB_PATH = assetPath('models/Astronaut.glb');
 
 const interactWith = (element: HTMLElement) => {
@@ -221,6 +223,11 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
       test('defaults FOV correctly', async () => {
         expect(element.getFieldOfView()).to.be.closeTo(DEFAULT_FOV, 0.00001);
+      });
+
+      test('defaults FOV limits correctly', async () => {
+        expect(element.getMinimumFieldOfView()).to.be.closeTo(DEFAULT_MIN_FOV, 0.00001);
+        expect(element.getMaximumFieldOfView()).to.be.closeTo(DEFAULT_MAX_FOV, 0.00001);
       });
 
       test('can independently adjust FOV', async () => {

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -27,7 +27,7 @@ import {settleControls} from '../three-components/SmoothControls-spec.js';
 
 const expect = chai.expect;
 const DEFAULT_FOV = 45;
-const DEFAULT_MIN_FOV = 10;
+const DEFAULT_MIN_FOV = 25;
 const DEFAULT_MAX_FOV = 45;
 const ASTRONAUT_GLB_PATH = assetPath('models/Astronaut.glb');
 

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -707,7 +707,7 @@ export class SmoothControls extends EventDispatcher {
   }
 
   /** Returns a copy of the current options */
-  get options() : SmoothControlsOptions {
+  get options(): SmoothControlsOptions {
     return {...this[$options]};
   }
 }

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -705,4 +705,9 @@ export class SmoothControls extends EventDispatcher {
       event.preventDefault();
     }
   }
+
+  /** Returns a copy of the current options */
+  get options() : SmoothControlsOptions {
+    return {...this[$options]};
+  }
 }


### PR DESCRIPTION
It may be useful to know the current FOV limits so user code can change them sensibly. And, to do this without needing to parse the attributes (duplicating work).