### PR TITLE
round size to integer before comparison

### DIFF
--- a/packages/model-viewer/src/test/model-viewer-base-spec.ts
+++ b/packages/model-viewer/src/test/model-viewer-base-spec.ts
@@ -35,8 +35,8 @@ const expectBlobDimensions =
     img.src = url;
   });
 
-  expect(img.width).to.be.equal(width);
-  expect(img.height).to.be.equal(height);
+  expect(img.width).to.be.equal(Math.round(width));
+  expect(img.height).to.be.equal(Math.round(height));
 };
 
 suite('ModelViewerElementBase', () => {


### PR DESCRIPTION
This is to fix a flake we just started seeing in master on the toBlob dimensions test.