### PR TITLE
disable offscreenCanvas for ChromeOS

### DIFF
--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -42,10 +42,13 @@ export const IS_MOBILE = (() => {
   return check;
 })();
 
+export const IS_CHROMEOS = /CrOS\//.test(navigator.userAgent);
+
 // Disabling offscreen canvas for now because it is slower and has bugs relating
 // to janky updates and out of sync frames.
 export const USE_OFFSCREEN_CANVAS = Boolean((self as any).OffscreenCanvas) &&
-    Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap);
+    Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap) &&
+    !IS_CHROMEOS;  // TODO(elalish): file a bug on inverted renders
 
 export const IS_ANDROID = /android/i.test(navigator.userAgent);
 

--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -43,7 +43,6 @@ export const IS_MOBILE = (() => {
 })();
 
 export const IS_CHROMEOS = /\bCrOS\b/.test(navigator.userAgent);
-console.log(IS_CHROMEOS);
 
 // Disabling offscreen canvas for now because it is slower and has bugs relating
 // to janky updates and out of sync frames.

--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -42,7 +42,8 @@ export const IS_MOBILE = (() => {
   return check;
 })();
 
-export const IS_CHROMEOS = /CrOS\//.test(navigator.userAgent);
+export const IS_CHROMEOS = /\bCrOS\b/.test(navigator.userAgent);
+console.log(IS_CHROMEOS);
 
 // Disabling offscreen canvas for now because it is slower and has bugs relating
 // to janky updates and out of sync frames.


### PR DESCRIPTION
We noticed the renders were inverted on ChromeOS, but only when offscreenCanvas was enabled. This is now disabled for CrOS as a workaround; next we need to file a bug on Chrome.