### PR TITLE
make poster cover hotspots

### DIFF
--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -117,6 +117,7 @@ canvas.show {
 }
 
 .slot.poster {
+  z-index: 1000;
   opacity: 0;
   transition: opacity 0.3s 0.3s;
   background-color: inherit;
@@ -270,6 +271,7 @@ canvas.show {
 }
 
 .slot.default {
+  z-index: 1001;
   pointer-events: none;
 }
 


### PR DESCRIPTION
During release testing I noticed the poster doesn't cover the hotspots, so in the annotations example when the model loaded, the annotations would snap into place while the model faded in, which was slightly jarring. This is a very simple fix, which will only work as long as there are less than 1,000 hotspots on a given model, but at that point there are probably bigger problems. 