### PR TITLE
Remove fullscreen polyfill

### DIFF
--- a/packages/model-viewer/POLYFILLS.md
+++ b/packages/model-viewer/POLYFILLS.md
@@ -27,7 +27,6 @@ Feature                    | Chrome | Canary | Safari 12 | Firefox 65 | Edge | I
 ---------------------------|--------|--------|-----------|------------|------|-------|------------------
 Resize Observer[¹](1)      |     ✅ |     ✅ |        ✋ |         ✋ |   ✋ |   ✋ |               ✅
 Intersection Observer[²](2)|     ✅ |     ✅ |        ✋ |         ✅ |   ✅ |   ✋ |               ✅
-Fullscreen API[³](3)       |     ✅ |     ✅ |        ✋ |         ✅ |   ✋ |   ✋ |               ✋
 `:focus-visible`[⁴](4)     |     ✋ |     ✋ |        ✋ |         ✋ |   ✋ |   ✋ |               ✋
 
 These browser features are **optional** and are only needed if you wish to use
@@ -41,7 +40,6 @@ WebXR HitTest API          |     🚧 |     ✅ |        🚫 |         🚫 |  
 
 [1]: https://github.com/PolymerLabs/model-viewer/blob/master/POLYFILLS.md#regarding-resize-observer
 [2]: https://github.com/PolymerLabs/model-viewer/blob/master/POLYFILLS.md#regarding-intersection-observer
-[3]: https://github.com/PolymerLabs/model-viewer/blob/master/POLYFILLS.md#regarding-fullscreen-api
 [4]: https://github.com/PolymerLabs/model-viewer/blob/master/POLYFILLS.md#regarding-focus-visible
 
 ### Regarding IE 11
@@ -66,7 +64,6 @@ The following emerging web platform APIs are *optional*, and will be used by
 
  - [Resize Observer](https://wicg.github.io/ResizeObserver/) ([CanIUse](https://caniuse.com/#feat=resizeobserver), [Chrome Platform Status](https://www.chromestatus.com/features/5705346022637568))
  - [Intersection Observer](https://w3c.github.io/IntersectionObserver/) ([CanIUse](https://caniuse.com/#feat=intersectionobserver), [Chrome Platform Status](https://www.chromestatus.com/features/5695342691483648))
- - [Fullscreen API](https://fullscreen.spec.whatwg.org/) ([CanIUse](https://caniuse.com/#feat=fullscreen), [Chrome Platform Status](https://www.chromestatus.com/features/6596356319739904))
  - [`:focus-visible`]() ([CanIUse](https://caniuse.com/#feat=css-focus-visible), [Chrome Platform Status](https://chromestatus.com/features/5823526732824576))
 
 Additionally, the following _highly experimental and volatile_ APIs are needed
@@ -84,23 +81,10 @@ fine. The following is a selection of recommended polyfill implementations:
  - [Web Components Polyfill](https://github.com/webcomponents/webcomponentsjs) (includes Custom Elements and Shadow DOM)
  - [Resize Observer Polyfill](https://github.com/que-etc/resize-observer-polyfill)
  - [Intersection Observer Polyfill](https://github.com/w3c/IntersectionObserver/tree/master/polyfill)
- - [Fullscreen Polyfill](https://github.com/nguyenj/fullscreen-polyfill)
  - [`:focus-visible` Polyfill](https://github.com/WICG/focus-visible)
 
 Please keep in mind that your mileage may vary depending on the browsers you
 need to support and the fidelity of the polyfills used.
-
-### Regarding Fullscreen API
-
-The Fullscreen API is necessary for AR use cases. Currently, it is  necessary
-for the experimental Web XR Device API-based AR mode. Since this is only
-available behind a flag in Chrome Dev today, it is not necessary to load a
-Fullscreen API polyfill in production scenarios.
-
-**Importantly:** Fullscreen API is used as a fallback when Scene Viewer fails
-to launch on Android. If you do not include a polyfill for this API, the AR
-button may appear to do nothing on Samsung Internet and other browsers like it
-that do not have Fullscreen API yet.
 
 ### Regarding Resize Observer
 
@@ -156,7 +140,6 @@ this NPM command:
 ```
 npm i --save @webcomponents/webcomponentsjs \
              resize-observer-polyfill \
-             fullscreen-polyfill \
              intersection-observer
 ```
 
@@ -179,9 +162,6 @@ the rest of your application code:
 
     <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
     <script src="./node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
-
-    <!-- 💁 OPTIONAL: Fullscreen polyfill is required for experimental AR features in Canary -->
-    <script src="./node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
 
     <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
     <script src="./node_modules/focus-visible/dist/focus-visible.js" defer></script>
@@ -227,9 +207,6 @@ recommended polyfills and `<model-viewer>`:
 
     <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
     <script src="https://unpkg.com/resize-observer-polyfill@1.5.0/dist/ResizeObserver.js"></script>
-
-    <!-- 💁 OPTIONAL: Fullscreen polyfill is required for experimental AR features in Canary -->
-    <script src="https://unpkg.com/fullscreen-polyfill@1.0.2/dist/fullscreen.polyfill.js"></script>
 
     <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
     <script src="https://unpkg.com/focus-visible@5.0.1/dist/focus-visible.js" defer></script>

--- a/packages/model-viewer/package-lock.json
+++ b/packages/model-viewer/package-lock.json
@@ -11685,12 +11685,6 @@
       "dev": true,
       "optional": true
     },
-    "fullscreen-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fullscreen-polyfill/-/fullscreen-polyfill-1.0.2.tgz",
-      "integrity": "sha512-E+GiRov/4L8hDQKo430ijaTFx4fM2ErBZMN0gzg3W1v0gJzG2bIvvcgNLV+kReF+f8vC++SzrzCzGsqDxGpEDA==",
-      "dev": true
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -79,7 +79,6 @@
     "@webcomponents/webcomponentsjs": "~2.1.3",
     "chai": "^4.1.2",
     "focus-visible": "^5.0.1",
-    "fullscreen-polyfill": "^1.0.2",
     "http-server": "^0.12.1",
     "intersection-observer": "^0.5.1",
     "karma": "^5.0.2",

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -349,7 +349,7 @@ canvas.show {
       <slot name="exit-webxr-ar-button">
         <a id="default-exit-webxr-ar-button"
             tabindex="3"
-            aria-label="Exit fullscreen"
+            aria-label="Exit AR"
             aria-hidden="true">
           ${CloseIcon}
         </a>

--- a/packages/modelviewer.dev/examples/accessibility.html
+++ b/packages/modelviewer.dev/examples/accessibility.html
@@ -34,9 +34,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: Include prismatic.js for Magic Leap support -->
   <!--<script src="../node_modules/@magicleap/prismatic/prismatic.min.js"></script>-->
 

--- a/packages/modelviewer.dev/examples/add.html
+++ b/packages/modelviewer.dev/examples/add.html
@@ -34,9 +34,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/animation.html
+++ b/packages/modelviewer.dev/examples/animation.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/annotations.html
+++ b/packages/modelviewer.dev/examples/annotations.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/augmented-reality.html
+++ b/packages/modelviewer.dev/examples/augmented-reality.html
@@ -103,6 +103,23 @@
     </div>
   </div>
 
+  <div class="sample">
+    <div id="demo-container-2" class="demo"></div>
+    <div class="content">
+      <div class="wrapper">
+        <div class="heading">
+          <h2 class="demo-title">Scene Viewer</h2>
+          <h4>Here AR is restricted to the Scene Viewer app, to make it easier to compare this with WebXR, above.</h4>
+        </div>
+        <example-snippet stamp-to="demo-container-2" highlight-as="html">
+          <template>
+<model-viewer src="../shared-assets/models/Astronaut.glb" ar ar-modes="scene-viewer" ar-scale="auto" camera-controls alt="A 3D model of an astronaut" skybox-image="../shared-assets/environments/aircraft_workshop_01_1k.hdr"></model-viewer>
+          </template>
+        </example-snippet>
+      </div>
+    </div>
+  </div>
+
   <div class="footer">
     <ul>
       <li class="attribution">

--- a/packages/modelviewer.dev/examples/augmented-reality.html
+++ b/packages/modelviewer.dev/examples/augmented-reality.html
@@ -35,9 +35,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/customizing-ui.html
+++ b/packages/modelviewer.dev/examples/customizing-ui.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 </head>

--- a/packages/modelviewer.dev/examples/fuzzer.html
+++ b/packages/modelviewer.dev/examples/fuzzer.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/lazy-loading.html
+++ b/packages/modelviewer.dev/examples/lazy-loading.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/lighting-and-environment.html
+++ b/packages/modelviewer.dev/examples/lighting-and-environment.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/list.html
+++ b/packages/modelviewer.dev/examples/list.html
@@ -35,9 +35,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/model-formats.html
+++ b/packages/modelviewer.dev/examples/model-formats.html
@@ -35,9 +35,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/multiple-elements.html
+++ b/packages/modelviewer.dev/examples/multiple-elements.html
@@ -35,9 +35,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/rendering-showcase.html
+++ b/packages/modelviewer.dev/examples/rendering-showcase.html
@@ -35,9 +35,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/scene-graph.html
+++ b/packages/modelviewer.dev/examples/scene-graph.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/staging-and-camera-control.html
+++ b/packages/modelviewer.dev/examples/staging-and-camera-control.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/tester.html
+++ b/packages/modelviewer.dev/examples/tester.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/examples/webxr.html
+++ b/packages/modelviewer.dev/examples/webxr.html
@@ -35,9 +35,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -36,9 +36,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="node_modules/focus-visible/dist/focus-visible.js" defer></script>
 
@@ -782,16 +779,6 @@
               <td><img class="icon-warning"></td>
               <td><img class="icon-check"></td>
               <td><img class="icon-check"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-check"></td>
-            </tr>
-            <tr>
-              <td>Fullscreen API</td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-warning"></td>
               <td><img class="icon-warning"></td>
               <td><img class="icon-check"></td>
             </tr>

--- a/packages/modelviewer.dev/package-lock.json
+++ b/packages/modelviewer.dev/package-lock.json
@@ -11813,10 +11813,6 @@
           "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
           "optional": true
         },
-        "fullscreen-polyfill": {
-          "version": "https://registry.npmjs.org/fullscreen-polyfill/-/fullscreen-polyfill-1.0.2.tgz",
-          "integrity": "sha512-E+GiRov/4L8hDQKo430ijaTFx4fM2ErBZMN0gzg3W1v0gJzG2bIvvcgNLV+kReF+f8vC++SzrzCzGsqDxGpEDA=="
-        },
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -20121,11 +20117,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fullscreen-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fullscreen-polyfill/-/fullscreen-polyfill-1.0.2.tgz",
-      "integrity": "sha512-E+GiRov/4L8hDQKo430ijaTFx4fM2ErBZMN0gzg3W1v0gJzG2bIvvcgNLV+kReF+f8vC++SzrzCzGsqDxGpEDA=="
     },
     "function-bind": {
       "version": "1.1.1",

--- a/packages/modelviewer.dev/package.json
+++ b/packages/modelviewer.dev/package.json
@@ -23,7 +23,6 @@
     "@types/resize-observer-browser": "^0.1.2",
     "@webcomponents/webcomponentsjs": "~2.1.3",
     "focus-visible": "^5.0.1",
-    "fullscreen-polyfill": "^1.0.2",
     "intersection-observer": "^0.5.1",
     "lit-element": "^2.2.1",
     "prismjs": "^1.15.0",

--- a/packages/modelviewer.dev/scripts/ci-before-deploy.sh
+++ b/packages/modelviewer.dev/scripts/ci-before-deploy.sh
@@ -35,8 +35,6 @@ DEPLOYABLE_STATIC_FILES=( \
   node_modules/@google/model-viewer/dist \
   node_modules/focus-visible \
   node_modules/intersection-observer \
-  node_modules/@magicleap \
-  node_modules/fullscreen-polyfill \
   node_modules/resize-observer-polyfill \
   shared-assets/models/*.glb \
   shared-assets/models/*.gltf \

--- a/packages/render-fidelity-tools/package-lock.json
+++ b/packages/render-fidelity-tools/package-lock.json
@@ -11842,10 +11842,6 @@
           "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
           "optional": true
         },
-        "fullscreen-polyfill": {
-          "version": "https://registry.npmjs.org/fullscreen-polyfill/-/fullscreen-polyfill-1.0.2.tgz",
-          "integrity": "sha512-E+GiRov/4L8hDQKo430ijaTFx4fM2ErBZMN0gzg3W1v0gJzG2bIvvcgNLV+kReF+f8vC++SzrzCzGsqDxGpEDA=="
-        },
         "function-bind": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -20537,11 +20533,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fullscreen-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fullscreen-polyfill/-/fullscreen-polyfill-1.0.2.tgz",
-      "integrity": "sha512-E+GiRov/4L8hDQKo430ijaTFx4fM2ErBZMN0gzg3W1v0gJzG2bIvvcgNLV+kReF+f8vC++SzrzCzGsqDxGpEDA=="
     },
     "function-bind": {
       "version": "1.1.1",

--- a/packages/render-fidelity-tools/package.json
+++ b/packages/render-fidelity-tools/package.json
@@ -33,7 +33,6 @@
     "@webcomponents/webcomponentsjs": "~2.1.3",
     "filament": "1.5.2",
     "focus-visible": "^5.0.1",
-    "fullscreen-polyfill": "^1.0.2",
     "http-server": "^0.12.1",
     "intersection-observer": "^0.5.1",
     "lit-element": "^2.2.1",

--- a/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
+++ b/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
@@ -30,9 +30,6 @@
   <!-- 💁 OPTIONAL: Resize Observer polyfill improves resize behavior in non-Chrome browsers -->
   <script src="../../../node_modules/resize-observer-polyfill/dist/ResizeObserver.js"></script>
 
-  <!-- 💁 OPTIONAL: Fullscreen polyfill is needed to fully support AR features -->
-  <script src="../../../node_modules/fullscreen-polyfill/dist/fullscreen.polyfill.js"></script>
-
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../../../node_modules/focus-visible/dist/focus-visible.js" defer></script>
 


### PR DESCRIPTION
This was vestigial, and seemed to be causing problems on IE11. I also added a SceneViewer example to the augmented-reality page to make it easier to compare to WebXR (and since the fullscreen polyfill was originally to help SceneViewer when it failed to launch). 