### PR TITLE
Make sure we remove tsbuildinfo cache upon clean

### DIFF
--- a/packages/editing-adapter/package.json
+++ b/packages/editing-adapter/package.json
@@ -8,7 +8,7 @@
     "build": "npm run build:tsc && npm run build:rollup",
     "build:tsc": "tsc --incremental && cp src/gltf/*.d.ts lib/gltf",
     "build:rollup": "rollup -c --environment NODE_ENV:production",
-    "clean": "rm -rf lib && rm -rf dist",
+    "clean": "rm tsconfig.tsbuildinfo; rm -rf lib && rm -rf dist",
     "test": "karma start --single-run",
     "test:ci": "npm run test",
     "update:package-lock": "rm ./package-lock.json; npm i --only=production",

--- a/packages/space-opera/package.json
+++ b/packages/space-opera/package.json
@@ -8,7 +8,7 @@
     "build": "npm run build:tsc && npm run build:rollup",
     "build:tsc": "tsc --incremental",
     "build:rollup": "rollup -c --environment NODE_ENV:production",
-    "clean": "rm -rf lib && rm -rf dist",
+    "clean": "rm tsconfig.tsbuildinfo; rm -rf lib && rm -rf dist",
     "test": "karma start --single-run",
     "test:ci": "npm run test",
     "prepare": "if [ ! -L './shared-assets' ]; then ln -s ./node_modules/@google/model-viewer-shared-assets ./shared-assets; fi",


### PR DESCRIPTION
..otherwise, build won't work after a clean, because tsc --incremental will assume there's nothing to be done (given the tsbuildinfo is still there).