### PR TITLE
Dynamic render scaling

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy_github_pages:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/fidelity-tests.yml
+++ b/.github/workflows/fidelity-tests.yml
@@ -5,6 +5,7 @@ on: [pull_request]
 jobs:
   compare_renders:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/unit-tests-third-party.yml
+++ b/.github/workflows/unit-tests-third-party.yml
@@ -5,6 +5,7 @@ on: [pull_request]
 jobs:
   minimal_test_run:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,7 @@ jobs:
       USE_BROWSER_STACK: true
 
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v1

--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -42,8 +42,11 @@ export const IS_MOBILE = (() => {
   return check;
 })();
 
-export const USE_OFFSCREEN_CANVAS = Boolean((self as any).OffscreenCanvas) &&
-    Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap);
+// Disabling offscreen canvas for now because it is slower and has bugs relating
+// to janky updates and out of sync frames.
+export const USE_OFFSCREEN_CANVAS = false;
+// Boolean((self as any).OffscreenCanvas) &&
+//     Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap);
 
 export const IS_ANDROID = /android/i.test(navigator.userAgent);
 

--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -42,8 +42,9 @@ export const IS_MOBILE = (() => {
   return check;
 })();
 
-export const USE_OFFSCREEN_CANVAS = Boolean((self as any).OffscreenCanvas) &&
-    Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap);
+export const USE_OFFSCREEN_CANVAS = false;
+// Boolean((self as any).OffscreenCanvas) &&
+//     Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap);
 
 export const IS_ANDROID = /android/i.test(navigator.userAgent);
 

--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -42,9 +42,8 @@ export const IS_MOBILE = (() => {
   return check;
 })();
 
-export const USE_OFFSCREEN_CANVAS = false;
-// Boolean((self as any).OffscreenCanvas) &&
-//     Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap);
+export const USE_OFFSCREEN_CANVAS = Boolean((self as any).OffscreenCanvas) &&
+    Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap);
 
 export const IS_ANDROID = /android/i.test(navigator.userAgent);
 

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -546,7 +546,6 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         this[$controls].adjustOrbit(deltaTheta, 0, 0);
 
         this[$lastPromptOffset] = offset;
-        this[$needsRender]();
       }
 
       this[$controls].update(time, delta);

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -544,13 +544,14 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         const offset = wiggle(animationTime);
         const opacity = fade(animationTime);
 
+        this[$promptAnimatedContainer].style.opacity = `${opacity}`;
+
         if (offset !== this[$lastPromptOffset]) {
           const xOffset = offset * scene.width * 0.05;
           const deltaTheta = (offset - this[$lastPromptOffset]) * Math.PI / 16;
 
           this[$promptAnimatedContainer].style.transform =
               `translateX(${xOffset}px)`;
-          this[$promptAnimatedContainer].style.opacity = `${opacity}`;
 
           this[$controls].adjustOrbit(deltaTheta, 0, 0);
 

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -544,20 +544,18 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         const offset = wiggle(animationTime);
         const opacity = fade(animationTime);
 
-        const xOffset = offset * scene.width * 0.05;
-        const deltaTheta = (offset - this[$lastPromptOffset]) * Math.PI / 16;
+        if (offset !== this[$lastPromptOffset]) {
+          const xOffset = offset * scene.width * 0.05;
+          const deltaTheta = (offset - this[$lastPromptOffset]) * Math.PI / 16;
 
-        if (deltaTheta === 0) {
-          return;
+          this[$promptAnimatedContainer].style.transform =
+              `translateX(${xOffset}px)`;
+          this[$promptAnimatedContainer].style.opacity = `${opacity}`;
+
+          this[$controls].adjustOrbit(deltaTheta, 0, 0);
+
+          this[$lastPromptOffset] = offset;
         }
-
-        this[$promptAnimatedContainer].style.transform =
-            `translateX(${xOffset}px)`;
-        this[$promptAnimatedContainer].style.opacity = `${opacity}`;
-
-        this[$controls].adjustOrbit(deltaTheta, 0, 0);
-
-        this[$lastPromptOffset] = offset;
       }
 
       this[$controls].update(time, delta);

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -535,6 +535,10 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         const xOffset = offset * scene.width * 0.05;
         const deltaTheta = (offset - this[$lastPromptOffset]) * Math.PI / 16;
 
+        if (deltaTheta === 0) {
+          return;
+        }
+
         this[$promptAnimatedContainer].style.transform =
             `translateX(${xOffset}px)`;
         this[$promptAnimatedContainer].style.opacity = `${opacity}`;

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -272,7 +272,12 @@ export default class ModelViewerElementBase extends UpdatingElement {
         }
       }, {
         root: null,
-        rootMargin: '10px',
+        // We used to have margin here, but it was causing animated models below
+        // the fold to steal the frame budget. Weirder still, it would also
+        // cause input events to be swallowed, sometimes for seconds on the
+        // model above the fold, but only when the animated model was completely
+        // below. Setting this margin to zero fixed it.
+        rootMargin: '0px',
         threshold: 0,
       });
     } else {

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -120,11 +120,11 @@ export default class ModelViewerElementBase extends UpdatingElement {
   static set minimumRenderScale(value: number) {
     if (value > 1) {
       console.warn(
-          '<model-vewer> minimumRenderScale has been clamped to a maximum value of 1.');
+          '<model-viewer> minimumRenderScale has been clamped to a maximum value of 1.');
     }
     if (value <= 0) {
       console.warn(
-          '<model-vewer> minimumRenderScale has been clamped to a minimum value of 0. This could result in single-pixel renders on some devices; consider increasing.');
+          '<model-viewer> minimumRenderScale has been clamped to a minimum value of 0. This could result in single-pixel renders on some devices; consider increasing.');
     }
     Renderer.singleton.minScale = Math.max(0, Math.min(1, value));
   }

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -120,11 +120,11 @@ export default class ModelViewerElementBase extends UpdatingElement {
   static set minimumRenderScale(value: number) {
     if (value > 1) {
       console.warn(
-          'minimumRenderScale has been clamped to a maximum value of 1.');
+          '<model-vewer> minimumRenderScale has been clamped to a maximum value of 1.');
     }
     if (value <= 0) {
       console.warn(
-          'minimumRenderScale has been clamped to a minimum value of 0. This could result in single-pixel renders on some devices; consider increasing.');
+          '<model-vewer> minimumRenderScale has been clamped to a minimum value of 0. This could result in single-pixel renders on some devices; consider increasing.');
     }
     Renderer.singleton.minScale = Math.max(0, Math.min(1, value));
   }

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -116,6 +116,24 @@ export default class ModelViewerElementBase extends UpdatingElement {
     return CachingGLTFLoader[$evictionPolicy].evictionThreshold
   }
 
+  /** @export */
+  static set minimumRenderScale(value: number) {
+    if (value > 1) {
+      console.warn(
+          'minimumRenderScale has been clamped to a maximum value of 1.');
+    }
+    if (value <= 0) {
+      console.warn(
+          'minimumRenderScale has been clamped to a minimum value of 0. This could result in single-pixel renders on some devices; consider increasing.');
+    }
+    Renderer.singleton.minScale = Math.max(0, Math.min(1, value));
+  }
+
+  /** @export */
+  static get minimumRenderScale(): number {
+    return Renderer.singleton.minScale;
+  }
+
   @property({type: String}) alt: string|null = null;
 
   @property({type: String}) src: string|null = null;

--- a/packages/model-viewer/src/test/three-components/Renderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/Renderer-spec.ts
@@ -77,6 +77,7 @@ suite('Renderer', () => {
 
   teardown(() => {
     renderer.unregisterScene(scene);
+    renderer.render(performance.now());
   });
 
   suite('render', () => {
@@ -88,6 +89,7 @@ suite('Renderer', () => {
 
     teardown(() => {
       renderer.unregisterScene(otherScene);
+      renderer.render(performance.now());
     });
 
     test('renders only dirty scenes', async function() {
@@ -130,21 +132,21 @@ suite('Renderer', () => {
     });
 
     test('uses the proper canvas when unregsitering scenes', function() {
-      expect(renderer.canvasElement.parentElement).to.be.not.ok;
+      renderer.render(performance.now());
+
+      expect(renderer.canvasElement.classList.contains('show')).to.be.eq(false);
       expect(scene.element[$canvas].classList.contains('show')).to.be.eq(true);
       expect(otherScene.element[$canvas].classList.contains('show'))
           .to.be.eq(true);
 
       renderer.unregisterScene(scene);
+      renderer.render(performance.now());
 
       expect(renderer.canvasElement.parentElement)
           .to.be.eq(otherScene.element[$userInputElement]);
+      expect(renderer.canvasElement.classList.contains('show')).to.be.eq(true);
       expect(otherScene.element[$canvas].classList.contains('show'))
           .to.be.eq(false);
-
-      renderer.unregisterScene(otherScene);
-
-      expect(renderer.canvasElement.parentElement).to.be.not.ok;
     });
 
     suite('when resizing', () => {

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -60,7 +60,8 @@ export class ModelScene extends Scene {
   public shadowSoftness = 1;
   public width = 1;
   public height = 1;
-  public isDirty: boolean = false;
+  public isDirty = false;
+  public hasRendered = true;
   public element: ModelViewerElementBase;
   public context: CanvasRenderingContext2D|ImageBitmapRenderingContext|null =
       null;
@@ -135,6 +136,7 @@ export class ModelScene extends Scene {
       source: string|null, progressCallback?: (progress: number) => void) {
     try {
       await this.model.setSource(source, progressCallback);
+      this.hasRendered = false;
     } catch (e) {
       throw new Error(
           `Could not set model source to '${source}': ${e.message}`);

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -36,9 +36,9 @@ export interface ContextLostEvent extends Event {
 
 // Between 0 and 1: larger means the average responds faster and is less smooth.
 const DURATION_DECAY = 0.2;
-const LOW_FRAME_DURATION = 18;   // ms
-const HIGH_FRAME_DURATION = 26;  // ms
-const MAX_AVG_CHANGE = 2;        // ms
+const LOW_FRAME_DURATION_MS = 18;
+const HIGH_FRAME_DURATION_MS = 26;
+const MAX_AVG_CHANGE_MS = 2;
 const SCALE_STEP = 0.79;
 const DEFAULT_MIN_SCALE = 0.5;
 
@@ -87,7 +87,8 @@ export class Renderer extends EventDispatcher {
   private width = 0;
   private height = 0;
   private scale = 1;
-  private avgFrameDuration = (HIGH_FRAME_DURATION + LOW_FRAME_DURATION) / 2;
+  private avgFrameDuration =
+      (HIGH_FRAME_DURATION_MS + LOW_FRAME_DURATION_MS) / 2;
 
   private[$webGLContextLostHandler] = (event: WebGLContextEvent) =>
       this[$onWebGLContextLost](event);
@@ -102,7 +103,7 @@ export class Renderer extends EventDispatcher {
     const webGlOptions = {
       alpha: true,
       antialias: true,
-      powerPreference: 'low-power' as WebGLPowerPreference
+      powerPreference: 'high-performance' as WebGLPowerPreference
     };
 
     this.dpr = resolveDpr();
@@ -217,9 +218,10 @@ export class Renderer extends EventDispatcher {
 
   private updateRendererScale() {
     let {scale} = this;
-    if (this.avgFrameDuration > HIGH_FRAME_DURATION && scale > this.minScale) {
+    if (this.avgFrameDuration > HIGH_FRAME_DURATION_MS &&
+        scale > this.minScale) {
       scale *= SCALE_STEP;
-    } else if (this.avgFrameDuration < LOW_FRAME_DURATION && scale < 1) {
+    } else if (this.avgFrameDuration < LOW_FRAME_DURATION_MS && scale < 1) {
       scale /= SCALE_STEP;
       scale = Math.min(scale, 1);
     }
@@ -229,7 +231,8 @@ export class Renderer extends EventDispatcher {
       return;
     }
     this.scale = scale;
-    this.avgFrameDuration = (HIGH_FRAME_DURATION + LOW_FRAME_DURATION) / 2;
+    this.avgFrameDuration =
+        (HIGH_FRAME_DURATION_MS + LOW_FRAME_DURATION_MS) / 2;
 
     const width = this.width / scale;
     const height = this.height / scale;
@@ -242,7 +245,6 @@ export class Renderer extends EventDispatcher {
       style.height = `${height}px`;
       scene.isDirty = true;
     }
-    console.log('scale = ', this.scale);
   }
 
   registerScene(scene: ModelScene) {
@@ -361,8 +363,8 @@ export class Renderer extends EventDispatcher {
 
     this.avgFrameDuration += clamp(
         DURATION_DECAY * (delta - this.avgFrameDuration),
-        -MAX_AVG_CHANGE,
-        MAX_AVG_CHANGE);
+        -MAX_AVG_CHANGE_MS,
+        MAX_AVG_CHANGE_MS);
 
     this.selectCanvas();
     this.updateRendererSize();

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -40,7 +40,7 @@ const LOW_FRAME_DURATION = 18;   // ms
 const HIGH_FRAME_DURATION = 26;  // ms
 const MAX_AVG_CHANGE = 2;        // ms
 const SCALE_STEP = 0.79;
-const MIN_SCALE = 0.5;
+const DEFAULT_MIN_SCALE = 0.5;
 
 export const $arRenderer = Symbol('arRenderer');
 
@@ -78,6 +78,7 @@ export class Renderer extends EventDispatcher {
   public textureUtils: TextureUtils|null;
   public arRenderer: ARRenderer;
   public dpr = 1;
+  public minScale = DEFAULT_MIN_SCALE;
 
   protected debugger: Debugger|null = null;
   private scenes: Set<ModelScene> = new Set();
@@ -216,13 +217,13 @@ export class Renderer extends EventDispatcher {
 
   private updateRendererScale() {
     let {scale} = this;
-    if (this.avgFrameDuration > HIGH_FRAME_DURATION && scale > MIN_SCALE) {
+    if (this.avgFrameDuration > HIGH_FRAME_DURATION && scale > this.minScale) {
       scale *= SCALE_STEP;
-      scale = Math.max(scale, MIN_SCALE);
     } else if (this.avgFrameDuration < LOW_FRAME_DURATION && scale < 1) {
       scale /= SCALE_STEP;
       scale = Math.min(scale, 1);
     }
+    scale = Math.max(scale, this.minScale);
 
     if (scale == this.scale) {
       return;

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -472,6 +472,12 @@
               loaded from a Google CDN.</p>
             </li>
             <li>
+              <div>ModelViewer.minimumRenderScale</div>
+              <p>This static, writable property sets &lt;model-viewer&gt;'s minimum rendering 
+              scale factor as it dynamically changes resolution to maintain framerate. Turn 
+              off this effect by setting to 1. Defaults to 0.5.</p>
+            </li>
+            <li>
               <div>ModelViewer.modelCacheSize</div>
               <p>This static, writable property sets &lt;model-viewer&gt;'s internal
               glTF model cache size, controlling number of individual models that should
@@ -480,7 +486,7 @@
               if they are not being used by a &lt;model-viewer&gt; element in the document.
               Note also that the cache size is measured in number of glTF models, not bytes!
               This is important to keep in mind, since any two models may have wildly
-              different byte sizes.</p>
+              different byte sizes. Default is 5.</p>
             </li>
           </ul>
 


### PR DESCRIPTION
Fixes #1220 
Fixes #261

This is a major performance improvement, where we now detect dropped frames and scale down the rendering appropriately to maintain framerate. This also includes an additional performance improvement for firefox, where we use the fast, no-copy render path when there is only a single model visible in the viewport, rather than on the page in its entirety. I also found that we were needlessly rendering during the motionless part of the interaction prompt, so that's also fixed. Finally, we now render a first frame when the model loads even if it's not visible to fix #1220, since that seems like desired default behavior. 