### PR TITLE
disable offscreenCanvas

### DIFF
--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -46,9 +46,10 @@ export const IS_CHROMEOS = /\bCrOS\b/.test(navigator.userAgent);
 
 // Disabling offscreen canvas for now because it is slower and has bugs relating
 // to janky updates and out of sync frames.
-export const USE_OFFSCREEN_CANVAS = Boolean((self as any).OffscreenCanvas) &&
-    Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap) &&
-    !IS_CHROMEOS;  // TODO(elalish): file a bug on inverted renders
+export const USE_OFFSCREEN_CANVAS = false;
+// Boolean((self as any).OffscreenCanvas) &&
+//     Boolean((self as any).OffscreenCanvas.prototype.transferToImageBitmap) &&
+//     !IS_CHROMEOS;  // TODO(elalish): file a bug on inverted renders
 
 export const IS_ANDROID = /android/i.test(navigator.userAgent);
 


### PR DESCRIPTION
There are just too many bugs to continue using this for now. We already had to disable it for ChromeOS because the renders were upside-down. Now it turns out it also fails to render over chrome remote desktop. It has no measurable performance benefit, so really it is only needed in order to move rendering off the main thread. Since that's a ways out anyway, we'll disable, file Chrome bugs and revisit when those are fixed. 