### PR TITLE
Quicklook link event / anchor

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -37,6 +37,23 @@ export const openIOSARQuickLook = (() => {
       modelUrl.hash = 'allowsContentScaling=0';
     }
     anchor.setAttribute('href', modelUrl.toString());
+    // one option: add directly to event listener here,
+    // make a message handler for model-viewer that can be attached to
+    // unclear: where to add handler, openIOSARQuickLook is export const right
+    // now but events should be on the ARMixin?
+    /*
+    anchor.addEventListener("message", (event: Event) => {
+      if ((<MessageEvent>event).data == "_apple_ar_quicklook_button_tapped") {
+        alert("user tapped on link: " + event.target + ", opening page");
+        console.log("user tapped on link: " + event.target + ", opening page");
+      }
+    }, true);
+    */
+    // another option: correctly configure the a tag
+    // (so that it's clear for which modelviewer this was) and add it to the DOM
+    // unclear: how to add it only once?
+    anchor.setAttribute('class', 'modelviewer-quicklook-button');
+    document.body.appendChild(anchor);
     anchor.click();
   };
 })();


### PR DESCRIPTION
I started adding a fix (or, actually two options) for the issues with iOS QuickLook links that need to be catched from the anchor tags QuickLook has been launched. 
I'm unclear how to proceed, though; 

**Option 1**: adding proper event handling so that one can attach a custom listener to the modelviewer instance (preferred)
Questions: currently it seems events should be in the ARMixin, however openIOSARQuickLook lives outside of the mixin. Not sure what the correct way is to add this event.

**Option 2**: adding the anchor to the DOM.
Questions: if that is done I think it should be added as a child of the AR Button (?), and not just in "body". Also, should it be cached internally to make sure it's not added multiple times?

### Reference Issues
Fixes #1030 
Fixes #1314