### PR TITLE
AR status event and attribute

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -179,6 +179,11 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     private[$onARStatus] = ({status}: ThreeEvent) => {
       if (this[$renderer].arRenderer.presentedScene === this[$scene]) {
+        if (status === ARStatus.SESSION_ENDED) {
+          this.setAttribute('ar-status', 'not-presenting');
+        } else {
+          this.setAttribute('ar-status', status);
+        }
         this.dispatchEvent(
             new CustomEvent<ARStatusDetails>('ar-status', {detail: {status}}));
       }
@@ -224,6 +229,7 @@ configuration or device capabilities');
       super.connectedCallback();
 
       this[$renderer].arRenderer.addEventListener('status', this[$onARStatus]);
+      this.setAttribute('ar-status', 'not-presenting');
     }
 
     disconnectedCallback() {

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -178,12 +178,12 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
     };
 
     private[$onARStatus] = ({status}: ThreeEvent) => {
-      if (this[$renderer].arRenderer.presentedScene === this[$scene]) {
-        if (status === ARStatus.SESSION_ENDED) {
-          this.setAttribute('ar-status', 'not-presenting');
-        } else {
-          this.setAttribute('ar-status', status);
-        }
+      if (status === ARStatus.SESSION_ENDED) {
+        this.setAttribute('ar-status', 'not-presenting');
+        this.dispatchEvent(
+            new CustomEvent<ARStatusDetails>('ar-status', {detail: {status}}));
+      } else if (this[$renderer].arRenderer.presentedScene === this[$scene]) {
+        this.setAttribute('ar-status', status);
         this.dispatchEvent(
             new CustomEvent<ARStatusDetails>('ar-status', {detail: {status}}));
       }

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -178,11 +178,8 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
     };
 
     private[$onARStatus] = ({status}: ThreeEvent) => {
-      if (status === ARStatus.SESSION_ENDED) {
-        this.setAttribute('ar-status', 'not-presenting');
-        this.dispatchEvent(
-            new CustomEvent<ARStatusDetails>('ar-status', {detail: {status}}));
-      } else if (this[$renderer].arRenderer.presentedScene === this[$scene]) {
+      if (status === ARStatus.NOT_PRESENTING ||
+          this[$renderer].arRenderer.presentedScene === this[$scene]) {
         this.setAttribute('ar-status', status);
         this.dispatchEvent(
             new CustomEvent<ARStatusDetails>('ar-status', {detail: {status}}));
@@ -229,7 +226,7 @@ configuration or device capabilities');
       super.connectedCallback();
 
       this[$renderer].arRenderer.addEventListener('status', this[$onARStatus]);
-      this.setAttribute('ar-status', 'not-presenting');
+      this.setAttribute('ar-status', ARStatus.NOT_PRESENTING);
     }
 
     disconnectedCallback() {

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -348,6 +348,9 @@ export class ARRenderer extends EventDispatcher {
       element[$onResize](element.getBoundingClientRect());
     }
 
+    // Force the Renderer to update its size
+    this.renderer.height = 0;
+
     const exitButton = this[$exitWebXRButtonContainer];
     if (exitButton != null) {
       exitButton.classList.remove('enabled');

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -15,7 +15,7 @@
 
 import '../types/webxr.js';
 
-import {EventDispatcher, Matrix4, PerspectiveCamera, Ray, Vector3, WebGLRenderer} from 'three';
+import {Event as ThreeEvent, EventDispatcher, Matrix4, PerspectiveCamera, Ray, Vector3, WebGLRenderer} from 'three';
 
 import {$onResize} from '../model-viewer-base.js';
 import {assertIsArCandidate} from '../utilities.js';
@@ -40,6 +40,20 @@ const HIT_ANGLE_DEG = 20;
 const INTRO_DAMPER_RATE = 0.4;
 const SCALE_SNAP_HIGH = 1.2;
 const SCALE_SNAP_LOW = 1 / SCALE_SNAP_HIGH;
+
+export type ARStatus =
+    'session-started'|'session-ended'|'object-visible'|'object-placed';
+
+export const ARStatus: {[index: string]: ARStatus} = {
+  SESSION_STARTED: 'session-started',
+  SESSION_ENDED: 'session-ended',
+  OBJECT_VISIBLE: 'object-visible',
+  OBJECT_PLACED: 'object-placed'
+};
+
+export interface ARStatusEvent extends ThreeEvent {
+  status: ARStatus,
+}
 
 const $presentedScene = Symbol('presentedScene');
 const $placementBox = Symbol('placementBox');
@@ -230,6 +244,8 @@ export class ARRenderer extends EventDispatcher {
     // Render a frame to turn off the hotspots
     await waitForAnimationFrame;
 
+    this.dispatchEvent({type: 'status', status: ARStatus.SESSION_STARTED});
+
     // This sets isPresenting to true
     this[$presentedScene] = scene;
 
@@ -371,6 +387,8 @@ export class ARRenderer extends EventDispatcher {
     if (this[$resolveCleanup] != null) {
       this[$resolveCleanup]!();
     }
+
+    this.dispatchEvent({type: 'status', status: ARStatus.SESSION_ENDED});
   }
 
   /**
@@ -428,6 +446,8 @@ export class ARRenderer extends EventDispatcher {
       this[$initialModelToWorld].copy(scene.model.matrixWorld);
       scene.model.setHotspotsVisibility(true);
       this[$initialized] = true;
+
+      this.dispatchEvent({type: 'status', status: ARStatus.OBJECT_VISIBLE});
     }
 
     this[$presentedScene]!.model.orientHotspots(
@@ -534,7 +554,7 @@ export class ARRenderer extends EventDispatcher {
     // Ignore the y-coordinate and set on the floor instead.
     goal.y = floor;
 
-    this.dispatchEvent({type: 'modelmove'});
+    this.dispatchEvent({type: 'status', status: ARStatus.OBJECT_PLACED});
   }
 
   [$onSelectStart] = (event: Event) => {

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -41,13 +41,11 @@ const INTRO_DAMPER_RATE = 0.4;
 const SCALE_SNAP_HIGH = 1.2;
 const SCALE_SNAP_LOW = 1 / SCALE_SNAP_HIGH;
 
-export type ARStatus =
-    'session-started'|'session-ended'|'object-visible'|'object-placed';
+export type ARStatus = 'not-presenting'|'session-started'|'object-placed';
 
 export const ARStatus: {[index: string]: ARStatus} = {
+  NOT_PRESENTING: 'not-presenting',
   SESSION_STARTED: 'session-started',
-  SESSION_ENDED: 'session-ended',
-  OBJECT_VISIBLE: 'object-visible',
   OBJECT_PLACED: 'object-placed'
 };
 
@@ -244,8 +242,6 @@ export class ARRenderer extends EventDispatcher {
     // Render a frame to turn off the hotspots
     await waitForAnimationFrame;
 
-    this.dispatchEvent({type: 'status', status: ARStatus.SESSION_STARTED});
-
     // This sets isPresenting to true
     this[$presentedScene] = scene;
 
@@ -391,7 +387,7 @@ export class ARRenderer extends EventDispatcher {
       this[$resolveCleanup]!();
     }
 
-    this.dispatchEvent({type: 'status', status: ARStatus.SESSION_ENDED});
+    this.dispatchEvent({type: 'status', status: ARStatus.NOT_PRESENTING});
   }
 
   /**
@@ -449,8 +445,7 @@ export class ARRenderer extends EventDispatcher {
       this[$initialModelToWorld].copy(scene.model.matrixWorld);
       scene.model.setHotspotsVisibility(true);
       this[$initialized] = true;
-
-      this.dispatchEvent({type: 'status', status: ARStatus.OBJECT_VISIBLE});
+      this.dispatchEvent({type: 'status', status: ARStatus.SESSION_STARTED});
     }
 
     this[$presentedScene]!.model.orientHotspots(

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -77,6 +77,8 @@ export class Renderer extends EventDispatcher {
   public canvas3D: HTMLCanvasElement|OffscreenCanvas;
   public textureUtils: TextureUtils|null;
   public arRenderer: ARRenderer;
+  public width = 0;
+  public height = 0;
   public dpr = 1;
   public minScale = DEFAULT_MIN_SCALE;
 
@@ -84,8 +86,6 @@ export class Renderer extends EventDispatcher {
   private scenes: Set<ModelScene> = new Set();
   private multipleScenesVisible = false;
   private lastTick: number;
-  private width = 0;
-  private height = 0;
   private scale = 1;
   private avgFrameDuration =
       (HIGH_FRAME_DURATION_MS + LOW_FRAME_DURATION_MS) / 2;

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -394,6 +394,16 @@
               to force the button to be hidden. Defaults to block.</p>
             </li>
             <li>
+              <div>ar-status</div>
+              <p>This read-only attribute enables DOM content to be styled based 
+              on the status of the WebXR AR presentation. Possible values include 
+              'not-presenting', 'session-started', and 'object-placed'. For instance, 
+              a prompt for the user to move their phone until the object is 
+              successfully placed in their space can be shown by scoping a CSS rule
+              to model-viewer[ar-status="session-started"]. Setting this attribute
+              has no effect.</p>
+            </li>
+            <li>
               <div>--interaction-prompt-display</div>
               <p>Sets the display property of the interaction prompt. Intended
               to be used to force the prompt to be hidden. Defaults to flex.</p>
@@ -630,6 +640,14 @@
           <h3 class="grouping-title">Events</h3>
 
           <ul class="list-attribute">
+            <li>
+              <div>ar-status</div>
+              <p>Fired when the ar-status attribute above fires. The event.detail.status
+              property will be set to the same value as the ar-status attribute, either
+              'not-presenting', 'session-started', or 'object-placed'. This event is
+              only enabled for WebXR AR sessions. 
+              </p>
+            </li>
             <li>
               <div>camera-change</div>
               <p>Fired when the camera position and/or field of view have


### PR DESCRIPTION
Fixes #567 

This adds an `ar-status` event and attribute which reflects the status of webxr. I have a small demo I've been testing this on which I'll need to clean up for an example in our docs. I also need to add some documentation before I merge this, but figured it would be good to get some feedback first. 