### PR TITLE
fixed texture asset paths

### DIFF
--- a/packages/modelviewer.dev/examples/scene-graph.html
+++ b/packages/modelviewer.dev/examples/scene-graph.html
@@ -176,17 +176,17 @@ modelViewerParameters.addEventListener("scene-graph-ready", (ev) => {
     <div>
       <p>Diffuse</p>
       <select id="diffuse">
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/Lantern/T_LanternPole_a.png">Lantern Pole</option>
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/DamagedHelmet/Default_albedo.jpg">Damaged helmet</option>
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/WaterBottle/WaterBottle_BaseColor.png">Water Bottle</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_baseColor.png">Lantern Pole</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_albedo.jpg">Damaged helmet</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_baseColor.png">Water Bottle</option>
       </select>
     </div>
     <div>
       <p>Metallic-roughness</p>
       <select id="metallicRoughness">
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/Lantern/T_LanternPole_mr.png">Lantern Pole</option>
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/DamagedHelmet/Default_metalRoughness.jpg">Damaged helmet</option>
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/WaterBottle/WaterBottle_MetalSmooth.png">Water Bottle</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_roughnessMetallic.png">Lantern Pole</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_metalRoughness.jpg">Damaged helmet</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
       </select>
     </div>
   </div>
@@ -233,24 +233,24 @@ modelViewerTexture.addEventListener("scene-graph-ready", (ev) => {
     <div>
       <p>Normals</p>
       <select id="normals">
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/DamagedHelmet/Default_normal.jpg">Damaged helmet</option>
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/Lantern/T_LanternPole_n.png">Lantern Pole</option>
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/WaterBottle/WaterBottle_Normal.png">Water Bottle</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_normal.jpg">Damaged helmet</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_normal.png">Lantern Pole</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_normal.png">Water Bottle</option>
       </select>
     </div>
     <div>
       <p>Occlusion</p>
       <select id="occlusion">
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/DamagedHelmet/Default_AO.jpg">Damaged helmet</option>
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/WaterBottle/WaterBottle_Occlusion.png">Water Bottle</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_AO.jpg">Damaged helmet</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
       </select>
     </div>
     <div>
       <p>Emission</p>
       <select id="emission">
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/DamagedHelmet/Default_emissive.jpg">Damaged helmet</option>
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/Lantern/T_LanternPole_e.png">Lantern Pole</option>
-        <option value="../shared-assets/models/glTF-Sample-Models/sourceModels/WaterBottle/WaterBottle_Emissive.png">Water Bottle</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_emissive.jpg">Damaged helmet</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_emissive.png">Lantern Pole</option>
+        <option value="../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_emissive.png">Water Bottle</option>
       </select>
     </div>
   </div>


### PR DESCRIPTION
The texture switching wasn't working in our scene-graph examples because they used paths that aren't served on our dev pages. I've updated them to point to the 2.0 folder instead of sourceModels.