### PR TITLE
disable firefox76 testing

### DIFF
--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -130,13 +130,14 @@ module.exports = function(config) {
         browser: 'Firefox',
         browser_version: 'latest',
       },
-      'Firefox 76.0': {
-        base: 'BrowserStack',
-        os: 'Windows',
-        os_version: '10',
-        browser: 'Firefox',
-        browser_version: '76.0',
-      },
+      // TODO(#1207)
+      // 'Firefox 76.0': {
+      //   base: 'BrowserStack',
+      //   os: 'Windows',
+      //   os_version: '10',
+      //   browser: 'Firefox',
+      //   browser_version: '76.0',
+      // },
       'Safari (latest)': {
         base: 'BrowserStack',
         os: 'OS X',


### PR DESCRIPTION
We have a couple of test flakes that only seem to happen on Firefox 76, so disabling for now. This should be investigated further at a later date.