### PR TITLE
Update CI browser versions

### DIFF
--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -124,16 +124,6 @@ module.exports = function(config) {
         // instances, causing them to time out:
         url: 'http://127.0.0.1:9876'
       },
-      'Safari 12.1': {
-        base: 'BrowserStack',
-        os: 'OS X',
-        os_version: 'Mojave',
-        browser: 'safari',
-        browser_version: '12.1',
-        // BrowserStack occassionally fails to tunnel localhost for Safari
-        // instances, causing them to time out:
-        url: 'http://127.0.0.1:9876'
-      },
       'iOS Safari (iOS 13)': {
         base: 'BrowserStack',
         os: 'iOS',

--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -72,6 +72,20 @@ module.exports = function(config) {
     }
 
     const browserStackLaunchers = {
+      'Chrome (latest)': {
+        base: 'BrowserStack',
+        os: 'Windows',
+        os_version: '10',
+        browser: 'Chrome',
+        browser_version: 'latest',
+      },
+      'Chrome (latest-1)': {
+        base: 'BrowserStack',
+        os: 'Windows',
+        os_version: '10',
+        browser: 'Chrome',
+        browser_version: 'latest-1',
+      },
       'Edge (latest)': {
         base: 'BrowserStack',
         os: 'Windows',
@@ -79,12 +93,12 @@ module.exports = function(config) {
         browser: 'Edge',
         browser_version: 'latest',
       },
-      'Edge 81.0': {
+      'Edge (latest-1)': {
         base: 'BrowserStack',
         os: 'Windows',
         os_version: '10',
         browser: 'Edge',
-        browser_version: '81.0',
+        browser_version: 'latest-1',
       },
       'Firefox (latest)': {
         base: 'BrowserStack',
@@ -93,12 +107,12 @@ module.exports = function(config) {
         browser: 'Firefox',
         browser_version: 'latest',
       },
-      'Firefox 76.0': {
+      'Firefox (latest-1)': {
         base: 'BrowserStack',
         os: 'Windows',
         os_version: '10',
         browser: 'Firefox',
-        browser_version: '76.0',
+        browser_version: 'latest-1',
       },
       'Safari (latest)': {
         base: 'BrowserStack',
@@ -120,18 +134,17 @@ module.exports = function(config) {
         // instances, causing them to time out:
         url: 'http://127.0.0.1:9876'
       },
-      // 'iOS Safari (iOS 13)': {
-      //   base: 'BrowserStack',
-      //   os: 'iOS',
-      //   os_version: '13',
-      //   device: 'iPhone 8',
-      //   browser: 'iPhone',
-      //   real_mobile: 'true',
-      //   // BrowserStack seems to drop the port when redirecting to this
-      //   special
-      //   // domain so we go there directly instead:
-      //   url: 'http://bs-local.com:9876'
-      // },
+      'iOS Safari (iOS 13)': {
+        base: 'BrowserStack',
+        os: 'iOS',
+        os_version: '13',
+        device: 'iPhone 8',
+        browser: 'iPhone',
+        real_mobile: 'true',
+        // BrowserStack seems to drop the port when redirecting to this special
+        // domain so we go there directly instead:
+        url: 'http://bs-local.com:9876'
+      },
       'iOS Safari (iOS 12)': {
         base: 'BrowserStack',
         os: 'iOS',

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -101,27 +101,33 @@ module.exports = function(config) {
     }
 
     const browserStackLaunchers = {
-      // TODO(#1207)
-      // 'Edge (latest)': {
-      //   base: 'BrowserStack',
-      //   os: 'Windows',
-      //   os_version: '10',
-      //   browser: 'Edge',
-      //   browser_version: 'latest',
-      // },
-      'Chrome 83.0': {
+      'Chrome (latest)': {
         base: 'BrowserStack',
         os: 'Windows',
         os_version: '10',
         browser: 'Chrome',
-        browser_version: '83.0',
+        browser_version: 'latest',
       },
-      'Edge 83.0': {
+      'Chrome (latest-1)': {
+        base: 'BrowserStack',
+        os: 'Windows',
+        os_version: '10',
+        browser: 'Chrome',
+        browser_version: 'latest-1',
+      },
+      'Edge (latest)': {
         base: 'BrowserStack',
         os: 'Windows',
         os_version: '10',
         browser: 'Edge',
-        browser_version: '83.0',
+        browser_version: 'latest',
+      },
+      'Edge (latest-1)': {
+        base: 'BrowserStack',
+        os: 'Windows',
+        os_version: '10',
+        browser: 'Edge',
+        browser_version: 'latest-1',
       },
       'Firefox (latest)': {
         base: 'BrowserStack',
@@ -130,14 +136,13 @@ module.exports = function(config) {
         browser: 'Firefox',
         browser_version: 'latest',
       },
-      // TODO(#1207)
-      // 'Firefox 76.0': {
-      //   base: 'BrowserStack',
-      //   os: 'Windows',
-      //   os_version: '10',
-      //   browser: 'Firefox',
-      //   browser_version: '76.0',
-      // },
+      'Firefox (latest-1)': {
+        base: 'BrowserStack',
+        os: 'Windows',
+        os_version: '10',
+        browser: 'Firefox',
+        browser_version: 'latest-1',
+      },
       'Safari (latest)': {
         base: 'BrowserStack',
         os: 'OS X',

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -153,16 +153,6 @@ module.exports = function(config) {
         // instances, causing them to time out:
         url: 'http://127.0.0.1:9876'
       },
-      'Safari 12.1': {
-        base: 'BrowserStack',
-        os: 'OS X',
-        os_version: 'Mojave',
-        browser: 'safari',
-        browser_version: '12.1',
-        // BrowserStack occassionally fails to tunnel localhost for Safari
-        // instances, causing them to time out:
-        url: 'http://127.0.0.1:9876'
-      },
       'iOS Safari (iOS 13)': {
         base: 'BrowserStack',
         os: 'iOS',

--- a/packages/modelviewer.dev/scripts/ci-before-deploy.sh
+++ b/packages/modelviewer.dev/scripts/ci-before-deploy.sh
@@ -52,6 +52,7 @@ DEPLOYABLE_STATIC_FILES=( \
   shared-assets/models/glTF-Sample-Models/2.0/MetalRoughSpheres \
   shared-assets/models/glTF-Sample-Models/2.0/Suzanne \
   shared-assets/models/glTF-Sample-Models/2.0/SpecGlossVsMetalRough \
+  shared-assets/models/glTF-Sample-Models/2.0/WaterBottle \
   shared-assets/environments \
   shared-assets/icons \
   node_modules/@google/model-viewer-space-opera/node_modules/web-animations-js/web-animations-next-lite.min.js \


### PR DESCRIPTION
These were out of date from the days when Chrome 81 was giving our unit tests headaches. Also added the WaterBottle to stop modelviewer.dev from getting 404s. 