### PR TITLE
3DOM metallicRoughness fix and extensions

### DIFF
--- a/packages/3dom/src/api.ts
+++ b/packages/3dom/src/api.ts
@@ -211,6 +211,16 @@ export declare interface PBRMetallicRoughness extends ThreeDOMElement {
   readonly baseColorFactor: Readonly<RGBA>;
 
   /**
+   * Metalness factor of the material, represented as number between 0 and 1
+   */
+  readonly metallicFactor: Readonly<number>;
+
+  /**
+   * Roughness factor of the material, represented as number between 0 and 1
+   */
+  readonly roughnessFactor: Readonly<number>;
+
+  /**
    * A texture reference, associating an image with color information and
    * a sampler for describing base color factor for a UV coordinate space.
    */
@@ -228,6 +238,18 @@ export declare interface PBRMetallicRoughness extends ThreeDOMElement {
    * Requires the 'material-properties' capability to be enabled.
    */
   setBaseColorFactor(rgba: RGBA): Promise<void>;
+
+   /**
+    * Changes the metalness factor of the material to the given value.
+    * Requires the 'material-properties' capability to be enabled.
+    */
+  setMetallicFactor(value: number): Promise<void>;
+
+   /**
+    * Changes the roughness factor of the material to the given value.
+    * Requires the 'material-properties' capability to be enabled.
+    */
+   setRoughnessFactor(value: number): Promise<void>;
 }
 
 /**

--- a/packages/3dom/src/api/material-spec.ts
+++ b/packages/3dom/src/api/material-spec.ts
@@ -25,7 +25,7 @@ suite('api/material', () => {
     test('yields a valid constructor', () => {
       const GeneratedConstructor = defineMaterial(ThreeDOMElement);
       const instance = new GeneratedConstructor(new FakeModelKernel(), {
-        pbrMetallicRoughness: {id: 1, baseColorFactor: [0, 0, 0, 1]},
+        pbrMetallicRoughness: {id: 1, baseColorFactor: [0, 0, 0, 1], metallicFactor: 0, roughnessFactor: 0},
         id: 0
       });
 
@@ -44,7 +44,7 @@ suite('api/material', () => {
 
       test('produces elements with the correct owner model', () => {
         const instance = new GeneratedConstructor(kernel, {
-          pbrMetallicRoughness: {id: 1, baseColorFactor: [0, 0, 0, 1]},
+          pbrMetallicRoughness: {id: 1, baseColorFactor: [0, 0, 0, 1], metallicFactor: 0, roughnessFactor: 0},
           id: 0
         });
 
@@ -53,7 +53,7 @@ suite('api/material', () => {
 
       test('expresses the material name when available', () => {
         const instance = new GeneratedConstructor(kernel, {
-          pbrMetallicRoughness: {id: 1, baseColorFactor: [0, 0, 0, 1]},
+          pbrMetallicRoughness: {id: 1, baseColorFactor: [0, 0, 0, 1], metallicFactor: 0, roughnessFactor: 0},
           id: 0,
           name: 'foo'
         });

--- a/packages/3dom/src/api/model-kernel-spec.ts
+++ b/packages/3dom/src/api/model-kernel-spec.ts
@@ -51,7 +51,7 @@ suite('api/model-kernel', () => {
         kernel.deactivate();
       });
 
-      suite('with a Model cntaining a Material', () => {
+      suite('with a Model containing a Material', () => {
         let kernel: ModelKernel;
 
         setup(() => {
@@ -62,7 +62,9 @@ suite('api/model-kernel', () => {
               id: getLocallyUniqueId(),
               pbrMetallicRoughness: {
                 id: getLocallyUniqueId(),
-                baseColorFactor: [0, 0, 0, 1] as RGBA
+                baseColorFactor: [0, 0, 0, 1] as RGBA,
+                metallicFactor: 0 as number,
+                roughnessFactor: 0 as number,
               }
             }],
             modelUri: ''

--- a/packages/3dom/src/api/pbr-metallic-roughness-spec.ts
+++ b/packages/3dom/src/api/pbr-metallic-roughness-spec.ts
@@ -26,7 +26,7 @@ suite('api/pbr-metallic-roughness', () => {
     test('yields a valid constructor', () => {
       const GeneratedConstructor = definePBRMetallicRoughness(ThreeDOMElement);
       const instance = new GeneratedConstructor(
-          new FakeModelKernel(), {id: 0, baseColorFactor: [0, 0, 0, 1]});
+          new FakeModelKernel(), {id: 0, baseColorFactor: [0, 0, 0, 1], metallicFactor: 0, roughnessFactor: 0});
 
       expect(instance).to.be.ok;
     });
@@ -35,7 +35,7 @@ suite('api/pbr-metallic-roughness', () => {
       const kernel = new FakeModelKernel();
       const GeneratedConstructor = definePBRMetallicRoughness(ThreeDOMElement);
       const instance = new GeneratedConstructor(
-          kernel, {id: 0, baseColorFactor: [0, 0, 0, 1]});
+          kernel, {id: 0, baseColorFactor: [0, 0, 0, 1], metallicFactor: 0, roughnessFactor: 0});
 
       expect(instance.ownerModel).to.be.equal(kernel.model);
     });
@@ -46,8 +46,11 @@ suite('api/pbr-metallic-roughness', () => {
             definePBRMetallicRoughness(ThreeDOMElement);
         const baseColorFactor: RGBA =
             [Math.random(), Math.random(), Math.random(), Math.random()];
+        const metallicFactor: number = Math.random();
+        const roughnessFactor: number = Math.random();
+
         const instance = new GeneratedConstructor(
-            new FakeModelKernel(), {id: 0, baseColorFactor});
+            new FakeModelKernel(), {id: 0, baseColorFactor, metallicFactor, roughnessFactor});
 
         expect(instance.baseColorFactor).to.be.deep.equal(baseColorFactor);
       });

--- a/packages/3dom/src/api/pbr-metallic-roughness.ts
+++ b/packages/3dom/src/api/pbr-metallic-roughness.ts
@@ -40,6 +40,8 @@ export function definePBRMetallicRoughness(
   const $baseColorFactor = Symbol('baseColorFactor');
   const $baseColorTexture = Symbol('baseColorTexture');
   const $metallicRoughnessTexture = Symbol('metallicRoughnessTexture');
+  const $metallicFactor = Symbol('metallicFactor');
+  const $roughnessFactor = Symbol('roughnessFactor');
 
   /**
    * PBRMetallicRoughness exposes the PBR properties for a given Material.
@@ -49,6 +51,8 @@ export function definePBRMetallicRoughness(
     protected[$kernel]: ModelKernel;
     protected[$baseColorFactor]: Readonly<RGBA>;
     protected[$baseColorTexture]: TextureInfo|null = null;
+    protected[$metallicFactor]: Readonly<number>;
+    protected[$roughnessFactor]: Readonly<number>;
     protected[$metallicRoughnessTexture]: TextureInfo|null = null;
 
     constructor(
@@ -58,6 +62,10 @@ export function definePBRMetallicRoughness(
       this[$kernel] = kernel;
       this[$baseColorFactor] =
           Object.freeze(serialized.baseColorFactor) as RGBA;
+      this[$metallicFactor] =
+          Object.freeze(serialized.metallicFactor) as number;
+      this[$roughnessFactor] =
+          Object.freeze(serialized.roughnessFactor) as number;
 
       const {baseColorTexture, metallicRoughnessTexture} = serialized;
 
@@ -79,6 +87,20 @@ export function definePBRMetallicRoughness(
       return this[$baseColorFactor];
     }
 
+    /**
+     * The metalness factor of the material in range [0,1].
+     */
+    get metallicFactor() {
+      return this[$metallicFactor];
+    }
+
+    /**
+     * The roughness factor of the material in range [0,1].
+     */
+    get roughnessFactor() {
+      return this[$roughnessFactor];
+    }
+
     get baseColorTexture() {
       return this[$baseColorTexture];
     }
@@ -96,6 +118,28 @@ export function definePBRMetallicRoughness(
     async setBaseColorFactor(color: RGBA) {
       await this[$kernel].mutate(this, 'baseColorFactor', color);
       this[$baseColorFactor] = Object.freeze(color) as RGBA;
+    }
+
+    /**
+     * Set the metallic factor of the material.
+     * Requires the material-properties capability.
+     *
+     * @see ../api.ts
+     */
+    async setMetallicFactor(color: number) {
+      await this[$kernel].mutate(this, 'metallicFactor', color);
+      this[$metallicFactor] = Object.freeze(color) as number;
+    }
+
+    /**
+     * Set the roughness factor of the material.
+     * Requires the material-properties capability.
+     *
+     * @see ../api.ts
+     */
+    async setRoughnessFactor(color: number) {
+      await this[$kernel].mutate(this, 'roughnessFactor', color);
+      this[$roughnessFactor] = Object.freeze(color) as number;
     }
   }
 

--- a/packages/3dom/src/context/generate-capability-filter.ts
+++ b/packages/3dom/src/context/generate-capability-filter.ts
@@ -58,6 +58,23 @@ function filterMaterialProperties(this: ThreeDOMGlobalScope) {
         configurable: false,
         writable: false
       });
+  Object.defineProperty(
+      this.PBRMetallicRoughness.prototype, 'setMetallicFactor', {
+        value: () => {
+          throw new Error(errorMessage);
+        },
+        configurable: false,
+        writable: false
+      });
+
+  Object.defineProperty(
+      this.PBRMetallicRoughness.prototype, 'setRoughnessFactor', {
+        value: () => {
+          throw new Error(errorMessage);
+        },
+        configurable: false,
+        writable: false
+      });
 }
 
 /**

--- a/packages/3dom/src/facade/api.ts
+++ b/packages/3dom/src/facade/api.ts
@@ -46,8 +46,12 @@ export interface ThreeDOMElement {
  */
 export interface PBRMetallicRoughness extends ThreeDOMElement {
   readonly baseColorFactor: RGBA;
+  readonly metallicFactor: number;
+  readonly roughnessFactor: number;
 
   mutate(property: 'baseColorFactor', value: RGBA): Promise<void>;
+  mutate(property: 'metallicFactor', value: number): Promise<void>;
+  mutate(property: 'roughnessFactor', value: number): Promise<void>;
 
   toJSON(): SerializedPBRMetallicRoughness;
 }

--- a/packages/3dom/src/facade/three-js/pbr-metallic-roughness.ts
+++ b/packages/3dom/src/facade/three-js/pbr-metallic-roughness.ts
@@ -79,6 +79,14 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
         [1, 1, 1, 1];
   }
 
+  get metallicFactor(): number {
+    return (this.sourceObject as PBRMetallicRoughness).metallicFactor || 0;
+  }
+
+  get roughnessFactor(): number {
+    return (this.sourceObject as PBRMetallicRoughness).roughnessFactor || 0;
+  }
+
   get baseColorTexture() {
     return this[$baseColorTexture];
   }
@@ -87,30 +95,47 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
     return this[$metallicRoughnessTexture];
   }
 
-  async mutate(property: 'baseColorFactor', value: RGBA): Promise<void> {
-    if (property !== 'baseColorFactor') {
+  async mutate(property: 'baseColorFactor' | 'metallicFactor' | 'roughnessFactor', value: RGBA | number): Promise<void> {
+    if (!['baseColorFactor', 'metallicFactor', 'roughnessFactor'].includes(property)) {
       throw new Error(`Cannot mutate ${property} on PBRMetallicRoughness`);
     }
+    switch(property) {
+      case 'baseColorFactor':
+        for (const material of this[$threeMaterials]) {
+          material.color.fromArray(value as RGBA);
+          material.opacity = (value as RGBA)[3];
 
-    for (const material of this[$threeMaterials]) {
-      material.color.fromArray(value);
-      material.opacity = value[3];
+          const pbrMetallicRoughness =
+              this[$sourceObject] as GLTFPBRMetallicRoughness;
 
-      const pbrMetallicRoughness =
-          this[$sourceObject] as GLTFPBRMetallicRoughness;
-
-      if (value[0] === 1 && value[1] === 1 && value[2] === 1 &&
-          value[3] === 1) {
-        delete pbrMetallicRoughness.baseColorFactor;
-      } else {
-        pbrMetallicRoughness.baseColorFactor = value;
-      }
+          if (value as RGBA[0] === 1 && value as RGBA[1] === 1 && value as RGBA[2] === 1 &&
+              value as RGBA[3] === 1) {
+            delete pbrMetallicRoughness.baseColorFactor;
+          } else {
+            pbrMetallicRoughness.baseColorFactor = value as RGBA;
+          }
+        }
+        break;
+      case 'metallicFactor':
+        for (const material of this[$threeMaterials]) {
+          material.metalness = value as number;
+          const pbrMetallicRoughness = this[$sourceObject] as GLTFPBRMetallicRoughness;
+          pbrMetallicRoughness.metallicFactor = value as number;
+        }
+        break;
+      case 'roughnessFactor':
+        for (const material of this[$threeMaterials]) {
+          material.roughness = value as number;
+          const pbrMetallicRoughness = this[$sourceObject] as GLTFPBRMetallicRoughness;
+          pbrMetallicRoughness.roughnessFactor = value as number;
+        }
+        break;
     }
   }
 
   toJSON(): SerializedPBRMetallicRoughness {
     const serialized: Partial<SerializedPBRMetallicRoughness> = super.toJSON();
-    const {baseColorTexture, metallicRoughnessTexture, baseColorFactor} = this;
+    const {baseColorTexture, metallicRoughnessTexture, baseColorFactor, roughnessFactor, metallicFactor} = this;
 
     if (baseColorTexture != null) {
       serialized.baseColorTexture = baseColorTexture.toJSON();
@@ -118,6 +143,14 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
 
     if (baseColorFactor != null) {
       serialized.baseColorFactor = baseColorFactor;
+    }
+
+    if (metallicFactor != null) {
+      serialized.metallicFactor = metallicFactor;
+    }
+
+    if (roughnessFactor != null) {
+      serialized.roughnessFactor = roughnessFactor;
     }
 
     if (metallicRoughnessTexture != null) {

--- a/packages/3dom/src/facade/three-js/pbr-metallic-roughness.ts
+++ b/packages/3dom/src/facade/three-js/pbr-metallic-roughness.ts
@@ -110,7 +110,7 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
 
   toJSON(): SerializedPBRMetallicRoughness {
     const serialized: Partial<SerializedPBRMetallicRoughness> = super.toJSON();
-    const {baseColorTexture, baseColorFactor} = this;
+    const {baseColorTexture, metallicRoughnessTexture, baseColorFactor} = this;
 
     if (baseColorTexture != null) {
       serialized.baseColorTexture = baseColorTexture.toJSON();
@@ -118,6 +118,10 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
 
     if (baseColorFactor != null) {
       serialized.baseColorFactor = baseColorFactor;
+    }
+
+    if (metallicRoughnessTexture != null) {
+      serialized.metallicRoughnessTexture = metallicRoughnessTexture.toJSON();
     }
 
     return serialized as SerializedPBRMetallicRoughness;

--- a/packages/3dom/src/protocol.ts
+++ b/packages/3dom/src/protocol.ts
@@ -125,6 +125,8 @@ export declare interface SerializedThreeDOMElement {
 export declare interface SerializedPBRMetallicRoughness extends
     SerializedThreeDOMElement {
   baseColorFactor: RGBA;
+  metallicFactor: number;
+  roughnessFactor: number;
   baseColorTexture?: SerializedTextureInfo;
   metallicRoughnessTexture?: SerializedTextureInfo;
 }

--- a/packages/3dom/src/test-helpers.ts
+++ b/packages/3dom/src/test-helpers.ts
@@ -23,6 +23,8 @@ import {SerializedElementMap, SerializedImage, SerializedMaterial, SerializedMod
 
 export class FakePBRMetallicRoughness implements PBRMetallicRoughness {
   readonly baseColorFactor: RGBA = [0, 0, 0, 1];
+  readonly metallicFactor = 0;
+  readonly roughnessFactor = 0;
   private static count = 0;
 
   readonly baseColorTexture = null;
@@ -39,6 +41,14 @@ export class FakePBRMetallicRoughness implements PBRMetallicRoughness {
   }
 
   setBaseColorFactor(_value: RGBA) {
+    return Promise.resolve();
+  }
+
+  setMetallicFactor(_value: number) {
+    return Promise.resolve();
+  }
+
+  setRoughnessFactor(_value: number) {
     return Promise.resolve();
   }
 }


### PR DESCRIPTION
I've been checking out the new 3dom API to edit textures at runtime and i realized that metallicRoughness texture was not being serialized to the worklet, resulting in a runtime exception when trying to set a new texture.

I haven't created a new issue since this should be an open-and-shut case. Let me know if it's required.
