### PR TITLE
Fix editor poster generation

### DIFF
--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -447,7 +447,8 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     async[$updateSource]() {
       this[$lastReportedProgress] = 0;
-      if (this[$scene].model.currentGLTF == null || this.src == null) {
+      if (this[$scene].model.currentGLTF == null || this.src == null ||
+          !this[$shouldAttemptPreload]()) {
         // Don't show the poster when switching models.
         this[$showPoster]();
       }

--- a/packages/space-opera/src/components/camera_settings/camera_settings.ts
+++ b/packages/space-opera/src/components/camera_settings/camera_settings.ts
@@ -47,7 +47,7 @@ const dispatchCameraControlsEnabled = registerStateMutator(
     });
 
 // Orbit
-const dispatchSaveCameraOrbit =
+export const dispatchSaveCameraOrbit =
     registerStateMutator('SAVE_CAMERA_ORBIT', (state) => {
       if (!state.currentCamera)
         return;
@@ -219,7 +219,7 @@ export class CameraSettings extends ConnectedLitElement {
   }
 
   onSaveCameraOrbit() {
-    dispatchSaveCameraOrbit(true);
+    dispatchSaveCameraOrbit();
   }
 
   onCameraTargetChange(newValue: Vector3D) {

--- a/packages/space-opera/src/components/poster_controls/poster_controls.ts
+++ b/packages/space-opera/src/components/poster_controls/poster_controls.ts
@@ -26,6 +26,7 @@ import {customElement, html, internalProperty} from 'lit-element';
 
 import {dispatchSetPoster} from '../../redux/poster_dispatchers.js';
 import {State} from '../../redux/space_opera_base.js';
+import {dispatchSaveCameraOrbit} from '../camera_settings/camera_settings.js';
 import {ConnectedLitElement} from '../connected_lit_element/connected_lit_element.js';
 
 import {styles} from './poster_controls.css';
@@ -78,6 +79,7 @@ export class PosterControlsElement extends ConnectedLitElement {
     const posterUrl =
         createSafeObjectURL(await this.modelViewer.toBlob({idealAspect: true}));
     dispatchSetPoster(posterUrl.unsafeUrl);
+    dispatchSaveCameraOrbit();
   }
 
   onDisplayPoster() {


### PR DESCRIPTION
Fixes #1428 

In fact this was a regression that also affected the old interactive example, so both are now fixed. I also updated the editor to set the initial camera when creating a poster, like the interactive example does.