### PR TITLE
reenable offscreen canvas

### DIFF
--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -44,9 +44,8 @@ export const IS_MOBILE = (() => {
 
 // Disabling offscreen canvas for now because it is slower and has bugs relating
 // to janky updates and out of sync frames.
-export const USE_OFFSCREEN_CANVAS = false;
-// Boolean((self as any).OffscreenCanvas) &&
-//     Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap);
+export const USE_OFFSCREEN_CANVAS = Boolean((self as any).OffscreenCanvas) &&
+    Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap);
 
 export const IS_ANDROID = /android/i.test(navigator.userAgent);
 

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -390,9 +390,9 @@ export default class ModelViewerElementBase extends UpdatingElement {
     const idealAspect = options ? options.idealAspect : undefined;
 
     const {width, height, model, aspect} = this[$scene];
-    const {dpr} = this[$renderer];
-    let outputWidth = width * dpr;
-    let outputHeight = height * dpr;
+    const {dpr, scaleFactor} = this[$renderer];
+    let outputWidth = width * scaleFactor * dpr;
+    let outputHeight = height * scaleFactor * dpr;
     let offsetX = 0;
     let offsetY = 0;
     if (idealAspect === true) {

--- a/packages/model-viewer/src/test/three-components/Renderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/Renderer-spec.ts
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import {USE_OFFSCREEN_CANVAS} from '../../constants.js';
 import ModelViewerElementBase, {$canvas, $onResize, $renderer, $userInputElement} from '../../model-viewer-base.js';
 import {ModelScene} from '../../three-components/ModelScene.js';
 import {Renderer} from '../../three-components/Renderer.js';
@@ -142,11 +143,19 @@ suite('Renderer', () => {
       renderer.unregisterScene(scene);
       renderer.render(performance.now());
 
-      expect(renderer.canvasElement.parentElement)
-          .to.be.eq(otherScene.element[$userInputElement]);
-      expect(renderer.canvasElement.classList.contains('show')).to.be.eq(true);
-      expect(otherScene.element[$canvas].classList.contains('show'))
-          .to.be.eq(false);
+      if (USE_OFFSCREEN_CANVAS) {
+        expect(renderer.canvasElement.classList.contains('show'))
+            .to.be.eq(false);
+        expect(otherScene.element[$canvas].classList.contains('show'))
+            .to.be.eq(true);
+      } else {
+        expect(renderer.canvasElement.parentElement)
+            .to.be.eq(otherScene.element[$userInputElement]);
+        expect(renderer.canvasElement.classList.contains('show'))
+            .to.be.eq(true);
+        expect(otherScene.element[$canvas].classList.contains('show'))
+            .to.be.eq(false);
+      }
     });
 
     suite('when resizing', () => {

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -303,7 +303,7 @@ export class Renderer extends EventDispatcher {
         visibleInput = scene.element[$userInputElement];
       }
     }
-    const multipleScenesVisible = visibleScenes > 1;
+    const multipleScenesVisible = visibleScenes > 1 || USE_OFFSCREEN_CANVAS;
     const {canvasElement} = this;
 
     if (multipleScenesVisible === this.multipleScenesVisible &&

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -97,6 +97,10 @@ export class Renderer extends EventDispatcher {
     return this.threeRenderer != null && this.context3D != null;
   }
 
+  get scaleFactor() {
+    return this.scale;
+  }
+
   constructor(options?: RendererOptions) {
     super();
 


### PR DESCRIPTION
I found a workaround for the offscreen canvas bug, where the dynamic render resize was briefly visible as you'd get a flash of wrong canvas scaling. This can be mitigated by forcing the offscreen canvas to go through the multi-scene render path where it does an extra copy. Interestingly, this is not noticeably slower, and seems to be less janky.

I had to make this change now due to another bug: I found ToBlob() gave blank output with OffscreenCanvas disabled (on Chrome). This was a quick fix, but I'm concerned that it may still not work on Firefox or other browsers without OffscreenCanvas. I need to investigate this more and determine whether this is a model-viewer or browser bug. 