### PR TITLE
remove magic-leap and fallback docs

### DIFF
--- a/packages/model-viewer/src/model-viewer.ts
+++ b/packages/model-viewer/src/model-viewer.ts
@@ -19,7 +19,6 @@ import {ARMixin} from './features/ar.js';
 import {ControlsMixin} from './features/controls.js';
 import {EnvironmentMixin} from './features/environment.js';
 import {LoadingMixin} from './features/loading.js';
-import {MagicLeapMixin} from './features/magic-leap.js';
 import {SceneGraphMixin} from './features/scene-graph.js';
 import {StagingMixin} from './features/staging.js';
 import ModelViewerElementBase from './model-viewer-base.js';
@@ -29,10 +28,9 @@ import {FocusVisiblePolyfillMixin} from './utilities/focus-visible.js';
 // export {default as TextureUtils} from './three-components/TextureUtils';
 // export * from 'three';
 
-export const ModelViewerElement =
-    AnnotationMixin(SceneGraphMixin(MagicLeapMixin(StagingMixin(
-        EnvironmentMixin(ControlsMixin(ARMixin(LoadingMixin(AnimationMixin(
-            FocusVisiblePolyfillMixin(ModelViewerElementBase))))))))));
+export const ModelViewerElement = AnnotationMixin(SceneGraphMixin(StagingMixin(
+    EnvironmentMixin(ControlsMixin(ARMixin(LoadingMixin(AnimationMixin(
+        FocusVisiblePolyfillMixin(ModelViewerElementBase)))))))));
 
 export type ModelViewerElement = InstanceType<typeof ModelViewerElement>;
 

--- a/packages/model-viewer/src/test/index.ts
+++ b/packages/model-viewer/src/test/index.ts
@@ -43,7 +43,6 @@ import './features/controls-spec.js';
 import './features/environment-spec.js';
 import './features/loading-spec.js';
 import './features/loading/status-announcer-spec.js';
-import './features/magic-leap-spec.js';
 import './features/scene-graph-spec.js';
 import './features/ar-spec.js';
 

--- a/packages/modelviewer.dev/examples/animation.html
+++ b/packages/modelviewer.dev/examples/animation.html
@@ -60,7 +60,7 @@
         </div>
         <example-snippet stamp-to="demo-container-1" highlight-as="html">
           <template>
-  <model-viewer camera-controls autoplay ar ar-modes="webxr scene-viewer quick-look fallback" shadow-intensity="1" src="../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
+  <model-viewer camera-controls autoplay ar shadow-intensity="1" src="../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
           </template>
         </example-snippet>
       </div>
@@ -77,7 +77,7 @@
         </div>
         <example-snippet stamp-to="demo-container-2" highlight-as="html">
           <template>
-  <model-viewer camera-controls autoplay animation-name="Running" ar ar-modes="webxr scene-viewer quick-look fallback" shadow-intensity="1" src="../shared-assets/models/RobotExpressive.glb" alt="An animate 3D model of a robot"></model-viewer>
+  <model-viewer camera-controls autoplay animation-name="Running" ar shadow-intensity="1" src="../shared-assets/models/RobotExpressive.glb" alt="An animate 3D model of a robot"></model-viewer>
           </template>
         </example-snippet>
       </div>
@@ -94,7 +94,7 @@
         </div>
         <example-snippet stamp-to="demo-container-3" highlight-as="html">
           <template>
-  <model-viewer id="paused-change-demo" camera-controls autoplay animation-name="Running" ar ar-modes="webxr scene-viewer quick-look fallback" shadow-intensity="1" src="../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
+  <model-viewer id="paused-change-demo" camera-controls autoplay animation-name="Running" ar shadow-intensity="1" src="../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
   <script>
   (() => {
     const modelViewer = document.querySelector('#paused-change-demo');
@@ -121,7 +121,7 @@
         </div>
         <example-snippet stamp-to="demo-container-4" highlight-as="html">
           <template>
-  <model-viewer id="xfade-demo" camera-controls animation-name="Running" ar ar-modes="webxr scene-viewer quick-look fallback" shadow-intensity="1" src="../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
+  <model-viewer id="xfade-demo" camera-controls animation-name="Running" ar shadow-intensity="1" src="../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
   <script>
   (() => {
     const modelViewer = document.querySelector('#xfade-demo');

--- a/packages/modelviewer.dev/examples/augmented-reality.html
+++ b/packages/modelviewer.dev/examples/augmented-reality.html
@@ -55,11 +55,11 @@
         <a class="lockup" href="../index.html"><div class="icon-button icon-modelviewer-black"></div><h1>examples</h1></a>
         <div class="heading">
           <h2 class="demo-title">Augmented Reality</h2>
-          <h4>This demonstrates several augmented reality modes, including <code>webxr</code>, <code>scene-viewer</code>, <code>quick-look</code>, &amp; the accompanying attributes, <code>magic-leap</code>, <code>ios-src</code>, <code>quick-look-browsers</code>.</h4>
+          <h4>This demonstrates several augmented reality modes, including <code>webxr</code>, <code>scene-viewer</code>, <code>quick-look</code> &amp; the accompanying attributes, <code>ios-src</code>, <code>quick-look-browsers</code>.</h4>
         </div>
         <example-snippet stamp-to="demo-container-1" highlight-as="html">
           <template>
-<model-viewer src="../shared-assets/models/Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look fallback" ar-scale="auto" magic-leap camera-controls alt="A 3D model of an astronaut" skybox-image="../shared-assets/environments/aircraft_workshop_01_1k.hdr" ios-src="../shared-assets/models/Astronaut.usdz"></model-viewer>
+<model-viewer src="../shared-assets/models/Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" ar-scale="auto" camera-controls alt="A 3D model of an astronaut" skybox-image="../shared-assets/environments/aircraft_workshop_01_1k.hdr" ios-src="../shared-assets/models/Astronaut.usdz"></model-viewer>
           </template>
         </example-snippet>
 
@@ -76,9 +76,8 @@
             Augmented Reality</a>.
             Allowed values are "webxr", to launch the AR experience in the browser, "scene-viewer",
             to launch the <a href="https://developers.google.com/ar/develop/java/scene-viewer">Scene Viewer</a> 
-            app, "quick-look", to launch the iOS Quick Look app, and "fallback", to launch a fullscreen non-AR
-            experience in the event Scene Viewer fails to launch. You can specify any number of modes separated by
-            whitespace. Defaults to "webxr scene-viewer quick-look fallback".
+            app, "quick-look", to launch the iOS Quick Look app. You can specify any number of modes separated by
+            whitespace. Defaults to "webxr scene-viewer quick-look".
           </li>
           <li>
             <div>ar-scale</div>
@@ -100,10 +99,6 @@
               to launch AR Quick Look on iOS. Allowed values are "safari" and
               "chrome". You can specify any number of browsers separated by
               whitespace, for example: "safari chrome". Defaults to "safari".</p>
-          </li>
-          <li>
-            <div>magic-leap</div>
-            <p>Provides augmented reality on Magic Leap's Helio browser. Requires that the primary model be a GLB file, and the <a href="https://www.npmjs.com/package/@magicleap/prismatic">@magicleap/prismatic</a> library.</p>
           </li>
         </ul>
 

--- a/packages/modelviewer.dev/examples/fuzzer.html
+++ b/packages/modelviewer.dev/examples/fuzzer.html
@@ -124,10 +124,6 @@ const attributes = [{
         'i-do-not-exist.usdz',
     ],
 }, {
-    name: 'magic-leap',
-    probability: 0.2,
-    values: [],
-}, {
     name: 'preload',
     probability: 0.2,
     values: [],

--- a/packages/modelviewer.dev/examples/staging-and-camera-control.html
+++ b/packages/modelviewer.dev/examples/staging-and-camera-control.html
@@ -145,7 +145,7 @@
         </div>
         <example-snippet stamp-to="demo-container-5" highlight-as="html">
           <template>
-<model-viewer camera-controls auto-rotate src="../shared-assets/models/odd-shape-labeled.glb" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1" ar ar-modes="webxr scene-viewer quick-look fallback"></model-viewer>
+<model-viewer camera-controls auto-rotate src="../shared-assets/models/odd-shape-labeled.glb" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1" ar></model-viewer>
           </template>
         </example-snippet>
       </div>
@@ -162,7 +162,7 @@
         </div>
         <example-snippet stamp-to="demo-container-6" highlight-as="html">
           <template>
-<model-viewer camera-controls camera-target="0m 0m 0m" auto-rotate src="../shared-assets/models/odd-shape-labeled.glb" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1" ar ar-modes="webxr scene-viewer quick-look fallback"></model-viewer>
+<model-viewer camera-controls camera-target="0m 0m 0m" auto-rotate src="../shared-assets/models/odd-shape-labeled.glb" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1" ar></model-viewer>
           </template>
         </example-snippet>
       </div>

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -141,9 +141,8 @@
               Augmented Reality</a>.
               Allowed values are "webxr", to launch the AR experience in the browser, "scene-viewer",
               to launch the <a href="https://developers.google.com/ar/develop/java/scene-viewer">Scene Viewer</a> 
-              app, "quick-look", to launch the iOS Quick Look app, and "fallback", to launch a fullscreen non-AR
-              experience in the event Scene Viewer fails to launch. You can specify any number of modes separated by
-              whitespace. Defaults to "webxr scene-viewer quick-look fallback".
+              app, "quick-look", to launch the iOS Quick Look app. You can specify any number of modes separated by
+              whitespace. Defaults to "webxr scene-viewer quick-look".
             </li>
             <li>
               <div>ar-scale</div>
@@ -293,15 +292,6 @@
               Quick Look</a> on Safari. See <a
               href="https://github.com/GoogleWebComponents/model-viewer#augmented-reality">Augmented
               Reality</a>.</p>
-            </li>
-            <li>
-              <div>magic-leap</div>
-              <p>Enables the ability to view models in AR when viewing content
-              on <a href="https://magicleaphelio.com/">Magic Leap's Helio</a>
-              browser, requires that src is a GLB model, and requires the
-              inclusion of the <a
-              href="https://www.npmjs.com/package/@magicleap/prismatic">@magicleap/prismatic</a>
-              library.</p>
             </li>
             <li>
               <div>max-camera-orbit</div>


### PR DESCRIPTION
Making good on our promise to deprecate magic-leap, and also removing reference to the ar fallback which was removed from the code a few weeks ago. Also removed the `ar-modes` that were just set to the now default values.