### PR TITLE
fix NaN progress

### DIFF
--- a/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
+++ b/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
@@ -38,7 +38,9 @@ export const loadWithLoader =
      loader: GLTFLoader,
      progressCallback: ProgressCallback = () => {}) => {
       const onProgress = (event: ProgressEvent) => {
-        progressCallback!(Math.max(0, Math.min(1, event.loaded / event.total)));
+        const fraction = event.loaded / event.total;
+        progressCallback!(
+            Math.max(0, Math.min(1, Number.isFinite(fraction) ? fraction : 1)));
       };
       return new Promise<GLTF>((resolve, reject) => {
         loader.load(url, resolve, onProgress, reject);

--- a/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
+++ b/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
@@ -39,8 +39,8 @@ export const loadWithLoader =
      progressCallback: ProgressCallback = () => {}) => {
       const onProgress = (event: ProgressEvent) => {
         const fraction = event.loaded / event.total;
-        progressCallback!(
-            Math.max(0, Math.min(1, Number.isFinite(fraction) ? fraction : 1)));
+        progressCallback!
+            (Math.max(0, Math.min(1, isFinite(fraction) ? fraction : 1)));
       };
       return new Promise<GLTF>((resolve, reject) => {
         loader.load(url, resolve, onProgress, reject);


### PR DESCRIPTION
Fixes #1332 

Since the progress was NaN, our state machine never saw loading as completed, even though it had.