### PR TITLE
Fix scene-graph for Safari

### DIFF
--- a/packages/3dom/src/facade/api.ts
+++ b/packages/3dom/src/facade/api.ts
@@ -131,7 +131,7 @@ export interface Model extends ThreeDOMElement {
  *
  * @see ../context.ts
  */
-export interface ModelGraft extends EventTarget {
+export interface ModelGraft {
   /**
    * A flat list of all unique materials found in this scene graph.
    *

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -51,6 +51,7 @@ template.innerHTML = `
   width: 100%;
   height: 100%;
   display: block;
+  position: relative;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Fixes #1379

This fix was just a one-liner; apparently `overflow:hidden` is only respected on Safari in combination with `position:relative`. In the process I discovered a larger issue where the scene-graph was not working in Safari, which is also fixed here. Safari doesn't implement EventTarget, so I had to copy a hack from another part of model-viewer. What troubles me most is that our scene-graph-spec should have caught this on our Safari tests. I still have no idea how it passed.