### PR TITLE
set radius limits to not clamp fidelity test configurations

### DIFF
--- a/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
+++ b/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
@@ -71,6 +71,8 @@
       modelViewer.src = scenario.model;
       modelViewer.skyboxImage = scenario.lighting;
       const {theta, phi, radius} = scenario.orbit;
+      modelViewer.minCameraOrbit = `auto auto ${radius}m`;
+      modelViewer.maxCameraOrbit = `auto auto ${radius}m`;
       modelViewer.cameraOrbit = `${theta}deg ${phi}deg ${radius}m`;
       const {x, y, z} = scenario.target;
       modelViewer.cameraTarget = `${x}m ${y}m ${z}m`;


### PR DESCRIPTION
This fixes Sponza, VC and SimpleMorph fidelity tests, which had the wrong camera position due to the radius being less than the default minimum. 