### PR TITLE
replace hdr file path in unit testing

### DIFF
--- a/packages/model-viewer/src/test/features/environment-spec.ts
+++ b/packages/model-viewer/src/test/features/environment-spec.ts
@@ -24,7 +24,7 @@ import {assetPath, rafPasses, textureMatchesMeta, timePasses, waitForEvent} from
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;
-const ALT_BG_IMAGE_URL = assetPath('environments/grey.png');
+const ALT_BG_IMAGE_URL = assetPath('environments/white_furnace.hdr');
 const BG_IMAGE_URL = assetPath('environments/spruit_sunrise_1k_LDR.jpg');
 const HDR_BG_IMAGE_URL = assetPath('environments/spruit_sunrise_1k_HDR.hdr');
 const MODEL_URL = assetPath('models/reflective-sphere.gltf');


### PR DESCRIPTION
Switch the unit test to point to the new hdr file path. Looks like all test passed. 

Do you also want me to add the "cheat" dspbr golden of furnace test in this pr? If so, i should remove dspbr from exclude, right?