### PR TITLE
update browser support tables

### DIFF
--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -135,17 +135,6 @@ module.exports = function(config) {
         // domain so we go there directly instead:
         url: 'http://bs-local.com:9876'
       },
-      'iOS Safari (iOS 12)': {
-        base: 'BrowserStack',
-        os: 'iOS',
-        os_version: '12',
-        device: 'iPhone 7',
-        browser: 'iPhone',
-        real_mobile: 'true',
-        // BrowserStack seems to drop the port when redirecting to this special
-        // domain so we go there directly instead:
-        url: 'http://bs-local.com:9876'
-      },
     };
 
     config.set({

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -164,17 +164,6 @@ module.exports = function(config) {
         // domain so we go there directly instead:
         url: 'http://bs-local.com:9876'
       },
-      'iOS Safari (iOS 12)': {
-        base: 'BrowserStack',
-        os: 'iOS',
-        os_version: '12',
-        device: 'iPhone 7',
-        browser: 'iPhone',
-        real_mobile: 'true',
-        // BrowserStack seems to drop the port when redirecting to this special
-        // domain so we go there directly instead:
-        url: 'http://bs-local.com:9876'
-      },
 
     };
 

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -722,10 +722,10 @@
           <h3 class="grouping-title border-bottom">Browser Support</h3>
 
           <div id="browser-support-icon-group">
-            <div class="icon-desc"><img class="size-24 icon-check"><div>Natively supported</div></div>
-            <div class="icon-desc"><img class="size-24 icon-warning"><div>Available with polyfill</div></div>
-            <div class="icon-desc"><img class="size-24 icon-flag"><div>Behind a flag, unstable</div></div>
-            <div class="icon-desc"><img class="size-24 icon-na"><div>Not available</div></div>
+            <div class="icon-desc"><img class="size-24 icon-check" alt="icon-check"><div>Natively supported</div></div>
+            <div class="icon-desc"><img class="size-24 icon-warning" alt="icon-warning"><div>Available with polyfill</div></div>
+            <div class="icon-desc"><img class="size-24 icon-flag" alt="icon-flag"><div>Behind a flag, unstable</div></div>
+            <div class="icon-desc"><img class="size-24 icon-na" alt="icon-na"><div>Not available</div></div>
           </div>
 
           <div style="clear:both"></div>
@@ -738,31 +738,31 @@
               <th>Feature</th>
               <th><img class="logo-chrome" title="Chrome" alt="Chrome"></th>
               <th><img class="logo-canary" title="Canary" alt="Canary"></th>
-              <th><img class="logo-safari" title="Safari 12" alt="Safari 12"></th>
-              <th><img class="logo-firefox" title="Firefox 65" alt="Firefox 65"></th>
+              <th><img class="logo-safari" title="Safari" alt="Safari"></th>
+              <th><img class="logo-firefox" title="Firefox" alt="Firefox"></th>
               <th><img class="logo-edge" title="Edge" alt="Edge"></th>
               <th><img class="logo-ie" title="IE 11" alt="IE 11"></th>
-              <th><img class="logo-samsung" title="Samsung Internet"></th>
+              <th><img class="logo-samsung" title="Samsung Internet" alt="Samsung Internet"></th>
             </tr>
             <tr>
               <td>Custom Elements</td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
             </tr>
             <tr>
               <td>Shadow DOM</td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
             </tr>
           </table>
 
@@ -774,41 +774,41 @@
               <th>Feature</th>
               <th><img class="logo-chrome" title="Chrome" alt="Chrome"></th>
               <th><img class="logo-canary" title="Canary" alt="Canary"></th>
-              <th><img class="logo-safari" title="Safari 12" alt="Safari 12"></th>
-              <th><img class="logo-firefox" title="Firefox 65" alt="Firefox 65"></th>
+              <th><img class="logo-safari" title="Safari" alt="Safari"></th>
+              <th><img class="logo-firefox" title="Firefox" alt="Firefox"></th>
               <th><img class="logo-edge" title="Edge" alt="Edge"></th>
               <th><img class="logo-ie" title="IE 11" alt="IE 11"></th>
-              <th><img class="logo-samsung" title="Samsung Internet"></th>
+              <th><img class="logo-samsung" title="Samsung Internet" alt="Samsung Internet"></th>
             </tr>
             <tr>
               <td>Resize Observer</td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
             </tr>
             <tr>
               <td>Intersection Observer</td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
             </tr>
             <tr>
               <td>:focus-visible</td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
-              <td><img class="icon-warning"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
+              <td><img class="icon-warning" alt="icon-warning"></td>
             </tr>
           </table>
 
@@ -820,32 +820,32 @@
               <th>Feature</th>
               <th><img class="logo-chrome" title="Chrome" alt="Chrome"></th>
               <th><img class="logo-canary" title="Canary" alt="Canary"></th>
-              <th><img class="logo-safari" title="Safari 12" alt="Safari 12"></th>
-              <th><img class="logo-firefox" title="Firefox 65" alt="Firefox 65"></th>
+              <th><img class="logo-safari" title="Safari" alt="Safari"></th>
+              <th><img class="logo-firefox" title="Firefox" alt="Firefox"></th>
               <th><img class="logo-edge" title="Edge" alt="Edge"></th>
               <th><img class="logo-ie" title="IE 11" alt="IE 11"></th>
-              <th><img class="logo-samsung" title="Samsung Internet"></th>
+              <th><img class="logo-samsung" title="Samsung Internet" alt="Samsung Internet"></th>
             </tr>
 
             <tr>
               <td>WebXR Device API</td>
-              <td><img class="icon-flag"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-na"></td>
-              <td><img class="icon-na"></td>
-              <td><img class="icon-na"></td>
-              <td><img class="icon-na"></td>
-              <td><img class="icon-na"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-na" alt="icon-na"></td>
+              <td><img class="icon-na" alt="icon-na"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-na" alt="icon-na"></td>
+              <td><img class="icon-na" alt="icon-na"></td>
             </tr>
             <tr>
               <td>WebXR HitTest API</td>
-              <td><img class="icon-flag"></td>
-              <td><img class="icon-check"></td>
-              <td><img class="icon-na"></td>
-              <td><img class="icon-na"></td>
-              <td><img class="icon-na"></td>
-              <td><img class="icon-na"></td>
-              <td><img class="icon-na"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-na" alt="icon-na"></td>
+              <td><img class="icon-na" alt="icon-na"></td>
+              <td><img class="icon-check" alt="icon-check"></td>
+              <td><img class="icon-na" alt="icon-na"></td>
+              <td><img class="icon-na" alt="icon-na"></td>
             </tr>
           </table>
 


### PR DESCRIPTION
Fixes #1157 

Also fixed the support tables not being legible in Firefox; for some reason alt tags fixed it.

Also turned off Mobile Safari 12 testing, as it's been getting too flaky and 14 is nearly out.