### PR TITLE
Initial support for configuring textures

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -60,6 +60,6 @@ overrides:
       no-unused-vars: off
       no-invalid-this: off
       new-cap: off
-  - files: ["packages/**/*-spec.ts"]
+  - files: ["packages/**/*.ts"]
     rules:
       "@typescript-eslint/no-non-null-assertion": off

--- a/packages/3dom/.gitignore
+++ b/packages/3dom/.gitignore
@@ -1,4 +1,6 @@
 node_modules/*
 dist/*
 lib/*
+demo/*.js
+demo/*.map
 shared-assets

--- a/packages/3dom/demo/add_photo_alternate-white-18dp.svg
+++ b/packages/3dom/demo/add_photo_alternate-white-18dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 7v2.99s-1.99.01-2 0V7h-3s.01-1.99 0-2h3V2h2v3h3v2h-3zm-3 4V8h-3V5H5c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-8h-3zM5 19l3-4 2 3 3-4 4 5H5z"/></svg>

--- a/packages/3dom/demo/index.html
+++ b/packages/3dom/demo/index.html
@@ -38,12 +38,43 @@ html {
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 64px;
+  height: 128px;
 }
 
 button {
   font-size: 2em;
   margin: 0 0.25em;
+}
+
+#textures > div {
+  position: relative;
+  background-image: url(./add_photo_alternate-white-18dp.svg);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 50%;
+  border: 4px dashed white;
+  border-radius: 6px;
+  width: 64px;
+  height: 64px;
+  margin: 0 1em;
+  cursor: pointer;
+}
+
+#textures > div > input {
+  display: block;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+}
+
+#textures .preview {
+  pointer-events: none;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  background-size: 100%;
+  z-index: 1;
 }
   </style>
 </head>
@@ -54,6 +85,14 @@ button {
     <button data-color="1,0,0,1">Red</button>
     <button data-color="0,1,0,1">Green</button>
     <button data-color="0,0,1,1">Blue</button>
+
+    <section id="textures">
+      <div id="base-color">
+        <div class="preview"></div>
+        <div class="dropzone"></div>
+        <input class="input" type="file">
+      </div>
+    </section>
   </div>
   <script type="3DOM">
 console.log('Hello, 3DOM!');
@@ -69,129 +108,18 @@ self.addEventListener('model-change', () => {
         console.log('Changing color to:', event.data.payload);
         material.pbrMetallicRoughness.setBaseColorFactor(event.data.payload);
         break;
+      case 'change-texture':
+        console.log('NEW TEXTURE URI', event.data.payload);
+        model.materials[0].pbrMetallicRoughness.baseColorTexture.texture.source.setURI(event.data.payload);
+        break;
     }
   });
 });
   </script>
 
-  <script type="module">
-import { ModelGraft } from '../lib/facade/three-js/model-graft.js';
-import { CorrelatedSceneGraph } from '../lib/facade/three-js/correlated-scene-graph.js';
-import { ThreeDOMExecutionContext } from '../lib/context.js';
+  <script src="../node_modules/simple-dropzone/dist/simple-dropzone.umd.js" defer></script>
+  <script type="module" src="./demo.js">
 
-import { Scene, sRGBEncoding, ACESFilmicToneMapping, UnsignedByteType, PMREMGenerator, PerspectiveCamera, WebGLRenderer } from '../node_modules/three/build/three.module.js';
-
-import { OrbitControls } from '../node_modules/three/examples/jsm/controls/OrbitControls.js';
-import { GLTFLoader } from '../node_modules/three/examples/jsm/loaders/GLTFLoader.js';
-import { RGBELoader } from '../node_modules/three/examples/jsm/loaders/RGBELoader.js';
-import { RoughnessMipmapper } from '../node_modules/three/examples/jsm/utils/RoughnessMipmapper.js';
-
-class ThreeDOMDemo {
-  constructor() {
-    this.container = document.querySelector('#container');
-
-    this.camera = new PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.25, 20);
-    this.camera.position.set(-1.8, 0.6, 2.7);
-    this.scene = new Scene();
-
-    this.renderer = new WebGLRenderer({ antialias: true });
-    this.renderer.setPixelRatio(window.devicePixelRatio);
-    this.renderer.setSize(window.innerWidth, window.innerHeight);
-    this.renderer.toneMapping = ACESFilmicToneMapping;
-    this.renderer.toneMappingExposure = 0.8;
-    this.renderer.outputEncoding = sRGBEncoding;
-
-    this.container.appendChild(this.renderer.domElement);
-
-    this.pmremGenerator = new PMREMGenerator(this.renderer);
-    this.pmremGenerator.compileEquirectangularShader();
-
-    this.controls = new OrbitControls(this.camera, this.renderer.domElement);
-    this.controls.minDistance = 2;
-    this.controls.maxDistance = 10
-    this.controls.target.set(0, 1, 0);
-    this.controls.update();
-
-    this.textureLoader = new RGBELoader();
-    this.textureLoader.setDataType(UnsignedByteType)
-      .setPath('../shared-assets/environments/')
-      .load('lightroom_14b.hdr', (environmentTexture) => {
-        const environmentMap = this.pmremGenerator
-          .fromEquirectangular(environmentTexture).texture;
-
-        this.scene.environment = environmentMap;
-
-        environmentTexture.dispose();
-        this.pmremGenerator.dispose();
-      });
-
-    this.gltfLoader = new GLTFLoader();
-    this.gltfLoader
-      .setPath('../shared-assets/models/')
-    this.gltfLoader.load('Astronaut.glb', (gltf) => {
-      const roughnessMipmapper = new RoughnessMipmapper(this.renderer);
-      gltf.scene.traverse((child) => {
-        if (child.isMesh) {
-          roughnessMipmapper.generateMipmaps(child.material);
-        }
-      });
-      roughnessMipmapper.dispose();
-
-      this.scene.add(gltf.scene);
-
-      this.activate3DOM(gltf);
-    });
-
-    window.addEventListener('resize', () => this.updateSize(), false);
-
-    this.render();
-  }
-
-  updateSize() {
-    this.camera.aspect = window.innerWidth / window.innerHeight;
-    this.camera.updateProjectionMatrix();
-    this.renderer.setSize(window.innerWidth, window.innerHeight);
-  }
-
-  render() {
-    this.renderer.render(this.scene, this.camera);
-
-    requestAnimationFrame(() => {
-      this.render();
-    });
-  }
-
-  activate3DOM(gltf) {
-    const script = document.querySelector('script[type="3DOM"]');
-    const scriptText = script.textContent;
-
-    const context = new ThreeDOMExecutionContext();
-    const graft = new ModelGraft('../shared-assets/models/Astronaut.glb',
-        CorrelatedSceneGraph.from(gltf));
-
-    context.eval(scriptText);
-    context.changeModel(graft);
-
-    document.querySelector('#ui').addEventListener('click', (event) => {
-      const colorString = event.target.dataset.color;
-
-      if (!colorString) {
-        return;
-      }
-
-      const color = colorString.split(',')
-          .map(numberString => parseFloat(numberString));
-
-      // Forward interaction details to the <model-viewer> worklet:
-      context.worker.postMessage({
-        action: 'change-color',
-        payload: color
-      });
-    });
-  }
-}
-
-self.demo = new ThreeDOMDemo();
   </script>
 </body>
 </html>

--- a/packages/3dom/package-lock.json
+++ b/packages/3dom/package-lock.json
@@ -970,6 +970,39 @@
       "integrity": "sha512-h+hqYkL+tQV/y2ESD5gFXMl5z4cC+XY1jTlBeGSBaTcj3VbB5OBEScbvRXm63NcEbBneQQYbHfBAXAkF9i9wIA==",
       "dev": true
     },
+    "@rollup/plugin-node-resolve": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.0.1.tgz",
+      "integrity": "sha512-KIeAmueDDaYMqMBnUngLVVZhURwxA12nq/YB6nGm5/JpVyOMwI1fCVU3oL/dAnnLBG7oiPXntO5LHOiMrfNXCA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "deep-freeze": "^0.0.1",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.14.2"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+          "dev": true
+        }
+      }
+    },
+    "@rollup/plugin-replace": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.3.3.tgz",
+      "integrity": "sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "magic-string": "^0.25.5"
+      }
+    },
     "@rollup/pluginutils": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.8.tgz",
@@ -2875,6 +2908,12 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
+      "dev": true
+    },
     "deepmerge": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
@@ -4535,6 +4574,39 @@
         }
       }
     },
+    "jest-worker": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.0.0.tgz",
+      "integrity": "sha512-pPaYa2+JnwmiZjK9x7p9BoZht+47ecFCDFA/CJxspHzeDvQcfVBLWzCiWyo+EGrSiQMWZtCFo9iSvMZnAAo8vw==",
+      "dev": true,
+      "requires": {
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5134,6 +5206,15 @@
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -6558,6 +6639,15 @@
         }
       }
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6923,6 +7013,46 @@
         "glob": "^7.1.3"
       }
     },
+    "rollup": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.15.0.tgz",
+      "integrity": "sha512-HAk4kyXiV5sdNDnbKWk5zBPnkX/DAgx09Kbp8rRIRDVsTUVN3vnSowR7ZHkV6/lAiE6c2TQ8HtYb72aCPGW4Jw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-6.1.0.tgz",
+      "integrity": "sha512-4fB3M9nuoWxrwm39habpd4hvrbrde2W2GG4zEGPQg1YITNkM3Tqur5jSuXlWNzbv/2aMLJ+dZJaySc3GCD8oDw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "jest-worker": "^26.0.0",
+        "serialize-javascript": "^3.0.0",
+        "terser": "^4.7.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "terser": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.7.0.tgz",
+          "integrity": "sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -6954,6 +7084,15 @@
       "dev": true,
       "requires": {
         "semver": "^5.0.3"
+      }
+    },
+    "serialize-javascript": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+      "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "serviceworker-cache-polyfill": {
@@ -7000,6 +7139,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-dropzone": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/simple-dropzone/-/simple-dropzone-0.7.1.tgz",
+      "integrity": "sha512-iygdwzsEhN2mvC4d8657JV58i5NM7UwBKCyJGx6J4vr3Vuy8EIeFy+VDgUE3YiQDVneAC/Lpl1CGiOZ5ApMY3Q==",
+      "dev": true,
+      "requires": {
+        "zip-js-esm": "^1.1.1"
+      }
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -7145,6 +7293,12 @@
           "dev": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -8239,6 +8393,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.2.1.tgz",
       "integrity": "sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==",
+      "dev": true
+    },
+    "zip-js-esm": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/zip-js-esm/-/zip-js-esm-1.1.1.tgz",
+      "integrity": "sha512-8fSLIpssGjX8mqTduIjlUStH1uBmAFWCmkiAo7/G8uDAY+rEnwE6nll5Cyvu+Ytqmw5FIQ7XAhohNrrZL2PheQ==",
       "dev": true
     }
   }

--- a/packages/3dom/package.json
+++ b/packages/3dom/package.json
@@ -21,15 +21,18 @@
   "scripts": {
     "prepare": "if [ ! -L './shared-assets' ]; then ln -s ./node_modules/@google/model-viewer-shared-assets ./shared-assets; fi",
     "prepack": "rm $(find ./lib -name *-spec.* -o -name test-helpers.*) 2>/dev/null",
-    "build": "tsc",
+    "build": "npm run build:tsc && npm run build:rollup",
+    "build:tsc": "tsc",
+    "build:rollup": "rollup -c",
     "clean": "rm -rf ./lib",
     "test": "karma start --single-run",
     "test:ci": "npm run test",
     "watch:test": "karma start",
     "watch:tsc": "tsc -w",
+    "watch:rollup": "rollup -c -w",
     "serve": "./node_modules/.bin/http-server -a 127.0.0.1 -o /demo/ -c-1",
     "update:package-lock": "rm ./package-lock.json && npm i --only=production",
-    "dev": "npm run build -- --incremental && npm-run-all --parallel 'watch:tsc -- --preserveWatchOutput --incremental' 'watch:test' 'serve -- -s'"
+    "dev": "npm run build -- --incremental && npm-run-all --parallel 'watch:tsc -- --preserveWatchOutput --incremental' 'watch:rollup' 'watch:test' 'serve -- -s'"
   },
   "keywords": [
     "gltf",
@@ -41,6 +44,8 @@
   "devDependencies": {
     "@google/model-viewer-shared-assets": "*",
     "@open-wc/karma-esm": "^2.11.1",
+    "@rollup/plugin-node-resolve": "^8.0.0",
+    "@rollup/plugin-replace": "^2.3.2",
     "@types/chai": "^4.2.7",
     "@types/mocha": "^5.2.5",
     "@ungap/event-target": "^0.1.0",
@@ -56,6 +61,9 @@
     "mocha": "^5.2.0",
     "npm-run-all": "^4.1.5",
     "polymer-build": "^3.1.1",
+    "rollup": "^2.12.0",
+    "rollup-plugin-terser": "^6.1.0",
+    "simple-dropzone": "^0.7.1",
     "typescript": "3.8.2"
   },
   "dependencies": {

--- a/packages/3dom/rollup.config.js
+++ b/packages/3dom/rollup.config.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import resolve from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
+import {terser} from 'rollup-plugin-terser';
+
+const onwarn = (warning, warn) => {
+  // Suppress non-actionable warning caused by TypeScript boilerplate:
+  if (warning.code !== 'THIS_IS_UNDEFINED') {
+    warn(warning);
+  }
+};
+
+const plugins = [
+  resolve(),
+  replace({
+    'Reflect.decorate': 'undefined',
+  }),
+  terser()
+];
+const watchFiles = ['lib/**'];
+
+export default {
+  input: './lib/demo.js',
+  output: {
+    file: './demo/demo.js',
+    sourcemap: true,
+    format: 'esm',
+    name: 'ModelViewerElement'
+  },
+  watch: {
+    include: watchFiles,
+  },
+  plugins,
+  onwarn,
+};

--- a/packages/3dom/src/api.ts
+++ b/packages/3dom/src/api.ts
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {MagFilter, MinFilter, WrapMode} from './gltf-2.0.js';
 
 /**
  * IMPORTANT NOTE: 3DOM is an experimental / radioactive API. It is very likely
@@ -30,7 +31,7 @@
  *    found in a model's scene graph
  */
 export declare type ThreeDOMCapability =
-    'messaging' | 'material-properties' | 'fetch';
+    'messaging' | 'material-properties' | 'textures' | 'fetch';
 
 /**
  * All constructs in a 3DOM scene graph have a corresponding string name.
@@ -41,6 +42,10 @@ export declare interface ThreeDOMElementMap {
   'model': Model;
   'material': Material;
   'pbr-metallic-roughness': PBRMetallicRoughness;
+  'sampler': Sampler;
+  'image': Image;
+  'texture': Texture;
+  'texture-info': TextureInfo;
 }
 
 /**
@@ -98,6 +103,14 @@ export declare interface ThreeDOMGlobalScope extends Worker {
    * checks; this class is not directly constructable.
    */
   PBRMetallicRoughness: Constructor<PBRMetallicRoughness>;
+
+  Sampler: Constructor<Sampler>;
+
+  TextureInfo: Constructor<Sampler>;
+
+  Texture: Constructor<Texture>;
+
+  Image: Constructor<Image>;
 }
 
 /**
@@ -182,6 +195,56 @@ export declare interface PBRMetallicRoughness extends ThreeDOMElement {
    * Requires the 'material-properties' capability to be enabled.
    */
   setBaseColorFactor(rgba: RGBA): Promise<void>;
+}
+
+export declare interface TextureInfo extends ThreeDOMElement {
+  readonly texture: Texture|null;
+
+  setTexture(texture: Texture|null): Promise<void>;
+}
+
+export declare interface Texture extends ThreeDOMElement {
+  /**
+   * The name of the material, if any.
+   */
+  readonly name?: string;
+
+  readonly sampler: Sampler|null;
+  readonly source: Image|null;
+
+  setSampler(sampler: Sampler): Promise<void>;
+  setSource(image: Image): Promise<void>;
+}
+
+export declare interface Sampler extends ThreeDOMElement {
+  /**
+   * The name of the material, if any.
+   */
+  readonly name?: string;
+
+  readonly minFilter: MinFilter|null;
+  readonly magFilter: MagFilter|null;
+
+  readonly wrapS: WrapMode;
+  readonly wrapT: WrapMode;
+
+  setMinFilter(filter: MinFilter|null): Promise<void>;
+  setMagFilter(filter: MagFilter|null): Promise<void>;
+
+  setWrapS(mode: WrapMode): Promise<void>;
+  setWrapT(mode: WrapMode): Promise<void>;
+}
+
+export declare interface Image extends ThreeDOMElement {
+  /**
+   * The name of the material, if any.
+   */
+  readonly name?: string;
+
+  readonly type: 'embedded'|'external';
+  readonly uri: string|null;
+
+  setURI(uri: string): Promise<void>;
 }
 
 /**

--- a/packages/3dom/src/api.ts
+++ b/packages/3dom/src/api.ts
@@ -189,9 +189,9 @@ export declare interface Material extends ThreeDOMElement {
    */
   readonly name?: string;
 
-  readonly normalTexture?: TextureInfo|null;
-  readonly occlusionTexture?: TextureInfo|null;
-  readonly emissiveTexture?: TextureInfo|null;
+  readonly normalTexture: TextureInfo|null;
+  readonly occlusionTexture: TextureInfo|null;
+  readonly emissiveTexture: TextureInfo|null;
 
   /**
    * The PBRMetallicRoughness configuration of the material.
@@ -209,6 +209,19 @@ export declare interface PBRMetallicRoughness extends ThreeDOMElement {
    * The base color factor of the material, represented as RGBA values
    */
   readonly baseColorFactor: Readonly<RGBA>;
+
+  /**
+   * A texture reference, associating an image with color information and
+   * a sampler for describing base color factor for a UV coordinate space.
+   */
+  readonly baseColorTexture: TextureInfo|null;
+
+  /**
+   * A texture reference, associating an image with color information and
+   * a sampler for describing metalness (B channel) and roughness (G channel)
+   * for a UV coordinate space.
+   */
+  readonly metallicRoughnessTexture: TextureInfo|null;
 
   /**
    * Changes the base color factor of the material to the given value.

--- a/packages/3dom/src/api.ts
+++ b/packages/3dom/src/api.ts
@@ -104,12 +104,28 @@ export declare interface ThreeDOMGlobalScope extends Worker {
    */
   PBRMetallicRoughness: Constructor<PBRMetallicRoughness>;
 
+  /**
+   * A reference to the Sampler constructor. Supports instanceof checks; this
+   * class is not directly constructable.
+   */
   Sampler: Constructor<Sampler>;
 
+  /**
+   * A reference to the TextureInfo constructor. Supports instanceof checks;
+   * this class is not directly constructable.
+   */
   TextureInfo: Constructor<Sampler>;
 
+  /**
+   * A reference to the Texture constructor. Supports instanceof checks; this
+   * class is not directly constructable.
+   */
   Texture: Constructor<Texture>;
 
+  /**
+   * A reference to the Image constructor. Supports instanceof checks; this
+   * class is not directly constructable.
+   */
   Image: Constructor<Image>;
 }
 
@@ -173,6 +189,10 @@ export declare interface Material extends ThreeDOMElement {
    */
   readonly name?: string;
 
+  readonly normalTexture?: TextureInfo|null;
+  readonly occlusionTexture?: TextureInfo|null;
+  readonly emissiveTexture?: TextureInfo|null;
+
   /**
    * The PBRMetallicRoughness configuration of the material.
    */
@@ -197,53 +217,144 @@ export declare interface PBRMetallicRoughness extends ThreeDOMElement {
   setBaseColorFactor(rgba: RGBA): Promise<void>;
 }
 
+/**
+ * A TextureInfo is a pointer to a specific Texture in use on a Material
+ *
+ * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-textureinfo
+ */
 export declare interface TextureInfo extends ThreeDOMElement {
+  /**
+   * The Texture being referenced by this TextureInfo
+   */
   readonly texture: Texture|null;
 
+  /**
+   * Configure the Texture referenced by this TextureInfo
+   * Requires the 'textures' capability to be enabled.
+   */
   setTexture(texture: Texture|null): Promise<void>;
 }
 
+/**
+ * A Texture pairs an Image and a Sampler for use in a Material
+ *
+ * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-texture
+ */
 export declare interface Texture extends ThreeDOMElement {
   /**
-   * The name of the material, if any.
+   * The name of the texture, if any.
    */
   readonly name?: string;
 
+  /**
+   * The Sampler for this Texture
+   */
   readonly sampler: Sampler|null;
+
+  /**
+   * The source Image for this Texture
+   */
   readonly source: Image|null;
 
+  /**
+   * Configure the Sampler used for this Texture.
+   * Requires the 'textures' capability to be enabled.
+   */
   setSampler(sampler: Sampler): Promise<void>;
+
+  /**
+   * Configure the source Image used for this Texture.
+   * Requires the 'textures' capability to be enabled.
+   */
   setSource(image: Image): Promise<void>;
 }
 
+/**
+ * A Sampler describes how to filter and wrap textures
+ *
+ * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-sampler
+ */
 export declare interface Sampler extends ThreeDOMElement {
   /**
-   * The name of the material, if any.
+   * The name of the sampler, if any.
    */
   readonly name?: string;
 
+  /**
+   * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#samplerminfilter
+   */
   readonly minFilter: MinFilter|null;
+
+  /**
+   * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#samplermagfilter
+   */
   readonly magFilter: MagFilter|null;
 
+  /**
+   * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#samplerwraps
+   */
   readonly wrapS: WrapMode;
+
+  /**
+   * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#samplerwrapt
+   */
   readonly wrapT: WrapMode;
 
+  /**
+   * Configure the minFilter value of the Sampler.
+   * Requires the 'textures' capability to be enabled.
+   */
   setMinFilter(filter: MinFilter|null): Promise<void>;
+
+  /**
+   * Configure the magFilter value of the Sampler.
+   * Requires the 'textures' capability to be enabled.
+   */
   setMagFilter(filter: MagFilter|null): Promise<void>;
 
+  /**
+   * Configure the S (U) wrap mode of the Sampler.
+   * Requires the 'textures' capability to be enabled.
+   */
   setWrapS(mode: WrapMode): Promise<void>;
+
+  /**
+   * Configure the T (V) wrap mode of the Sampler.
+   * Requires the 'textures' capability to be enabled.
+   */
   setWrapT(mode: WrapMode): Promise<void>;
 }
 
+
+/**
+ * An Image represents an embedded or external image used to provide texture
+ * color data.
+ *
+ * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-image
+ */
 export declare interface Image extends ThreeDOMElement {
   /**
-   * The name of the material, if any.
+   * The name of the image, if any.
    */
   readonly name?: string;
 
+  /**
+   * The type is 'external' if the image has a configured URI. Otherwise, it is
+   * considered to be 'embedded'. Note: this distinction is only implied by the
+   * glTF spec, and is made explicit here for convenience.
+   */
   readonly type: 'embedded'|'external';
+
+  /**
+   * The URI of the image, if it is external.
+   */
   readonly uri: string|null;
 
+  /**
+   * Configure the URI of the image. If a URI is specified for an otherwise
+   * embedded image, the URI will take precedence over an embedded buffer.
+   * Requires the 'textures' capability to be enabled.
+   */
   setURI(uri: string): Promise<void>;
 }
 

--- a/packages/3dom/src/api/image-spec.ts
+++ b/packages/3dom/src/api/image-spec.ts
@@ -1,0 +1,86 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impliedv
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {FakeModelKernel} from '../test-helpers.js';
+
+import {defineImage, ImageConstructor} from './image.js';
+import {defineThreeDOMElement} from './three-dom-element.js';
+
+const ThreeDOMElement = defineThreeDOMElement();
+
+suite('api/image', () => {
+  suite('defineImage', () => {
+    test('yields a valid constructor', () => {
+      const GeneratedConstructor = defineImage(ThreeDOMElement);
+      const instance = new GeneratedConstructor(new FakeModelKernel(), {
+        uri: 'http://example.com',
+        id: 0,
+      });
+
+      expect(instance).to.be.ok;
+    });
+
+    suite('the generated class', () => {
+      let kernel: FakeModelKernel;
+      let GeneratedConstructor: ImageConstructor;
+
+      setup(() => {
+        kernel = new FakeModelKernel();
+        GeneratedConstructor = defineImage(ThreeDOMElement);
+      });
+
+      test('produces elements with the correct owner model', () => {
+        const instance = new GeneratedConstructor(kernel, {
+          uri: 'http://example.com',
+          id: 0,
+        });
+
+        expect(instance.ownerModel).to.be.equal(kernel.model);
+      });
+
+      test('expresses the image name when available', () => {
+        const instance = new GeneratedConstructor(kernel, {id: 0, name: 'foo'});
+
+        expect(instance.name).to.be.equal('foo');
+      });
+
+      test('expresses the image uri when available', () => {
+        const instance = new GeneratedConstructor(kernel, {
+          id: 0,
+          uri: 'http://example.com',
+        });
+
+        expect(instance.uri).to.be.equal('http://example.com');
+      });
+
+      test('is external if a uri is available', () => {
+        const instance = new GeneratedConstructor(kernel, {
+          id: 0,
+          uri: 'http://example.com',
+        });
+
+        expect(instance.type).to.be.equal('external');
+      });
+
+      test('is embedded if no uri is available', () => {
+        const instance = new GeneratedConstructor(kernel, {
+          id: 0,
+        });
+
+        expect(instance.type).to.be.equal('embedded');
+      });
+    });
+  });
+});

--- a/packages/3dom/src/api/image.ts
+++ b/packages/3dom/src/api/image.ts
@@ -21,6 +21,16 @@ import {ModelKernel} from './model-kernel.js';
 export type ImageConstructor = Constructor<ImageInterface>&
     ConstructedWithArguments<[ModelKernel, SerializedImage]>;
 
+/**
+ * A constructor factory for a Image class. The Image is defined based on
+ * a provided implementation for all specified 3DOM scene graph element types.
+ *
+ * The sole reason for using this factory pattern is to enable sound type
+ * checking while also providing for the ability to stringify the factory so
+ * that it can be part of a runtime-generated Worker script.
+ *
+ * @see ../api.ts
+ */
 export function defineImage(ThreeDOMElement: Constructor<ThreeDOMElement>):
     ImageConstructor {
   const $kernel = Symbol('kernel');

--- a/packages/3dom/src/api/image.ts
+++ b/packages/3dom/src/api/image.ts
@@ -1,0 +1,64 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ConstructedWithArguments, Constructor, Image as ImageInterface, ThreeDOMElement} from '../api.js';
+import {SerializedImage} from '../protocol.js';
+
+import {ModelKernel} from './model-kernel.js';
+
+export type ImageConstructor = Constructor<ImageInterface>&
+    ConstructedWithArguments<[ModelKernel, SerializedImage]>;
+
+export function defineImage(ThreeDOMElement: Constructor<ThreeDOMElement>):
+    ImageConstructor {
+  const $kernel = Symbol('kernel');
+  const $uri = Symbol('uri');
+  const $name = Symbol('name');
+
+  class Image extends ThreeDOMElement implements ImageInterface {
+    private[$kernel]: ModelKernel;
+
+    private[$uri]: string|null;
+
+    private[$name]?: string;
+
+    constructor(kernel: ModelKernel, serialized: SerializedImage) {
+      super(kernel);
+
+      this[$kernel] = kernel;
+
+      this[$uri] = serialized.uri || null;
+      this[$name] = serialized.name;
+    }
+
+    get name() {
+      return this[$name];
+    }
+
+    get type() {
+      return this.uri != null ? 'external' : 'embedded';
+    }
+
+    get uri() {
+      return this[$uri];
+    }
+
+    async setURI(uri: string|null): Promise<void> {
+      this[$kernel].mutate(this, 'uri', uri);
+    }
+  }
+
+  return Image;
+}

--- a/packages/3dom/src/api/material.ts
+++ b/packages/3dom/src/api/material.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {ConstructedWithArguments, Constructor, Material as MaterialInterface, PBRMetallicRoughness, ThreeDOMElement} from '../api.js';
+import {ConstructedWithArguments, Constructor, Material as MaterialInterface, PBRMetallicRoughness, TextureInfo, ThreeDOMElement} from '../api.js';
 import {SerializedMaterial} from '../protocol.js';
 
 import {ModelKernel} from './model-kernel.js';
@@ -33,6 +33,10 @@ export type MaterialConstructor = Constructor<MaterialInterface>&
 export function defineMaterial(ThreeDOMElement: Constructor<ThreeDOMElement>):
     MaterialConstructor {
   const $pbrMetallicRoughness = Symbol('pbrMetallicRoughness');
+  const $normalTexture = Symbol('normalTexture');
+  const $occlusionTexture = Symbol('occlusionTexture');
+  const $emissiveTexture = Symbol('emissiveTexture');
+
   const $kernel = Symbol('kernel');
   const $name = Symbol('name');
 
@@ -43,6 +47,10 @@ export function defineMaterial(ThreeDOMElement: Constructor<ThreeDOMElement>):
    */
   class Material extends ThreeDOMElement implements MaterialInterface {
     protected[$pbrMetallicRoughness]: PBRMetallicRoughness;
+    protected[$normalTexture]: TextureInfo|null = null;
+    protected[$occlusionTexture]: TextureInfo|null = null;
+    protected[$emissiveTexture]: TextureInfo|null = null;
+
     protected[$kernel]: ModelKernel;
     protected[$name]: string;
 
@@ -55,8 +63,30 @@ export function defineMaterial(ThreeDOMElement: Constructor<ThreeDOMElement>):
         this[$name] = serialized.name;
       }
 
-      this[$pbrMetallicRoughness] = kernel.deserialize(
-          'pbr-metallic-roughness', serialized.pbrMetallicRoughness);
+      const {
+        pbrMetallicRoughness,
+        normalTexture,
+        occlusionTexture,
+        emissiveTexture
+      } = serialized;
+
+      this[$pbrMetallicRoughness] =
+          kernel.deserialize('pbr-metallic-roughness', pbrMetallicRoughness);
+
+      if (normalTexture != null) {
+        this[$normalTexture] =
+            kernel.deserialize('texture-info', normalTexture);
+      }
+
+      if (occlusionTexture != null) {
+        this[$occlusionTexture] =
+            kernel.deserialize('texture-info', occlusionTexture);
+      }
+
+      if (emissiveTexture != null) {
+        this[$emissiveTexture] =
+            kernel.deserialize('texture-info', emissiveTexture);
+      }
     }
 
     /**
@@ -64,6 +94,17 @@ export function defineMaterial(ThreeDOMElement: Constructor<ThreeDOMElement>):
      */
     get pbrMetallicRoughness() {
       return this[$pbrMetallicRoughness];
+    }
+
+    get normalTexture() {
+      return this[$normalTexture];
+    }
+
+    get occlusionTexture() {
+      return this[$occlusionTexture];
+    }
+    get emissiveTexture() {
+      return this[$emissiveTexture];
     }
 
     /**

--- a/packages/3dom/src/api/model-kernel-spec.ts
+++ b/packages/3dom/src/api/model-kernel-spec.ts
@@ -14,7 +14,8 @@
  */
 
 import {RGBA} from '../api.js';
-import {FakeMaterial, FakeModel, FakePBRMetallicRoughness} from '../test-helpers.js';
+import {ThreeDOMMessageType} from '../protocol.js';
+import {FakeImage, FakeMaterial, FakeModel, FakePBRMetallicRoughness, FakeSampler, FakeTexture, FakeTextureInfo, FakeThreeDOMElement} from '../test-helpers.js';
 import {getLocallyUniqueId} from '../utilities.js';
 
 import {defineModelKernel, ModelKernel, ModelKernelConstructor} from './model-kernel.js';
@@ -23,8 +24,16 @@ suite('api/model-kernel', () => {
   suite('defineModelKernel', () => {
     let ModelKernel: ModelKernelConstructor;
     setup(() => {
-      ModelKernel =
-          defineModelKernel(FakeModel, FakeMaterial, FakePBRMetallicRoughness);
+      ModelKernel = defineModelKernel(
+          ThreeDOMMessageType,
+          FakeThreeDOMElement,
+          FakeModel,
+          FakeMaterial,
+          FakePBRMetallicRoughness,
+          FakeSampler,
+          FakeImage,
+          FakeTexture,
+          FakeTextureInfo);
     });
 
     suite('ModelKernel', () => {

--- a/packages/3dom/src/api/pbr-metallic-roughness.ts
+++ b/packages/3dom/src/api/pbr-metallic-roughness.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {ConstructedWithArguments, Constructor, PBRMetallicRoughness as PBRMetallicRoughnessInterface, RGBA, ThreeDOMElement} from '../api.js';
+import {ConstructedWithArguments, Constructor, PBRMetallicRoughness as PBRMetallicRoughnessInterface, RGBA, TextureInfo, ThreeDOMElement} from '../api.js';
 import {SerializedPBRMetallicRoughness} from '../protocol.js';
 
 import {ModelKernel} from './model-kernel.js';
@@ -38,6 +38,8 @@ export function definePBRMetallicRoughness(
     PBRMetallicRoughnessConstructor {
   const $kernel = Symbol('kernel');
   const $baseColorFactor = Symbol('baseColorFactor');
+  const $baseColorTexture = Symbol('baseColorTexture');
+  const $metallicRoughnessTexture = Symbol('metallicRoughnessTexture');
 
   /**
    * PBRMetallicRoughness exposes the PBR properties for a given Material.
@@ -46,6 +48,8 @@ export function definePBRMetallicRoughness(
       PBRMetallicRoughnessInterface {
     protected[$kernel]: ModelKernel;
     protected[$baseColorFactor]: Readonly<RGBA>;
+    protected[$baseColorTexture]: TextureInfo|null = null;
+    protected[$metallicRoughnessTexture]: TextureInfo|null = null;
 
     constructor(
         kernel: ModelKernel, serialized: SerializedPBRMetallicRoughness) {
@@ -54,6 +58,18 @@ export function definePBRMetallicRoughness(
       this[$kernel] = kernel;
       this[$baseColorFactor] =
           Object.freeze(serialized.baseColorFactor) as RGBA;
+
+      const {baseColorTexture, metallicRoughnessTexture} = serialized;
+
+      if (baseColorTexture != null) {
+        this[$baseColorTexture] =
+            kernel.deserialize('texture-info', baseColorTexture);
+      }
+
+      if (metallicRoughnessTexture != null) {
+        this[$metallicRoughnessTexture] =
+            kernel.deserialize('texture-info', metallicRoughnessTexture);
+      }
     }
 
     /**
@@ -61,6 +77,14 @@ export function definePBRMetallicRoughness(
      */
     get baseColorFactor() {
       return this[$baseColorFactor];
+    }
+
+    get baseColorTexture() {
+      return this[$baseColorTexture];
+    }
+
+    get metallicRoughnessTexture() {
+      return this[$metallicRoughnessTexture];
     }
 
     /**

--- a/packages/3dom/src/api/sampler-spec.ts
+++ b/packages/3dom/src/api/sampler-spec.ts
@@ -1,0 +1,57 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {FakeModelKernel} from '../test-helpers.js';
+
+import {defineSampler, SamplerConstructor} from './sampler.js';
+import {defineThreeDOMElement} from './three-dom-element.js';
+
+const ThreeDOMElement = defineThreeDOMElement();
+
+suite('api/sampler', () => {
+  suite('defineSampler', () => {
+    test('yields a valid constructor', () => {
+      const GeneratedConstructor = defineSampler(ThreeDOMElement);
+      const instance = new GeneratedConstructor(new FakeModelKernel(), {
+        id: 0,
+      });
+
+      expect(instance).to.be.ok;
+    });
+
+    suite('the generated class', () => {
+      let kernel: FakeModelKernel;
+      let GeneratedConstructor: SamplerConstructor;
+
+
+      setup(() => {
+        kernel = new FakeModelKernel();
+        GeneratedConstructor = defineSampler(ThreeDOMElement);
+      });
+
+      test('produces elements with the correct owner model', () => {
+        const instance = new GeneratedConstructor(kernel, {id: 0});
+
+        expect(instance.ownerModel).to.be.equal(kernel.model);
+      });
+
+      test('expresses the sampler name when available', () => {
+        const instance = new GeneratedConstructor(kernel, {id: 0, name: 'foo'});
+
+        expect(instance.name).to.be.equal('foo');
+      });
+    });
+  });
+});

--- a/packages/3dom/src/api/sampler.ts
+++ b/packages/3dom/src/api/sampler.ts
@@ -1,0 +1,100 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ConstructedWithArguments, Constructor, Sampler as SamplerInterface, ThreeDOMElement} from '../api.js';
+import {MagFilter, MinFilter, WrapMode} from '../gltf-2.0.js';
+import {SerializedSampler} from '../protocol.js';
+
+import {ModelKernel} from './model-kernel.js';
+
+export type SamplerConstructor = Constructor<SamplerInterface>&
+    ConstructedWithArguments<[ModelKernel, SerializedSampler]>;
+
+export function defineSampler(ThreeDOMElement: Constructor<ThreeDOMElement>):
+    SamplerConstructor {
+  const $kernel = Symbol('kernel');
+  const $minFilter = Symbol('minFilter');
+  const $magFilter = Symbol('magFilter');
+  const $wrapS = Symbol('wrapS');
+  const $wrapT = Symbol('wrapT');
+  const $name = Symbol('name');
+
+  class Sampler extends ThreeDOMElement implements SamplerInterface {
+    private[$kernel]: ModelKernel;
+
+    private[$minFilter]: MinFilter|null = null;
+    private[$magFilter]: MagFilter|null = null;
+
+    private[$wrapS]: WrapMode;
+    private[$wrapT]: WrapMode;
+
+    private[$name]?: string;
+
+    constructor(kernel: ModelKernel, serialized: SerializedSampler) {
+      super(kernel);
+
+      this[$kernel] = kernel;
+
+      this[$name] = serialized.name;
+
+      this[$minFilter] = serialized.minFilter || null;
+      this[$magFilter] = serialized.magFilter || null;
+      this[$wrapS] = serialized.wrapS || 10497;
+      this[$wrapT] = serialized.wrapT || 10497;
+    }
+
+    get name() {
+      return this[$name];
+    }
+
+    get minFilter() {
+      return this[$minFilter];
+    }
+
+    get magFilter() {
+      return this[$magFilter];
+    }
+
+    get wrapS() {
+      return this[$wrapS];
+    }
+
+    get wrapT() {
+      return this[$wrapT];
+    }
+
+    async setMinFilter(filter: MinFilter|null): Promise<void> {
+      await this[$kernel].mutate(this, 'minFilter', filter);
+      this[$minFilter] = filter;
+    }
+
+    async setMagFilter(filter: MagFilter|null): Promise<void> {
+      await this[$kernel].mutate(this, 'magFilter', filter);
+      this[$magFilter] = filter;
+    }
+
+    async setWrapS(mode: WrapMode): Promise<void> {
+      await this[$kernel].mutate(this, 'wrapS', mode);
+      this[$wrapS] = mode;
+    }
+
+    async setWrapT(mode: WrapMode): Promise<void> {
+      await this[$kernel].mutate(this, 'wrapT', mode);
+      this[$wrapT] = mode;
+    }
+  }
+
+  return Sampler;
+}

--- a/packages/3dom/src/api/sampler.ts
+++ b/packages/3dom/src/api/sampler.ts
@@ -22,6 +22,16 @@ import {ModelKernel} from './model-kernel.js';
 export type SamplerConstructor = Constructor<SamplerInterface>&
     ConstructedWithArguments<[ModelKernel, SerializedSampler]>;
 
+/**
+ * A constructor factory for a Sampler class. The Sampler is defined based on
+ * a provided implementation for all specified 3DOM scene graph element types.
+ *
+ * The sole reason for using this factory pattern is to enable sound type
+ * checking while also providing for the ability to stringify the factory so
+ * that it can be part of a runtime-generated Worker script.
+ *
+ * @see ../api.ts
+ */
 export function defineSampler(ThreeDOMElement: Constructor<ThreeDOMElement>):
     SamplerConstructor {
   const $kernel = Symbol('kernel');

--- a/packages/3dom/src/api/texture-info-spec.ts
+++ b/packages/3dom/src/api/texture-info-spec.ts
@@ -1,0 +1,49 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {FakeModelKernel} from '../test-helpers.js';
+
+import {defineTextureInfo, TextureInfoConstructor} from './texture-info.js';
+import {defineThreeDOMElement} from './three-dom-element.js';
+
+const ThreeDOMElement = defineThreeDOMElement();
+
+suite('api/texture-info', () => {
+  suite('defineTextureInfo', () => {
+    test('yields a valid constructor', () => {
+      const GeneratedConstructor = defineTextureInfo(ThreeDOMElement);
+      const instance = new GeneratedConstructor(new FakeModelKernel(), {id: 0});
+
+      expect(instance).to.be.ok;
+    });
+
+    suite('the generated class', () => {
+      let kernel: FakeModelKernel;
+      let GeneratedConstructor: TextureInfoConstructor;
+
+
+      setup(() => {
+        kernel = new FakeModelKernel();
+        GeneratedConstructor = defineTextureInfo(ThreeDOMElement);
+      });
+
+      test('produces elements with the correct owner model', () => {
+        const instance = new GeneratedConstructor(kernel, {id: 0});
+
+        expect(instance.ownerModel).to.be.equal(kernel.model);
+      });
+    });
+  });
+});

--- a/packages/3dom/src/api/texture-info.ts
+++ b/packages/3dom/src/api/texture-info.ts
@@ -21,6 +21,17 @@ import {ModelKernel} from './model-kernel.js';
 export type TextureInfoConstructor = Constructor<TextureInfoInterface>&
     ConstructedWithArguments<[ModelKernel, SerializedTextureInfo]>;
 
+/**
+ * A constructor factory for a TextureInfo class. The TextureInfo is defined
+ * based on a provided implementation for all specified 3DOM scene graph element
+ * types.
+ *
+ * The sole reason for using this factory pattern is to enable sound type
+ * checking while also providing for the ability to stringify the factory so
+ * that it can be part of a runtime-generated Worker script.
+ *
+ * @see ../api.ts
+ */
 export function defineTextureInfo(
     ThreeDOMElement: Constructor<ThreeDOMElement>): TextureInfoConstructor {
   const $kernel = Symbol('kernel');

--- a/packages/3dom/src/api/texture-info.ts
+++ b/packages/3dom/src/api/texture-info.ts
@@ -1,0 +1,57 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ConstructedWithArguments, Constructor, Texture, TextureInfo as TextureInfoInterface, ThreeDOMElement} from '../api.js';
+import {SerializedTextureInfo} from '../protocol.js';
+
+import {ModelKernel} from './model-kernel.js';
+
+export type TextureInfoConstructor = Constructor<TextureInfoInterface>&
+    ConstructedWithArguments<[ModelKernel, SerializedTextureInfo]>;
+
+export function defineTextureInfo(
+    ThreeDOMElement: Constructor<ThreeDOMElement>): TextureInfoConstructor {
+  const $kernel = Symbol('kernel');
+  const $texture = Symbol('texture');
+
+  class TextureInfo extends ThreeDOMElement implements TextureInfoInterface {
+    private[$kernel]: ModelKernel;
+
+    private[$texture]: Texture|null = null;
+
+    constructor(kernel: ModelKernel, serialized: SerializedTextureInfo) {
+      super(kernel);
+
+      this[$kernel] = kernel;
+
+      const {texture} = serialized;
+
+      if (texture != null) {
+        this[$texture] = kernel.deserialize('texture', texture);
+      }
+    }
+
+    get texture() {
+      return this[$texture];
+    }
+
+    async setTexture(texture: Texture|null): Promise<void> {
+      await this[$kernel].mutate(this, 'texture', texture);
+      this[$texture] = texture;
+    }
+  }
+
+  return TextureInfo;
+}

--- a/packages/3dom/src/api/texture-spec.ts
+++ b/packages/3dom/src/api/texture-spec.ts
@@ -1,0 +1,75 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {FakeModelKernel} from '../test-helpers.js';
+
+import {defineTexture, TextureConstructor} from './texture.js';
+import {defineThreeDOMElement} from './three-dom-element.js';
+
+const ThreeDOMElement = defineThreeDOMElement();
+
+suite('api/texture', () => {
+  suite('defineTexture', () => {
+    test('yields a valid constructor', () => {
+      const GeneratedConstructor = defineTexture(ThreeDOMElement);
+      const instance = new GeneratedConstructor(new FakeModelKernel(), {
+        id: 0,
+      });
+
+      expect(instance).to.be.ok;
+    });
+
+    suite('the generated class', () => {
+      let kernel: FakeModelKernel;
+      let GeneratedConstructor: TextureConstructor;
+
+      setup(() => {
+        kernel = new FakeModelKernel();
+        GeneratedConstructor = defineTexture(ThreeDOMElement);
+      });
+
+      test('produces elements with the correct owner model', () => {
+        const instance = new GeneratedConstructor(kernel, {id: 0});
+
+        expect(instance.ownerModel).to.be.equal(kernel.model);
+      });
+
+      test('expresses the texture name when available', () => {
+        const instance = new GeneratedConstructor(kernel, {
+          id: 0,
+          name: 'foo',
+        });
+
+        expect(instance.name).to.be.equal('foo');
+      });
+
+      suite('with a configured sampler', () => {
+        test('expresses the sampler on the instance', () => {
+          const instance = new GeneratedConstructor(kernel, {
+            id: 0,
+            name: 'foo',
+            sampler: {
+              id: 1,
+              name: 'bar',
+            },
+          });
+
+          expect(instance.sampler).to.be.ok;
+          expect(instance.sampler!.name).to.be.equal('bar');
+        });
+      });
+    });
+  });
+});

--- a/packages/3dom/src/api/texture.ts
+++ b/packages/3dom/src/api/texture.ts
@@ -1,0 +1,81 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ConstructedWithArguments, Constructor, Image, Sampler, Texture as TextureInterface, ThreeDOMElement} from '../api.js';
+import {SerializedTexture} from '../protocol.js';
+
+import {ModelKernel} from './model-kernel.js';
+
+export type TextureConstructor = Constructor<TextureInterface>&
+    ConstructedWithArguments<[ModelKernel, SerializedTexture]>;
+
+export function defineTexture(ThreeDOMElement: Constructor<ThreeDOMElement>):
+    TextureConstructor {
+  const $kernel = Symbol('kernel');
+  const $source = Symbol('source');
+  const $sampler = Symbol('sampler');
+  const $name = Symbol('name');
+
+  class Texture extends ThreeDOMElement implements TextureInterface {
+    private[$kernel]: ModelKernel;
+
+    private[$source]: Image|null = null;
+    private[$sampler]: Sampler|null = null;
+
+    private[$name]?: string;
+
+    constructor(kernel: ModelKernel, serialized: SerializedTexture) {
+      super(kernel);
+
+      this[$kernel] = kernel;
+
+      const {sampler, source, name} = serialized;
+
+      this[$name] = name;
+
+      if (sampler != null) {
+        this[$sampler] = kernel.deserialize('sampler', sampler);
+      }
+
+      if (source != null) {
+        this[$source] = kernel.deserialize('image', source);
+      }
+    }
+
+    get name() {
+      return this[$name];
+    }
+
+    get sampler() {
+      return this[$sampler];
+    }
+
+    get source() {
+      return this[$source];
+    }
+
+    async setSampler(sampler: Sampler|null): Promise<void> {
+      await this[$kernel].mutate(this, 'sampler', sampler);
+      this[$sampler] = sampler;
+    }
+
+    async setSource(image: Image|null): Promise<void> {
+      await this[$kernel].mutate(this, 'source', image);
+      this[$source] = image;
+    }
+  }
+
+  return Texture;
+}

--- a/packages/3dom/src/api/texture.ts
+++ b/packages/3dom/src/api/texture.ts
@@ -21,6 +21,17 @@ import {ModelKernel} from './model-kernel.js';
 export type TextureConstructor = Constructor<TextureInterface>&
     ConstructedWithArguments<[ModelKernel, SerializedTexture]>;
 
+/**
+ * A constructor factory for a Texture class. The Texture is defined
+ * based on a provided implementation for all specified 3DOM scene graph element
+ * types.
+ *
+ * The sole reason for using this factory pattern is to enable sound type
+ * checking while also providing for the ability to stringify the factory so
+ * that it can be part of a runtime-generated Worker script.
+ *
+ * @see ../api.ts
+ */
 export function defineTexture(ThreeDOMElement: Constructor<ThreeDOMElement>):
     TextureConstructor {
   const $kernel = Symbol('kernel');

--- a/packages/3dom/src/context-spec.ts
+++ b/packages/3dom/src/context-spec.ts
@@ -75,8 +75,7 @@ suite('context', () => {
       test('dispatches an event in the worker', async () => {
         const modelGraft = new ModelGraft(
             '',
-            await CorrelatedSceneGraph.from(
-                await loadThreeGLTF(ASTRONAUT_GLB_PATH)));
+            CorrelatedSceneGraph.from(await loadThreeGLTF(ASTRONAUT_GLB_PATH)));
         const context = new ThreeDOMExecutionContext(['messaging']);
         const workerConfirmsEvent = waitForEvent(context.worker, 'message');
 

--- a/packages/3dom/src/context.ts
+++ b/packages/3dom/src/context.ts
@@ -87,8 +87,6 @@ const ALL_CAPABILITIES: Readonly<Array<ThreeDOMCapability>> =
 export const generateContextScriptSource =
     (capabilities: Readonly<Array<ThreeDOMCapability>> = ALL_CAPABILITIES) => {
       return `;(function() {
-var ThreeDOMMessageType = ${JSON.stringify(ThreeDOMMessageType)};
-
 var preservedContext = {
   postMessage: self.postMessage.bind(self),
   addEventListener: self.addEventListener.bind(self),
@@ -98,9 +96,7 @@ var preservedContext = {
 ${generateContextPatch(ALLOWLISTED_GLOBALS)}
 ${generateAPI()}
 ${generateCapabilityFilter(capabilities)}
-${generateInitializer()}
-
-initialize.call(self, ModelKernel, preservedContext);
+(${generateInitializer()}).call(self, ThreeDOMMessageType, ModelKernel, preservedContext);
 
 })();`;
     };

--- a/packages/3dom/src/context/generate-api.ts
+++ b/packages/3dom/src/context/generate-api.ts
@@ -13,27 +13,49 @@
  * limitations under the License.
  */
 
+import {defineImage} from '../api/image.js';
 import {defineMaterial} from '../api/material.js';
 import {defineModelKernel} from '../api/model-kernel.js';
 import {defineModel} from '../api/model.js';
 import {definePBRMetallicRoughness} from '../api/pbr-metallic-roughness.js';
+import {defineSampler} from '../api/sampler.js';
+import {defineTextureInfo} from '../api/texture-info.js';
+import {defineTexture} from '../api/texture.js';
 import {defineThreeDOMElement} from '../api/three-dom-element.js';
+import {ThreeDOMMessageType} from '../protocol.js';
 
-export const generateAPI = () => `${defineModelKernel.toString()}
+export const generateAPI = () => `
+var ThreeDOMMessageType = ${JSON.stringify(ThreeDOMMessageType)};
+
+${defineModelKernel.toString()}
 ${defineThreeDOMElement.toString()}
 ${defineModel.toString()}
 ${defineMaterial.toString()}
 ${definePBRMetallicRoughness.toString()}
+${defineSampler.toString()}
+${defineImage.toString()}
+${defineTexture.toString()}
+${defineTextureInfo.toString()}
 
-var ThreeDOMElement = defineThreeDOMElement();
-var Model = defineModel(ThreeDOMElement);
-var Material = defineMaterial(ThreeDOMElement);
-var PBRMetallicRoughness = definePBRMetallicRoughness(ThreeDOMElement);
+var ThreeDOMElement = ${defineThreeDOMElement.name}();
+var Model = ${defineModel.name}(ThreeDOMElement);
+var Material = ${defineMaterial.name}(ThreeDOMElement);
+var PBRMetallicRoughness = ${definePBRMetallicRoughness.name}(ThreeDOMElement);
+var Sampler = ${defineSampler.name}(ThreeDOMElement);
+var Image = ${defineImage.name}(ThreeDOMElement);
+var Texture = ${defineTexture.name}(ThreeDOMElement);
+var TextureInfo = ${defineTextureInfo.name}(ThreeDOMElement);
 
-var ModelKernel = defineModelKernel(
+var ModelKernel = ${defineModelKernel.name}(
+  ThreeDOMMessageType,
+  ThreeDOMElement,
   Model,
   Material,
-  PBRMetallicRoughness
+  PBRMetallicRoughness,
+  Sampler,
+  Image,
+  Texture,
+  TextureInfo
 );
 
 // Populate the global scope with constructors
@@ -41,4 +63,9 @@ var ModelKernel = defineModelKernel(
 self.ThreeDOMElement = ThreeDOMElement;
 self.Model = Model;
 self.Material = Material;
-self.PBRMetallicRoughness = PBRMetallicRoughness;`;
+self.PBRMetallicRoughness = PBRMetallicRoughness;
+self.Sampler = Sampler;
+self.Image = Image;
+self.Texture = Texture;
+self.TextureInfo = TextureInfo;
+`;

--- a/packages/3dom/src/context/generate-capability-filter.ts
+++ b/packages/3dom/src/context/generate-capability-filter.ts
@@ -15,6 +15,33 @@
 
 import {ThreeDOMCapability, ThreeDOMGlobalScope} from '../api.js';
 
+function filterTextures(this: ThreeDOMGlobalScope) {
+  const errorMessage = 'Capability "textures" not allowed';
+  const descriptor = {
+    value: () => {
+      throw new Error(errorMessage);
+    },
+    configurable: false,
+    writable: false
+  };
+
+  Object.defineProperties(this.Texture.prototype, {
+    'setSampler': descriptor,
+    'setSource': descriptor,
+  });
+
+  Object.defineProperties(this.Image.prototype, {
+    'setURI': descriptor,
+  });
+
+  Object.defineProperties(this.Sampler.prototype, {
+    'setMinFilter': descriptor,
+    'setMagFilter': descriptor,
+    'setWrapS': descriptor,
+    'setWrapT': descriptor,
+  });
+}
+
 /**
  * Given a 3DOM execution context, patch any methods that give write access
  * to otherwise configurable material properties so that they are automatically
@@ -92,6 +119,7 @@ type CapabilityFilterMap = {
 };
 
 const capabilityFilterMap: CapabilityFilterMap = {
+  'textures': filterTextures,
   'messaging': filterMessaging,
   'material-properties': filterMaterialProperties,
   'fetch': filterFetch

--- a/packages/3dom/src/context/generate-initializer.ts
+++ b/packages/3dom/src/context/generate-initializer.ts
@@ -15,7 +15,7 @@
 
 import {ModelChangeEvent, ThreeDOMGlobalScope} from '../api.js';
 import {ModelKernel, ModelKernelConstructor} from '../api/model-kernel.js';
-import {SerializedModel, ThreeDOMMessageType} from '../protocol.js';
+import {SerializedModel, ThreeDOMMessageTypeMap} from '../protocol.js';
 
 /**
  * The "preserved" context includes the original native implementations
@@ -31,7 +31,6 @@ export interface PreservedContext {
   importScripts: (...scripts: Array<string>) => unknown;
 }
 
-
 /**
  * A function that will be stringified and appended the a runtime-generated
  * execution context script to initialize the scene graph execution context.
@@ -42,6 +41,7 @@ export interface PreservedContext {
  */
 function initialize(
     this: ThreeDOMGlobalScope,
+    ThreeDOMMessageType: ThreeDOMMessageTypeMap,
     ModelKernel: ModelKernelConstructor,
     preservedContext: PreservedContext) {
   let currentKernel: ModelKernel|null = null;

--- a/packages/3dom/src/demo.ts
+++ b/packages/3dom/src/demo.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {ACESFilmicToneMapping, Mesh, MeshStandardMaterial, PerspectiveCamera, PMREMGenerator, Scene, sRGBEncoding, UnsignedByteType, WebGLRenderer} from 'three';
+import {OrbitControls} from 'three/examples/jsm/controls/OrbitControls.js';
+import {GLTF, GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader.js';
+import {RGBELoader} from 'three/examples/jsm/loaders/RGBELoader.js';
+import {RoughnessMipmapper} from 'three/examples/jsm/utils/RoughnessMipmapper.js';
+
+
+import {ThreeDOMExecutionContext} from './context.js';
+import {CorrelatedSceneGraph} from './facade/three-js/correlated-scene-graph.js';
+import {ModelGraft} from './facade/three-js/model-graft.js';
+
+class ThreeDOMDemo {
+  container = document.querySelector('#container')!;
+  camera = new PerspectiveCamera(
+      45, window.innerWidth / window.innerHeight, 0.25, 20);
+  scene = new Scene();
+  renderer = new WebGLRenderer({antialias: true});
+
+  pmremGenerator = new PMREMGenerator(this.renderer);
+
+  controls = new OrbitControls(this.camera, this.renderer.domElement);
+
+  textureLoader = new RGBELoader();
+  gltfLoader = new GLTFLoader();
+
+  constructor() {
+    this.camera.position.set(-1.8, 0.6, 2.7);
+
+    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    this.renderer.toneMapping = ACESFilmicToneMapping;
+    this.renderer.toneMappingExposure = 0.8;
+    this.renderer.outputEncoding = sRGBEncoding;
+
+    this.container.appendChild(this.renderer.domElement);
+
+    this.pmremGenerator.compileEquirectangularShader();
+
+    this.controls.minDistance = 2;
+    this.controls.maxDistance = 10;
+    this.controls.target.set(0, 1, 0);
+    this.controls.update();
+
+    this.textureLoader.setDataType(UnsignedByteType)
+        .setPath('../shared-assets/environments/')
+        .load('lightroom_14b.hdr', (environmentTexture) => {
+          const environmentMap =
+              this.pmremGenerator.fromEquirectangular(environmentTexture)
+                  .texture;
+
+          this.scene.environment = environmentMap;
+
+          environmentTexture.dispose();
+          this.pmremGenerator.dispose();
+        });
+
+    this.gltfLoader.setPath('../shared-assets/models/');
+    this.gltfLoader.load('Astronaut.glb', (gltf) => {
+      const roughnessMipmapper = new RoughnessMipmapper(this.renderer);
+      gltf.scene.traverse((child) => {
+        if ((child as Mesh).isMesh && (child as Mesh).material &&
+            ((child as Mesh).material as MeshStandardMaterial).isMaterial) {
+          roughnessMipmapper.generateMipmaps(
+              (child as Mesh).material as MeshStandardMaterial);
+        }
+      });
+      roughnessMipmapper.dispose();
+
+      this.scene.add(gltf.scene);
+
+      this.activate3DOM(gltf);
+    });
+
+    window.addEventListener('resize', () => this.updateSize(), false);
+
+    this.render();
+  }
+
+  updateSize() {
+    this.camera.aspect = window.innerWidth / window.innerHeight;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+  }
+
+  render() {
+    this.renderer.render(this.scene, this.camera);
+
+    requestAnimationFrame(() => {
+      this.render();
+    });
+  }
+
+  activate3DOM(gltf: GLTF) {
+    const script = document.querySelector('script[type="3DOM"]')!;
+    const scriptText = script.textContent!;
+
+    const context =
+        new ThreeDOMExecutionContext(['material-properties', 'messaging']);
+    const graft = new ModelGraft(
+        '../shared-assets/models/Astronaut.glb',
+        CorrelatedSceneGraph.from(gltf));
+
+    context.eval(scriptText);
+    context.changeModel(graft);
+
+    document.querySelector('#ui')!.addEventListener('click', (event) => {
+      const colorString = (event.target as HTMLElement).dataset.color;
+
+      if (!colorString) {
+        return;
+      }
+
+      const color = colorString.split(',').map(
+          (numberString) => parseFloat(numberString));
+
+      // Forward interaction details to the <model-viewer> worklet:
+      context.worker.postMessage({action: 'change-color', payload: color});
+    });
+
+    const dropZone =
+        document.querySelector('#base-color .dropzone') as HTMLDivElement;
+    const dropInputElement =
+        document.querySelector('#base-color .input') as HTMLInputElement;
+    const dropPreview =
+        document.querySelector('#base-color .preview') as HTMLDivElement;
+
+
+    const dropControl =
+        new (self as any)
+            .SimpleDropzone.SimpleDropzone(dropZone, dropInputElement);
+
+    dropControl.on('drop', ({files}: any) => {
+      let url = '';
+
+      for (const file of (files as Map<string, File>).values()) {
+        url = URL.createObjectURL(file);
+        dropPreview.style.backgroundImage = `url(${url})`;
+        break;
+      }
+
+      context.worker.postMessage({action: 'change-texture', payload: url});
+    });
+  }
+}
+
+(self as any).demo = new ThreeDOMDemo();

--- a/packages/3dom/src/facade/api.ts
+++ b/packages/3dom/src/facade/api.ts
@@ -17,14 +17,24 @@ import {RGBA} from '../api.js';
 import {GLTF, GLTFElement, MagFilter, MinFilter, WrapMode} from '../gltf-2.0.js';
 import {SerializedImage, SerializedMaterial, SerializedModel, SerializedPBRMetallicRoughness, SerializedSampler, SerializedTexture, SerializedThreeDOMElement} from '../protocol.js';
 
+/**
+ * Implementation common to all elements in the 3DOM facade domain.
+ */
 export interface ThreeDOMElement {
   readonly ownerModel: Model;
   readonly internalID: number;
   readonly name: string|null;
   readonly sourceObject: GLTF|GLTFElement;
 
+  /**
+   * Mutate a property on the element. Throws for all properties and values that
+   * are not explicitly supported by the implementation.
+   */
   mutate(property: string, value: unknown): Promise<void>;
 
+  /**
+   * Serialize the element so that it can be transferred to another context.
+   */
   toJSON(): SerializedThreeDOMElement;
 }
 
@@ -49,17 +59,30 @@ export interface PBRMetallicRoughness extends ThreeDOMElement {
  */
 export interface Material extends ThreeDOMElement {
   readonly pbrMetallicRoughness: PBRMetallicRoughness|null;
+
+  readonly normalTexture: TextureInfo|null;
+  readonly occlusionTexture: TextureInfo|null;
+  readonly emissiveTexture: TextureInfo|null;
+
   toJSON(): SerializedMaterial;
 }
 
-export type BufferView = ThreeDOMElement;
-
+/**
+ * A facade that wraps an underlying renderer's notion of an image
+ *
+ * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#image
+ */
 export interface Image {
   mutate(property: 'uri', value: string): Promise<void>;
 
   toJSON(): SerializedImage;
 }
 
+/**
+ * A facade that wraps an underlying renderer's notion of a sampler
+ *
+ * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#sampler
+ */
 export interface Sampler {
   mutate(property: 'minFilter', value: MinFilter|null): Promise<void>;
   mutate(property: 'magFilter', value: MagFilter|null): Promise<void>;
@@ -68,12 +91,22 @@ export interface Sampler {
   toJSON(): SerializedSampler;
 }
 
+/**
+ * A facade that wraps an underlying renderer's notion of a texture
+ *
+ * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#texture
+ */
 export interface Texture extends ThreeDOMElement {
   mutate(property: 'source'|'sampler', value: number|null): Promise<void>;
 
   toJSON(): SerializedTexture;
 }
 
+/**
+ * A facade that wraps an underlying renderer's notion of a texture
+ *
+ * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#texture
+ */
 export interface TextureInfo extends ThreeDOMElement {
   mutate(property: 'texture', value: number|null): Promise<void>;
 }

--- a/packages/3dom/src/facade/api.ts
+++ b/packages/3dom/src/facade/api.ts
@@ -14,14 +14,17 @@
  */
 
 import {RGBA} from '../api.js';
-import {GLTF, GLTFElement} from '../gltf-2.0.js';
-import {SerializedMaterial, SerializedModel, SerializedPBRMetallicRoughness, SerializedThreeDOMElement} from '../protocol.js';
+import {GLTF, GLTFElement, MagFilter, MinFilter, WrapMode} from '../gltf-2.0.js';
+import {SerializedImage, SerializedMaterial, SerializedModel, SerializedPBRMetallicRoughness, SerializedSampler, SerializedTexture, SerializedThreeDOMElement} from '../protocol.js';
 
 export interface ThreeDOMElement {
   readonly ownerModel: Model;
   readonly internalID: number;
   readonly name: string|null;
   readonly sourceObject: GLTF|GLTFElement;
+
+  mutate(property: string, value: unknown): Promise<void>;
+
   toJSON(): SerializedThreeDOMElement;
 }
 
@@ -32,7 +35,10 @@ export interface ThreeDOMElement {
  * @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#pbrmetallicroughness
  */
 export interface PBRMetallicRoughness extends ThreeDOMElement {
-  baseColorFactor: RGBA;
+  readonly baseColorFactor: RGBA;
+
+  mutate(property: 'baseColorFactor', value: RGBA): Promise<void>;
+
   toJSON(): SerializedPBRMetallicRoughness;
 }
 
@@ -44,6 +50,32 @@ export interface PBRMetallicRoughness extends ThreeDOMElement {
 export interface Material extends ThreeDOMElement {
   readonly pbrMetallicRoughness: PBRMetallicRoughness|null;
   toJSON(): SerializedMaterial;
+}
+
+export type BufferView = ThreeDOMElement;
+
+export interface Image {
+  mutate(property: 'uri', value: string): Promise<void>;
+
+  toJSON(): SerializedImage;
+}
+
+export interface Sampler {
+  mutate(property: 'minFilter', value: MinFilter|null): Promise<void>;
+  mutate(property: 'magFilter', value: MagFilter|null): Promise<void>;
+  mutate(property: 'wrapS'|'wrapT', value: WrapMode|null): Promise<void>;
+
+  toJSON(): SerializedSampler;
+}
+
+export interface Texture extends ThreeDOMElement {
+  mutate(property: 'source'|'sampler', value: number|null): Promise<void>;
+
+  toJSON(): SerializedTexture;
+}
+
+export interface TextureInfo extends ThreeDOMElement {
+  mutate(property: 'texture', value: number|null): Promise<void>;
 }
 
 /**

--- a/packages/3dom/src/facade/three-js/correlated-scene-graph.ts
+++ b/packages/3dom/src/facade/three-js/correlated-scene-graph.ts
@@ -79,7 +79,13 @@ export class CorrelatedSceneGraph {
       }
 
       const {type, index} = gltfElementReference;
-      const gltfElement = gltf[type][index] as GLTFElement;
+      const elementArray = gltf[type] || [];
+      const gltfElement = elementArray[index];
+
+      if (gltfElement == null) {
+        // TODO: Maybe throw here...
+        return;
+      }
 
       let threeObjects = gltfElementMap.get(gltfElement);
 
@@ -120,7 +126,7 @@ export class CorrelatedSceneGraph {
 
             if (elementReference != null) {
               const {type, index} = elementReference;
-              const cloneElement = cloneGLTF[type][index];
+              const cloneElement = cloneGLTF[type]![index];
 
               cloneThreeObjectMap.set(cloneObject, {type, index});
 

--- a/packages/3dom/src/facade/three-js/image.ts
+++ b/packages/3dom/src/facade/three-js/image.ts
@@ -1,0 +1,92 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ImageLoader, Texture as ThreeTexture} from 'three';
+
+import {EmbeddedImage as GLTFEmbeddedImage, ExternalImage as GLTFExternalImage, Image as GLTFImage} from '../../gltf-2.0.js';
+import {SerializedImage} from '../../protocol.js';
+import {Image as ImageInterface} from '../api.js';
+
+import {ModelGraft} from './model-graft.js';
+import {$correlatedObjects, ThreeDOMElement} from './three-dom-element.js';
+
+const loader = new ImageLoader();
+
+const $threeTextures = Symbol('threeTextures');
+const $bufferViewImages = Symbol('bufferViewImages');
+
+/**
+ * Image facade implementation for Three.js textures
+ */
+export class Image extends ThreeDOMElement implements ImageInterface {
+  private get[$threeTextures]() {
+    return this[$correlatedObjects] as Set<ThreeTexture>;
+  }
+
+  private[$bufferViewImages]: WeakMap<ThreeTexture, unknown> = new WeakMap();
+
+  constructor(
+      graft: ModelGraft, image: GLTFImage,
+      correlatedTextures: Set<ThreeTexture>) {
+    super(graft, image, correlatedTextures);
+
+    if ((image as GLTFEmbeddedImage).bufferView != null) {
+      for (const texture of correlatedTextures) {
+        this[$bufferViewImages].set(texture, texture.image);
+      }
+    }
+  }
+
+  async mutate(property: 'uri', value: string|null) {
+    let image: HTMLImageElement|null = null;
+
+    if (property !== 'uri') {
+      throw new Error(`Cannot configure property "${property}" on Image`);
+    }
+
+    console.log('MUTATING URI', value);
+
+    if (value != null) {
+      image = await new Promise((resolve, reject) => {
+        loader.load(value, resolve, undefined, reject);
+      });
+    }
+
+    for (const texture of this[$threeTextures]) {
+      // If the URI is set to null but the Image had an associated buffer view
+      // (this would happen if it started out as embedded), then fall back to
+      // the cached object URL created by GLTFLoader:
+      if (image == null &&
+          (this.sourceObject as GLTFEmbeddedImage).bufferView != null) {
+        texture.image = this[$bufferViewImages].get(texture);
+      } else {
+        texture.image = image;
+      }
+
+      texture.needsUpdate = true;
+    }
+  }
+
+  toJSON(): SerializedImage {
+    const serialized: Partial<SerializedImage> = super.toJSON();
+    const {uri} = this.sourceObject as GLTFExternalImage;
+
+    if (uri != null) {
+      serialized.uri = uri;
+    }
+
+    return serialized as SerializedImage;
+  }
+}

--- a/packages/3dom/src/facade/three-js/image.ts
+++ b/packages/3dom/src/facade/three-js/image.ts
@@ -56,8 +56,6 @@ export class Image extends ThreeDOMElement implements ImageInterface {
       throw new Error(`Cannot configure property "${property}" on Image`);
     }
 
-    console.log('MUTATING URI', value);
-
     if (value != null) {
       image = await new Promise((resolve, reject) => {
         loader.load(value, resolve, undefined, reject);

--- a/packages/3dom/src/facade/three-js/material.ts
+++ b/packages/3dom/src/facade/three-js/material.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {MeshStandardMaterial} from 'three';
+import {MeshStandardMaterial, Texture as ThreeTexture} from 'three';
 
 import {Material as GLTFMaterial} from '../../gltf-2.0.js';
 import {SerializedMaterial} from '../../protocol.js';
@@ -21,10 +21,14 @@ import {Material as MaterialInterface} from '../api.js';
 
 import {ModelGraft} from './model-graft.js';
 import {PBRMetallicRoughness} from './pbr-metallic-roughness.js';
+import {TextureInfo} from './texture-info.js';
 import {ThreeDOMElement} from './three-dom-element.js';
 
 
 const $pbrMetallicRoughness = Symbol('pbrMetallicRoughness');
+const $normalTexture = Symbol('normalTexture');
+const $occlusionTexture = Symbol('occlusionTexture');
+const $emissiveTexture = Symbol('emissiveTexture');
 
 /**
  * Material facade implementation for Three.js materials
@@ -32,16 +36,60 @@ const $pbrMetallicRoughness = Symbol('pbrMetallicRoughness');
 export class Material extends ThreeDOMElement implements MaterialInterface {
   private[$pbrMetallicRoughness]: PBRMetallicRoughness|null = null;
 
+  private[$normalTexture]: TextureInfo|null = null;
+  private[$occlusionTexture]: TextureInfo|null = null;
+  private[$emissiveTexture]: TextureInfo|null = null;
+
   constructor(
       graft: ModelGraft, material: GLTFMaterial,
       correlatedMaterials: Set<MeshStandardMaterial>) {
     super(graft, material, correlatedMaterials);
 
-    const {pbrMetallicRoughness} = material;
+    const {
+      pbrMetallicRoughness,
+      normalTexture,
+      occlusionTexture,
+      emissiveTexture
+    } = material;
 
     if (pbrMetallicRoughness != null) {
       this[$pbrMetallicRoughness] = new PBRMetallicRoughness(
           graft, pbrMetallicRoughness, correlatedMaterials);
+    }
+
+    const normalTextures = new Set<ThreeTexture>();
+    const occlusionTextures = new Set<ThreeTexture>();
+    const emissiveTextures = new Set<ThreeTexture>();
+
+    for (const material of correlatedMaterials) {
+      const {normalMap, aoMap, emissiveMap} = material;
+
+      if (normalTexture != null && normalMap != null) {
+        normalTextures.add(normalMap);
+      }
+
+      if (occlusionTexture != null && aoMap != null) {
+        occlusionTextures.add(aoMap);
+      }
+
+      if (emissiveTexture != null && emissiveMap != null) {
+        emissiveTextures.add(emissiveMap);
+      }
+    }
+
+    if (normalTextures.size > 0) {
+      this[$normalTexture] =
+          new TextureInfo(graft, normalTexture!, normalTextures);
+    }
+
+    if (occlusionTextures.size > 0) {
+      this[$occlusionTexture] =
+          new TextureInfo(graft, occlusionTexture!, occlusionTextures);
+    }
+
+    if (emissiveTextures.size > 0) {
+      this[$emissiveTexture] =
+          new TextureInfo(graft, emissiveTexture!, emissiveTextures);
     }
   }
 
@@ -49,12 +97,42 @@ export class Material extends ThreeDOMElement implements MaterialInterface {
     return this[$pbrMetallicRoughness];
   }
 
+  get normalTexture() {
+    return this[$normalTexture];
+  }
+
+  get occlusionTexture() {
+    return this[$occlusionTexture];
+  }
+
+  get emissiveTexture() {
+    return this[$emissiveTexture];
+  }
+
   toJSON(): SerializedMaterial {
     const serialized: Partial<SerializedMaterial> = super.toJSON();
-    const {pbrMetallicRoughness} = this;
+    const {
+      pbrMetallicRoughness,
+      normalTexture,
+      occlusionTexture,
+      emissiveTexture
+    } = this;
     if (pbrMetallicRoughness != null) {
       serialized.pbrMetallicRoughness = pbrMetallicRoughness.toJSON();
     }
+
+    if (normalTexture != null) {
+      serialized.normalTexture = normalTexture.toJSON();
+    }
+
+    if (occlusionTexture != null) {
+      serialized.occlusionTexture = occlusionTexture.toJSON();
+    }
+
+    if (emissiveTexture != null) {
+      serialized.emissiveTexture = emissiveTexture.toJSON();
+    }
+
     return serialized as SerializedMaterial;
   }
 }

--- a/packages/3dom/src/facade/three-js/sampler-spec.ts
+++ b/packages/3dom/src/facade/three-js/sampler-spec.ts
@@ -1,0 +1,52 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import {MeshStandardMaterial} from
+// 'three/src/materials/MeshStandardMaterial.js'; import {Color} from
+// 'three/src/math/Color.js';
+
+// import {Sampler as GLTFSampler} from '../../gltf-2.0.js';
+// import {createFakeThreeGLTF} from '../../test-helpers.js';
+
+// import {CorrelatedSceneGraph} from './correlated-scene-graph.js';
+// import {Sampler} from './sampler.js';
+// import {ModelGraft} from './model-graft.js';
+
+// suite('facade/three-js/sampler', () => {
+//   suite('Sampler', () => {
+//     test(
+//         'expresses Three.js material color as PBRMetallicRoughness base color
+//         factor', async () => {
+//           const graft = new ModelGraft(
+//               '', CorrelatedSceneGraph.from(createFakeThreeGLTF()));
+//           const gltfMaterial: GLTFMaterial = {
+//             pbrMetallicRoughness: {baseColorFactor: [1, 0.5, 0, 1]}
+//           };
+
+//           const threeMaterial = new MeshStandardMaterial();
+//           threeMaterial.color = new Color('rgb(255, 127, 0)');
+
+//           const material =
+//               new Material(graft, gltfMaterial, new Set([threeMaterial]));
+//           const {pbrMetallicRoughness} = material;
+
+
+//           expect(pbrMetallicRoughness).to.be.ok;
+//           expect((pbrMetallicRoughness as
+//           PBRMetallicRoughness).baseColorFactor)
+//               .to.be.deep.equal([1, 0.5, 0, 1]);
+//         });
+//   });
+// });

--- a/packages/3dom/src/facade/three-js/sampler-spec.ts
+++ b/packages/3dom/src/facade/three-js/sampler-spec.ts
@@ -13,40 +13,57 @@
  * limitations under the License.
  */
 
-// import {MeshStandardMaterial} from
-// 'three/src/materials/MeshStandardMaterial.js'; import {Color} from
-// 'three/src/math/Color.js';
+import {Texture} from 'three';
 
-// import {Sampler as GLTFSampler} from '../../gltf-2.0.js';
-// import {createFakeThreeGLTF} from '../../test-helpers.js';
+import {Sampler as GLTFSampler} from '../../gltf-2.0.js';
+import {createFakeThreeGLTF} from '../../test-helpers.js';
 
-// import {CorrelatedSceneGraph} from './correlated-scene-graph.js';
-// import {Sampler} from './sampler.js';
-// import {ModelGraft} from './model-graft.js';
+import {CorrelatedSceneGraph} from './correlated-scene-graph.js';
+import {ModelGraft} from './model-graft.js';
+import {Sampler} from './sampler.js';
 
-// suite('facade/three-js/sampler', () => {
-//   suite('Sampler', () => {
-//     test(
-//         'expresses Three.js material color as PBRMetallicRoughness base color
-//         factor', async () => {
-//           const graft = new ModelGraft(
-//               '', CorrelatedSceneGraph.from(createFakeThreeGLTF()));
-//           const gltfMaterial: GLTFMaterial = {
-//             pbrMetallicRoughness: {baseColorFactor: [1, 0.5, 0, 1]}
-//           };
+suite('facade/three-js/sampler', () => {
+  suite('Sampler', () => {
+    test('expresses Three.js texture wrap mode', () => {
+      const texture = new Texture();
+      texture.wrapS = 10497;
+      texture.wrapT = 33071;
 
-//           const threeMaterial = new MeshStandardMaterial();
-//           threeMaterial.color = new Color('rgb(255, 127, 0)');
+      const graft =
+          new ModelGraft('', CorrelatedSceneGraph.from(createFakeThreeGLTF()));
 
-//           const material =
-//               new Material(graft, gltfMaterial, new Set([threeMaterial]));
-//           const {pbrMetallicRoughness} = material;
+      const gltfSampler: GLTFSampler = {
+        wrapS: 10497,
+        wrapT: 33071,
+      };
 
+      const sampler = new Sampler(graft, gltfSampler, new Set([texture]));
 
-//           expect(pbrMetallicRoughness).to.be.ok;
-//           expect((pbrMetallicRoughness as
-//           PBRMetallicRoughness).baseColorFactor)
-//               .to.be.deep.equal([1, 0.5, 0, 1]);
-//         });
-//   });
-// });
+      const {wrapS, wrapT} = sampler.toJSON();
+
+      expect(wrapS).to.be.undefined;
+      expect(wrapT).to.be.equal(33071);
+    });
+
+    test('expresses Three.js texture filter', () => {
+      const texture = new Texture();
+      texture.minFilter = 9987;
+      texture.magFilter = 9728;
+
+      const graft =
+          new ModelGraft('', CorrelatedSceneGraph.from(createFakeThreeGLTF()));
+
+      const gltfSampler: GLTFSampler = {
+        minFilter: 9987,
+        magFilter: 9728,
+      };
+
+      const sampler = new Sampler(graft, gltfSampler, new Set([texture]));
+
+      const {minFilter, magFilter} = sampler.toJSON();
+
+      expect(minFilter).to.be.equal(9987);
+      expect(magFilter).to.be.equal(9728);
+    });
+  });
+});

--- a/packages/3dom/src/facade/three-js/sampler.ts
+++ b/packages/3dom/src/facade/three-js/sampler.ts
@@ -1,0 +1,134 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Texture as ThreeTexture} from 'three';
+
+import {MagFilter, MinFilter, Sampler as GLTFSampler, WrapMode} from '../../gltf-2.0.js';
+import {SerializedSampler} from '../../protocol.js';
+import {Sampler as SamplerInterface} from '../api.js';
+
+import {ModelGraft} from './model-graft.js';
+import {$correlatedObjects, ThreeDOMElement} from './three-dom-element.js';
+
+const isMinFilter = (() => {
+  const minFilterValues: Array<MinFilter> =
+      [9728, 9729, 9984, 9985, 9986, 9987];
+  return (value: unknown): value is MinFilter =>
+             minFilterValues.indexOf(value as MinFilter) > -1;
+})();
+
+const isMagFilter = (() => {
+  const magFilterValues: Array<MagFilter> = [9728, 9729];
+  return (value: unknown): value is MagFilter =>
+             magFilterValues.indexOf(value as MagFilter) > -1;
+})();
+
+const isWrapMode = (() => {
+  const wrapModes: Array<WrapMode> = [33071, 33648, 10497];
+  return (value: unknown): value is WrapMode =>
+             wrapModes.indexOf(value as WrapMode) > -1;
+})();
+
+const isValidSamplerValue = <P extends 'minFilter'|'magFilter'|'wrapS'|'wrapT'>(
+    property: P, value: unknown): value is GLTFSampler[P] => {
+  switch (property) {
+    case 'minFilter':
+      return isMinFilter(value);
+    case 'magFilter':
+      return isMagFilter(value);
+    case 'wrapS':
+    case 'wrapT':
+      return isWrapMode(value);
+    default:
+      throw new Error(`Cannot configure property "${property}" on Sampler`);
+  }
+};
+
+// These defaults represent a convergence of glTF defaults for wrap mode and
+// Three.js defaults for filters. Per glTF 2.0 spec, a renderer may choose its
+// own defaults for filters.
+// @see https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-sampler
+// @see https://threejs.org/docs/#api/en/textures/Texture
+const defaultValues:
+    {[k in 'minFilter' | 'magFilter' | 'wrapS' | 'wrapT']: number} = {
+      minFilter: 9987,
+      magFilter: 9729,
+      wrapS: 10497,
+      wrapT: 10497,
+    };
+
+const $threeTextures = Symbol('threeTextures');
+
+/**
+ * Sampler facade implementation for Three.js textures
+ */
+export class Sampler extends ThreeDOMElement implements SamplerInterface {
+  private get[$threeTextures]() {
+    return this[$correlatedObjects] as Set<ThreeTexture>;
+  }
+
+  constructor(
+      graft: ModelGraft, sampler: GLTFSampler,
+      correlatedTextures: Set<ThreeTexture>) {
+    super(graft, sampler, correlatedTextures);
+  }
+
+  async mutate<P extends 'minFilter'|'magFilter'|'wrapS'|'wrapT'>(
+      property: P, value: MinFilter|MagFilter|WrapMode|null) {
+    const sampler = this.sourceObject as GLTFSampler;
+
+    if (value != null) {
+      if (isValidSamplerValue(property, value)) {
+        sampler[property] = value;
+
+        for (const texture of this[$threeTextures]) {
+          texture[property] = value;
+          texture.needsUpdate = true;
+        }
+      }
+    } else if (property in sampler) {
+      delete sampler[property];
+
+      for (const texture of this[$threeTextures]) {
+        texture[property] = defaultValues[property];
+        texture.needsUpdate = true;
+      }
+    }
+  }
+
+  toJSON(): SerializedSampler {
+    const serialized: Partial<SerializedSampler> = super.toJSON();
+    const {minFilter, magFilter, wrapS, wrapT} =
+        this.sourceObject as GLTFSampler;
+
+    if (minFilter != null) {
+      serialized.minFilter = minFilter;
+    }
+
+    if (magFilter != null) {
+      serialized.magFilter = magFilter;
+    }
+
+    if (wrapS !== 10497) {
+      serialized.wrapS = wrapS;
+    }
+
+    if (wrapT !== 10497) {
+      serialized.wrapT = wrapT;
+    }
+
+    return serialized as SerializedSampler;
+  }
+}

--- a/packages/3dom/src/facade/three-js/texture-info.ts
+++ b/packages/3dom/src/facade/three-js/texture-info.ts
@@ -27,7 +27,7 @@ import {ThreeDOMElement} from './three-dom-element.js';
 const $texture = Symbol('texture');
 
 /**
- * Material facade implementation for Three.js materials
+ * TextureInfo facade implementation for Three.js materials
  */
 export class TextureInfo extends ThreeDOMElement implements
     TextureInfoInterface {

--- a/packages/3dom/src/facade/three-js/texture-info.ts
+++ b/packages/3dom/src/facade/three-js/texture-info.ts
@@ -1,0 +1,67 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Texture as ThreeTexture} from 'three';
+
+import {TextureInfo as GLTFTextureInfo} from '../../gltf-2.0.js';
+import {SerializedTexture, SerializedTextureInfo} from '../../protocol.js';
+import {TextureInfo as TextureInfoInterface} from '../api.js';
+
+import {ModelGraft} from './model-graft.js';
+import {Texture} from './texture.js';
+import {ThreeDOMElement} from './three-dom-element.js';
+
+
+const $texture = Symbol('texture');
+
+/**
+ * Material facade implementation for Three.js materials
+ */
+export class TextureInfo extends ThreeDOMElement implements
+    TextureInfoInterface {
+  private[$texture]: Texture|null = null;
+
+  constructor(
+      graft: ModelGraft, textureInfo: GLTFTextureInfo,
+      correlatedTextures: Set<ThreeTexture>) {
+    super(graft, textureInfo, correlatedTextures);
+
+    const glTF = graft.correlatedSceneGraph.gltf;
+    const {index: textureIndex} = textureInfo;
+    const texture = textureIndex != null && glTF.textures != null ?
+        glTF.textures[textureIndex] :
+        null;
+
+    if (texture != null) {
+      this[$texture] = new Texture(graft, texture, correlatedTextures);
+    }
+  }
+
+  get texture() {
+    return this[$texture];
+  }
+
+  toJSON(): SerializedTexture {
+    const serialized: Partial<SerializedTextureInfo> = super.toJSON();
+
+    const {texture} = this;
+
+    if (texture != null) {
+      serialized.texture = texture.toJSON();
+    }
+
+    return serialized as SerializedTexture;
+  }
+}

--- a/packages/3dom/src/facade/three-js/texture-spec.ts
+++ b/packages/3dom/src/facade/three-js/texture-spec.ts
@@ -1,0 +1,38 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Texture as ThreeTexture} from 'three';
+
+import {Texture as GLTFTexture} from '../../gltf-2.0.js';
+import {createFakeThreeGLTF} from '../../test-helpers.js';
+
+import {CorrelatedSceneGraph} from './correlated-scene-graph.js';
+import {ModelGraft} from './model-graft.js';
+import {Texture} from './texture.js';
+
+suite('facade/three-js/texture', () => {
+  suite('Texture', () => {
+    test('can be realized from a Three.js texture', () => {
+      const texture = new ThreeTexture();
+
+      const graft =
+          new ModelGraft('', CorrelatedSceneGraph.from(createFakeThreeGLTF()));
+
+      const gltfTexture: GLTFTexture = {};
+
+      expect(new Texture(graft, gltfTexture, new Set([texture]))).to.be.ok;
+    });
+  });
+});

--- a/packages/3dom/src/facade/three-js/texture.ts
+++ b/packages/3dom/src/facade/three-js/texture.ts
@@ -1,0 +1,86 @@
+/* @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Texture as ThreeTexture} from 'three';
+
+import {Texture as GLTFTexture} from '../../gltf-2.0.js';
+import {SerializedTexture} from '../../protocol.js';
+import {Texture as TextureInterface} from '../api.js';
+
+import {Image} from './image.js';
+import {ModelGraft} from './model-graft.js';
+import {Sampler} from './sampler.js';
+import {ThreeDOMElement} from './three-dom-element.js';
+
+
+const $source = Symbol('source');
+const $sampler = Symbol('sampler');
+
+/**
+ * Material facade implementation for Three.js materials
+ */
+export class Texture extends ThreeDOMElement implements TextureInterface {
+  private[$source]: Image|null = null;
+  private[$sampler]: Sampler|null = null;
+
+  constructor(
+      graft: ModelGraft, texture: GLTFTexture,
+      correlatedTextures: Set<ThreeTexture>) {
+    super(graft, texture, correlatedTextures);
+
+    const glTF = graft.correlatedSceneGraph.gltf;
+    const {sampler: samplerIndex, source: imageIndex} = texture;
+
+    if (samplerIndex != null) {
+      const sampler = glTF.samplers && glTF.samplers[samplerIndex];
+
+      if (sampler != null) {
+        this[$sampler] = new Sampler(graft, sampler, correlatedTextures);
+      }
+    }
+
+    if (imageIndex != null) {
+      const image = glTF.images && glTF.images[imageIndex];
+
+      if (image != null) {
+        this[$source] = new Image(graft, image, correlatedTextures);
+      }
+    }
+  }
+
+  get sampler() {
+    return this[$sampler];
+  }
+
+  get source() {
+    return this[$source];
+  }
+
+  toJSON(): SerializedTexture {
+    const serialized: Partial<SerializedTexture> = super.toJSON();
+
+    const {sampler, source} = this;
+
+    if (sampler != null) {
+      serialized.sampler = sampler.toJSON();
+    }
+
+    if (source != null) {
+      serialized.source = source.toJSON();
+    }
+
+    return serialized as SerializedTexture;
+  }
+}

--- a/packages/3dom/src/facade/three-js/three-dom-element.ts
+++ b/packages/3dom/src/facade/three-js/three-dom-element.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {Material, Object3D} from 'three';
+import {Material, Object3D, Texture} from 'three';
 
 import {GLTF, GLTFElement} from '../../gltf-2.0.js';
 import {SerializedThreeDOMElement} from '../../protocol.js';
@@ -29,7 +29,7 @@ export const $sourceObject = Symbol('sourceObject');
 const $graft = Symbol('graft');
 const $id = Symbol('id');
 
-export type CorrelatedObjects = Set<Object3D>|Set<Material>;
+export type CorrelatedObjects = Set<Object3D>|Set<Material>|Set<Texture>;
 
 /**
  * A SerializableThreeDOMElement is the common primitive of all scene graph
@@ -94,6 +94,17 @@ export class ThreeDOMElement implements ThreeDOMElementInterface {
     return this[$sourceObject];
   }
 
+  /**
+   * Mutate a property of the scene graph element. Returns a promise that
+   * resolves when the mutation has been successfully applied.
+   */
+  mutate(_property: string, _value: unknown): Promise<void> {
+    throw new Error('Mutation not implemented for this element');
+  }
+
+  /**
+   * Serialize the element in order to share it with a worker context.
+   */
   toJSON(): SerializedThreeDOMElement {
     const serialized: SerializedThreeDOMElement = {id: this[$id]};
     const {name} = this;

--- a/packages/3dom/src/gltf-2.0.ts
+++ b/packages/3dom/src/gltf-2.0.ts
@@ -68,11 +68,55 @@ export interface OrthographicCamera {
 
 export type Camera = PerspectiveCamera|OrthographicCamera;
 
+export type NearestFilter = 9728;
+export type LinearFilter = 9729;
+export type NearestMipmapNearestFilter = 9984;
+export type LinearMipmapNearestFilter = 9985;
+export type NearestMipmapLinearFilter = 9986;
+export type LinearMipmapLinearFilter = 9987;
+
+export type MagFilter = NearestFilter|LinearFilter;
+export type MinFilter = NearestFilter|LinearFilter|NearestMipmapNearestFilter|
+    LinearMipmapNearestFilter|NearestMipmapLinearFilter|
+    LinearMipmapLinearFilter;
+
+export type ClampToEdgeWrap = 33071;
+export type MirroredRepeatWrap = 33648;
+export type RepeatWrap = 10497;
+
+export type WrapMode = RepeatWrap|ClampToEdgeWrap|MirroredRepeatWrap;
+
+export interface Sampler {
+  name?: string;
+  magFilter?: MagFilter;
+  minFilter?: MinFilter;
+  wrapS?: WrapMode;
+  wrapT?: WrapMode;
+  extensions?: ExtensionDictionary;
+  extras?: Extras;
+}
+
+export interface Texture {
+  name?: string;
+  sampler?: number;
+  source?: number;
+  extensions?: ExtensionDictionary;
+  extras?: Extras;
+}
+
 export interface TextureInfo {
   index: number;
   texCoord?: number;
   extensions?: ExtensionDictionary;
   extras?: Extras;
+}
+
+export interface OcclusionTextureInfo extends TextureInfo {
+  strength?: number;
+}
+
+export interface NormalTextureInfo extends TextureInfo {
+  scale?: number;
 }
 
 export interface PBRMetallicRoughness {
@@ -94,8 +138,8 @@ export interface Material {
   alphaCutoff?: number;
   emissiveFactor?: number;
   pbrMetallicRoughness?: PBRMetallicRoughness;
-  normalTexture?: TextureInfo;
-  occlusionTexture?: TextureInfo;
+  normalTexture?: NormalTextureInfo;
+  occlusionTexture?: OcclusionTextureInfo;
   emissiveTexture?: TextureInfo;
   extensions?: ExtensionDictionary;
   extras?: Extras;
@@ -144,7 +188,7 @@ export interface Texture {
 
 export interface ExternalImage {
   name?: string;
-  url: string;
+  uri: string;
   extensions?: ExtensionDictionary;
   extras?: Extras;
 }
@@ -235,15 +279,26 @@ export interface GLTFElementMap {
   'animation': Animation;
 }
 
+export interface Asset {
+  version: '2.0';
+  copyright?: string;
+  generator?: string;
+  minVersion?: string;
+  extensions?: ExtensionDictionary;
+  extras?: Extras;
+}
+
 export interface GLTF {
-  scene: number;
-  scenes: Scene[];
-  nodes: Node[];
-  materials: Material[];
-  accessors: Accessor[];
-  images: Image[];
-  textures: Texture[];
-  meshes: Mesh[];
-  cameras: Camera[];
-  animations: Animation[];
+  asset: Asset;
+  scene?: number;
+  scenes?: Scene[];
+  nodes?: Node[];
+  materials?: Material[];
+  accessors?: Accessor[];
+  samplers?: Sampler[];
+  images?: Image[];
+  textures?: Texture[];
+  meshes?: Mesh[];
+  cameras?: Camera[];
+  animations?: Animation[];
 }

--- a/packages/3dom/src/protocol.ts
+++ b/packages/3dom/src/protocol.ts
@@ -14,6 +14,7 @@
  */
 
 import {RGBA} from './api.js';
+import {MagFilter, MinFilter, WrapMode} from './gltf-2.0.js';
 
 /**
  * The protocol between 3DOM execution contexts is strictly defined.
@@ -50,6 +51,8 @@ export const ThreeDOMMessageType = {
   // of the backing host scene graph
   MUTATE: 6
 };
+
+export type ThreeDOMMessageTypeMap = typeof ThreeDOMMessageType;
 
 /**
  * Messages exchanged between a scene graph context and the host context.
@@ -100,6 +103,10 @@ export declare interface SerializedElementMap {
   'model': SerializedModel;
   'material': SerializedMaterial;
   'pbr-metallic-roughness': SerializedPBRMetallicRoughness;
+  'sampler': SerializedSampler;
+  'image': SerializedImage;
+  'texture': SerializedTexture;
+  'texture-info': SerializedTextureInfo;
 }
 
 /**
@@ -118,6 +125,8 @@ export declare interface SerializedThreeDOMElement {
 export declare interface SerializedPBRMetallicRoughness extends
     SerializedThreeDOMElement {
   baseColorFactor: RGBA;
+  baseColorTexture?: SerializedTextureInfo;
+  metallicRoughnessTexture?: SerializedTextureInfo;
 }
 
 /**
@@ -126,6 +135,27 @@ export declare interface SerializedPBRMetallicRoughness extends
  */
 export declare interface SerializedMaterial extends SerializedThreeDOMElement {
   pbrMetallicRoughness: SerializedPBRMetallicRoughness;
+}
+
+export declare interface SerializedSampler extends SerializedThreeDOMElement {
+  magFilter?: MagFilter;
+  minFilter?: MinFilter;
+  wrapS?: WrapMode;
+  wrapT?: WrapMode;
+}
+
+export declare interface SerializedImage extends SerializedThreeDOMElement {
+  uri?: string;
+}
+
+export declare interface SerializedTexture extends SerializedThreeDOMElement {
+  sampler?: SerializedSampler;
+  source?: SerializedImage;
+}
+
+export declare interface SerializedTextureInfo extends
+    SerializedThreeDOMElement {
+  texture?: SerializedTexture;
 }
 
 /**

--- a/packages/3dom/src/protocol.ts
+++ b/packages/3dom/src/protocol.ts
@@ -135,6 +135,9 @@ export declare interface SerializedPBRMetallicRoughness extends
  */
 export declare interface SerializedMaterial extends SerializedThreeDOMElement {
   pbrMetallicRoughness: SerializedPBRMetallicRoughness;
+  normalTexture?: SerializedTextureInfo;
+  occlusionTexture?: SerializedTextureInfo;
+  emissiveTexture?: SerializedTextureInfo;
 }
 
 export declare interface SerializedSampler extends SerializedThreeDOMElement {

--- a/packages/3dom/src/test-helpers.ts
+++ b/packages/3dom/src/test-helpers.ts
@@ -16,9 +16,10 @@
 import {EventDispatcher, Group} from 'three';
 import {GLTF as ThreeGLTF, GLTFLoader, GLTFParser} from 'three/examples/jsm/loaders/GLTFLoader.js';
 
-import {Material, Model, PBRMetallicRoughness, RGBA, ThreeDOMElement, ThreeDOMElementMap} from './api.js';
+import {Image, Material, Model, PBRMetallicRoughness, RGBA, Sampler, Texture, TextureInfo, ThreeDOMElement, ThreeDOMElementMap} from './api.js';
 import {ModelKernel} from './api/model-kernel.js';
-import {SerializedElementMap, SerializedMaterial, SerializedModel, SerializedPBRMetallicRoughness} from './protocol.js';
+import {MagFilter, MinFilter, WrapMode} from './gltf-2.0.js';
+import {SerializedElementMap, SerializedImage, SerializedMaterial, SerializedModel, SerializedPBRMetallicRoughness, SerializedSampler} from './protocol.js';
 
 export class FakePBRMetallicRoughness implements PBRMetallicRoughness {
   readonly baseColorFactor: RGBA = [0, 0, 0, 1];
@@ -39,7 +40,9 @@ export class FakePBRMetallicRoughness implements PBRMetallicRoughness {
   }
 }
 
-export class FakeMaterial implements Material {
+export class FakeThreeDOMElement implements ThreeDOMElement {}
+
+export class FakeMaterial extends FakeThreeDOMElement implements Material {
   readonly pbrMetallicRoughness = new FakePBRMetallicRoughness(
       this.kernel, this.serialized.pbrMetallicRoughness);
 
@@ -48,6 +51,7 @@ export class FakeMaterial implements Material {
   constructor(
       private kernel: ModelKernel, private serialized: SerializedMaterial,
       readonly name = `fake-material-${FakeMaterial.count++}`) {
+    super();
   }
 
   get ownerModel() {
@@ -55,13 +59,14 @@ export class FakeMaterial implements Material {
   }
 }
 
-export class FakeModel implements Model {
+export class FakeModel extends FakeThreeDOMElement implements Model {
   readonly materials: Readonly<Array<Material>>;
   private static count = 0;
 
   constructor(
       kernel: ModelKernel, serialized: SerializedModel,
       readonly name = `fake-model-${FakeModel.count++}`) {
+    super();
     const materials: Material[] = [];
     for (const material of serialized.materials) {
       materials.push(new FakeMaterial(kernel, material));
@@ -70,10 +75,87 @@ export class FakeModel implements Model {
   }
 }
 
+export class FakeImage extends FakeThreeDOMElement implements Image {
+  private static count = 0;
+  uri: string|null = null;
+
+  get type() {
+    return this.uri ? 'external' : 'embedded';
+  }
+
+  constructor(
+      _kernel: ModelKernel, _serialized: SerializedImage,
+      readonly name = `fake-image-${FakeImage.count++}`) {
+    super();
+  }
+
+  async setURI(uri: string): Promise<void> {
+    this.uri = uri;
+  }
+}
+
+export class FakeSampler extends FakeThreeDOMElement implements Sampler {
+  private static count = 0;
+
+  minFilter: MinFilter|null = null;
+  magFilter: MagFilter|null = null;
+  wrapS: WrapMode = 10497;
+  wrapT: WrapMode = 10497;
+
+  constructor(
+      _kernel: ModelKernel, serialized: SerializedSampler,
+      readonly name = serialized.name || `fake-image-${FakeSampler.count++}`) {
+    super();
+  }
+
+  async setMinFilter(filter: 9728|9729|9984|9985|9986|9987|
+                     null): Promise<void> {
+    this.minFilter = filter;
+  }
+
+  async setMagFilter(filter: 9728|9729|null): Promise<void> {
+    this.magFilter = filter;
+  }
+
+  async setWrapS(mode: WrapMode): Promise<void> {
+    this.wrapS = mode;
+  }
+
+  async setWrapT(mode: WrapMode): Promise<void> {
+    this.wrapT = mode;
+  }
+}
+
+export class FakeTexture extends FakeThreeDOMElement implements Texture {
+  sampler: Sampler|null = null;
+  source: Image|null = null;
+
+  async setSampler(sampler: Sampler): Promise<void> {
+    this.sampler = sampler;
+  }
+
+  async setSource(image: Image): Promise<void> {
+    this.source = image;
+  }
+}
+
+export class FakeTextureInfo extends FakeThreeDOMElement implements
+    TextureInfo {
+  texture: Texture|null = null;
+
+  async setTexture(texture: Texture|null): Promise<void> {
+    this.texture = texture;
+  }
+}
+
 export const FakeThreeDOMElementMap = {
   'model': FakeModel,
   'material': FakeMaterial,
-  'pbr-metallic-roughness': FakePBRMetallicRoughness
+  'pbr-metallic-roughness': FakePBRMetallicRoughness,
+  'image': FakeImage,
+  'sampler': FakeSampler,
+  'texture': FakeTexture,
+  'texture-info': FakeTextureInfo
 };
 
 export class FakeModelKernel implements ModelKernel {

--- a/packages/3dom/src/test-helpers.ts
+++ b/packages/3dom/src/test-helpers.ts
@@ -25,6 +25,9 @@ export class FakePBRMetallicRoughness implements PBRMetallicRoughness {
   readonly baseColorFactor: RGBA = [0, 0, 0, 1];
   private static count = 0;
 
+  readonly baseColorTexture = null;
+  readonly metallicRoughnessTexture = null;
+
   constructor(
       private kernel: ModelKernel, _serialized: SerializedPBRMetallicRoughness,
       readonly name = `fake-pbr-metallic-roughness-${
@@ -45,6 +48,10 @@ export class FakeThreeDOMElement implements ThreeDOMElement {}
 export class FakeMaterial extends FakeThreeDOMElement implements Material {
   readonly pbrMetallicRoughness = new FakePBRMetallicRoughness(
       this.kernel, this.serialized.pbrMetallicRoughness);
+
+  readonly normalTexture = null;
+  readonly occlusionTexture = null;
+  readonly emissiveTexture = null;
 
   private static count = 0;
 

--- a/packages/3dom/src/utilities.ts
+++ b/packages/3dom/src/utilities.ts
@@ -120,19 +120,25 @@ export class GLTFTreeVisitor {
   visit(gltf: GLTF, options: VisitOptions = {}) {
     const allScenes = !!options.allScenes;
     const sparse = !!options.sparse;
-    const scenes = allScenes ? gltf.scenes : [gltf.scenes[gltf.scene]];
+    const scenes = allScenes ?
+        gltf.scenes || [] :
+        (gltf.scenes && gltf.scene != null) ? [gltf.scenes[gltf.scene]] : [];
 
     const state: VisitorTraversalState =
         {hierarchy: [], visited: new Set(), sparse, gltf};
 
     for (const scene of scenes) {
-      this[$visitScene](gltf.scenes.indexOf(scene), state);
+      this[$visitScene](gltf.scenes!.indexOf(scene), state);
     }
   }
 
   private[$visitElement]<T extends GLTFElement>(
-      index: number, elementList: T[], state: VisitorTraversalState,
+      index: number, elementList: T[]|undefined, state: VisitorTraversalState,
       visit?: VisitorCallback<T>, traverse?: (element: T) => void) {
+    if (elementList == null) {
+      return;
+    }
+
     const element = elementList[index];
     const {sparse, hierarchy, visited} = state;
 


### PR DESCRIPTION
This change implements the first wave of capabilities related to configuring textures in the model. At this time, it supports configuring existing textures on the model. Textures can be configured by setting the URI of their associated source images. For example:

```typescript
self.addEventListener('model-change', () => {
  console.log('Got a new model:', self.model);

  model.materials[0]
      .pbrMetallicRoughness
      .baseColorTexture
      .texture
      .source
      .setURI(event.data.payload);
});
```

Any valid URI is supported. URIs for images that fail to load will result in a mutation error, and any associated mutations will not be applied to the source glTF. At this time, all material textures in the base glTF 2.0 spec can be configured.