### PR TITLE
set timer for model-viewer's model-ready event

### DIFF
--- a/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
+++ b/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
@@ -58,7 +58,11 @@
 
       modelViewer.addEventListener('model-visibility', (event) => {
         if (event.detail.visible) {
-          self.dispatchEvent(new CustomEvent('model-ready'));
+          //TODO: this is a temporary workaround for taking screenshots before the model has been loaded
+          //This will be fixed when the screenshot function is refactored.
+          setTimeout(()=>{
+            self.dispatchEvent(new CustomEvent('model-ready'));
+          }, 300);
         }
       }, { once: true });
       

--- a/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
+++ b/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
@@ -62,7 +62,7 @@
           //This will be fixed when the screenshot function is refactored.
           setTimeout(()=>{
             self.dispatchEvent(new CustomEvent('model-ready'));
-          }, 300);
+          }, 500);
         }
       }, { once: true });
       


### PR DESCRIPTION
A temporary workaround for model-viewer's golden is taken before the model is actually loaded. 
