### PR TITLE
updated Chrome and Edge to 83

### DIFF
--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -93,12 +93,12 @@ module.exports = function(config) {
         browser: 'Firefox',
         browser_version: 'latest',
       },
-      'Firefox 72.0': {
+      'Firefox 76.0': {
         base: 'BrowserStack',
         os: 'Windows',
         os_version: '10',
         browser: 'Firefox',
-        browser_version: '72.0',
+        browser_version: '76.0',
       },
       'Safari (latest)': {
         base: 'BrowserStack',

--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -79,12 +79,12 @@ module.exports = function(config) {
         browser: 'Edge',
         browser_version: 'latest',
       },
-      'Edge 79.0': {
+      'Edge 81.0': {
         base: 'BrowserStack',
         os: 'Windows',
         os_version: '10',
         browser: 'Edge',
-        browser_version: '80.0',
+        browser_version: '81.0',
       },
       'Firefox (latest)': {
         base: 'BrowserStack',

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -88,8 +88,7 @@ module.exports = function(config) {
 
     // Note setting --browsers on the command-line always overrides this list.
     browsers: [
-      // TODO(#1207)
-      // 'ChromeHeadless',
+      'ChromeHeadless',
     ],
   });
 
@@ -110,19 +109,19 @@ module.exports = function(config) {
       //   browser: 'Edge',
       //   browser_version: 'latest',
       // },
-      'Chrome 83.0 (Beta)': {
+      'Chrome 83.0': {
         base: 'BrowserStack',
         os: 'Windows',
         os_version: '10',
         browser: 'Chrome',
-        browser_version: '83.0 beta',
+        browser_version: '83.0',
       },
-      'Edge 83.0 (Beta)': {
+      'Edge 83.0': {
         base: 'BrowserStack',
         os: 'Windows',
         os_version: '10',
         browser: 'Edge',
-        browser_version: '83.0 beta',
+        browser_version: '83.0',
       },
       'Firefox (latest)': {
         base: 'BrowserStack',

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -130,12 +130,12 @@ module.exports = function(config) {
         browser: 'Firefox',
         browser_version: 'latest',
       },
-      'Firefox 72.0': {
+      'Firefox 76.0': {
         base: 'BrowserStack',
         os: 'Windows',
         os_version: '10',
         browser: 'Firefox',
-        browser_version: '72.0',
+        browser_version: '76.0',
       },
       'Safari (latest)': {
         base: 'BrowserStack',


### PR DESCRIPTION
Fixes #1207 

Interestingly, the `83.0 beta` we had been using started launching Chrome 84. Looks like Headless Chrome in Github actions has also been updated to 83 now, so that's reenabled. I also pushed out old Firefox version from 62 to 66, which looks to have removed a test flake I was seeing occasionally.