### PR TITLE
deploy IE11 builds to github pages

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -41,6 +41,9 @@ jobs:
     - name: Build packages
       run: npm run build
 
+    - name: Generate legacy bundles
+      run: npm run build:legacy-support
+
     - name: Generate fidelity artifacts 
       uses: GabrielBB/xvfb-action@v1.0
       with:


### PR DESCRIPTION
I just noticed that modelviewer.dev has not been loading on IE11 because we were neglecting to build the legacy bundles during our deployment step. This has probably been broken for a while. 