### PR TITLE
fix relative urls

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -20,7 +20,7 @@ import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_
 import ModelViewerElementBase, {$renderer, $scene} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
 import {ARStatus} from '../three-components/ARRenderer.js';
-import {Constructor, deserializeUrl} from '../utilities.js';
+import {Constructor} from '../utilities.js';
 
 /**
  * Takes a URL to a USDZ file and sets the appropriate fields so that Safari
@@ -149,9 +149,7 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
     @property({type: String, attribute: 'ar-modes'})
     arModes: string = DEFAULT_AR_MODES;
 
-    @property(
-        {converter: {fromAttribute: deserializeUrl}, attribute: 'ios-src'})
-    iosSrc: string|null = null;
+    @property({type: String, attribute: 'ios-src'}) iosSrc: string|null = null;
 
     @property({type: String, attribute: 'quick-look-browsers'})
     quickLookBrowsers: string = 'safari';

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -32,7 +32,7 @@ export const openIOSARQuickLook = (() => {
   anchor.appendChild(document.createElement('img'));
 
   return (usdzSrc: string, arScale: string) => {
-    const modelUrl = new URL(usdzSrc);
+    const modelUrl = new URL(usdzSrc, self.location.toString());
     if (arScale === 'fixed') {
       modelUrl.hash = 'allowsContentScaling=0';
     }
@@ -58,7 +58,7 @@ export const openSceneViewer = (() => {
 
     const location = self.location.toString();
     const locationUrl = new URL(location);
-    const modelUrl = new URL(gltfSrc);
+    const modelUrl = new URL(gltfSrc, location);
     const scheme = modelUrl.protocol.replace(':', '');
 
     locationUrl.hash = noArViewerSigil;

--- a/packages/model-viewer/src/features/environment.ts
+++ b/packages/model-viewer/src/features/environment.ts
@@ -40,18 +40,10 @@ export declare interface EnvironmentInterface {
 export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
     ModelViewerElement: T): Constructor<EnvironmentInterface>&T => {
   class EnvironmentModelViewerElement extends ModelViewerElement {
-    @property({
-      type: String,
-      attribute: 'environment-image',
-      converter: {fromAttribute: deserializeUrl}
-    })
+    @property({type: String, attribute: 'environment-image'})
     environmentImage: string|null = null;
 
-    @property({
-      type: String,
-      attribute: 'skybox-image',
-      converter: {fromAttribute: deserializeUrl}
-    })
+    @property({type: String, attribute: 'skybox-image'})
     skyboxImage: string|null = null;
 
     @property({type: Number, attribute: 'shadow-intensity'})
@@ -124,8 +116,8 @@ export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
         const {environmentMap, skybox} =
             await new Promise(async (resolve, reject) => {
               const texturesLoad = textureUtils.generateEnvironmentMapAndSkybox(
-                  skyboxImage,
-                  environmentImage,
+                  deserializeUrl(skyboxImage),
+                  deserializeUrl(environmentImage),
                   {progressTracker: this[$progressTracker]});
               this[$cancelEnvironmentUpdate] = () => reject(texturesLoad);
               resolve(await texturesLoad);

--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -18,7 +18,7 @@ import {property} from 'lit-element';
 import ModelViewerElementBase, {$announceModelVisibility, $ariaLabel, $getLoaded, $getModelIsVisible, $isElementInViewport, $progressTracker, $updateSource, $userInputElement} from '../model-viewer-base.js';
 import {$loader, CachingGLTFLoader} from '../three-components/CachingGLTFLoader.js';
 import {ModelViewerGLTFInstance} from '../three-components/gltf-instance/ModelViewerGLTFInstance.js';
-import {Constructor, deserializeUrl, throttle} from '../utilities.js';
+import {Constructor, throttle} from '../utilities.js';
 
 import {LoadingStatusAnnouncer} from './loading/status-announcer.js';
 
@@ -179,8 +179,7 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
      * A URL pointing to the image to use as a poster in scenarios where the
      * <model-viewer> is not ready to reveal a rendered model to the viewer.
      */
-    @property({converter: {fromAttribute: deserializeUrl}})
-    poster: string|null = null;
+    @property({type: String}) poster: string|null = null;
 
     /**
      * An enumerable attribute describing under what conditions the

--- a/packages/model-viewer/src/test/model-viewer-base-spec.ts
+++ b/packages/model-viewer/src/test/model-viewer-base-spec.ts
@@ -307,8 +307,7 @@ suite('ModelViewerElementBase', () => {
         test('idealAspect gives the proper blob dimensions', async () => {
           const basicBlob = await element.toBlob();
           const idealBlob = await element.toBlob({idealAspect: true});
-          const idealHeight =
-              Math.round(32 / element[$scene].model.fieldOfViewAspect);
+          const idealHeight = 32 / element[$scene].model.fieldOfViewAspect;
 
           const {dpr, scaleFactor} = element[$renderer];
           const f = dpr * scaleFactor;


### PR DESCRIPTION
Fixes #1286 

The problem was relative vs. absolute URLs. This problem was introduced by the fix to another bug where URLs were being converted from relative to absolute when set as attributes, but not when set from JS. Turns out we were doing a similar thing in other parts of the code, so all the URL handling has been updated here.