### PR TITLE
Improve auto fidelity test

### DIFF
--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -416,25 +416,31 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
 
         // We might need to forward focus to our internal canvas, but that
         // cannot happen until the poster has completely transitioned away
-        posterContainerElement.addEventListener('transitionend', () => {
-          requestAnimationFrame(() => {
-            this[$transitioned] = true;
-            const root = this.getRootNode();
+        posterContainerElement.addEventListener(
+            'transitionend',
+            () => {// use two raf to make sure that everything here happened on
+                   // the the frame when the poster is completed faded away
+                   requestAnimationFrame(() => {
+                     requestAnimationFrame(() => {
+                       this[$transitioned] = true;
+                       const root = this.getRootNode();
 
-            // If the <model-viewer> is still focused, forward the focus to
-            // the canvas that has just been revealed
-            if (root &&
-                (root as Document | ShadowRoot).activeElement === this) {
-              this[$userInputElement].focus();
-            }
+                       // If the <model-viewer> is still focused, forward the
+                       // focus to the canvas that has just been revealed
+                       if (root &&
+                           (root as Document | ShadowRoot).activeElement ===
+                               this) {
+                         this[$userInputElement].focus();
+                       }
 
-            // Ensure that the poster is no longer focusable or visible to
-            // screen readers
-            defaultPosterElement.setAttribute('aria-hidden', 'true');
-            defaultPosterElement.tabIndex = -1;
-            this.dispatchEvent(new CustomEvent('poster-dismissed'));
-          });
-        }, {once: true});
+                       // Ensure that the poster is no longer focusable or
+                       // visible to screen readers
+                       defaultPosterElement.setAttribute('aria-hidden', 'true');
+                       defaultPosterElement.tabIndex = -1;
+                       this.dispatchEvent(new CustomEvent('poster-dismissed'));
+                     });
+                   })},
+            {once: true});
       }
     }
 

--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -416,31 +416,25 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
 
         // We might need to forward focus to our internal canvas, but that
         // cannot happen until the poster has completely transitioned away
-        posterContainerElement.addEventListener(
-            'transitionend',
-            () => {// use two raf to make sure that everything here happened on
-                   // the the frame when the poster is completed faded away
-                   requestAnimationFrame(() => {
-                     requestAnimationFrame(() => {
-                       this[$transitioned] = true;
-                       const root = this.getRootNode();
+        posterContainerElement.addEventListener('transitionend', () => {
+          requestAnimationFrame(() => {
+            this[$transitioned] = true;
+            const root = this.getRootNode();
 
-                       // If the <model-viewer> is still focused, forward the
-                       // focus to the canvas that has just been revealed
-                       if (root &&
-                           (root as Document | ShadowRoot).activeElement ===
-                               this) {
-                         this[$userInputElement].focus();
-                       }
+            // If the <model-viewer> is still focused, forward the focus to
+            // the canvas that has just been revealed
+            if (root &&
+                (root as Document | ShadowRoot).activeElement === this) {
+              this[$userInputElement].focus();
+            }
 
-                       // Ensure that the poster is no longer focusable or
-                       // visible to screen readers
-                       defaultPosterElement.setAttribute('aria-hidden', 'true');
-                       defaultPosterElement.tabIndex = -1;
-                       this.dispatchEvent(new CustomEvent('poster-dismissed'));
-                     });
-                   })},
-            {once: true});
+            // Ensure that the poster is no longer focusable or visible to
+            // screen readers
+            defaultPosterElement.setAttribute('aria-hidden', 'true');
+            defaultPosterElement.tabIndex = -1;
+            this.dispatchEvent(new CustomEvent('poster-dismissed'));
+          });
+        }, {once: true});
       }
     }
 

--- a/packages/render-fidelity-tools/src/artifact-creator.ts
+++ b/packages/render-fidelity-tools/src/artifact-creator.ts
@@ -77,7 +77,7 @@ export class ArtifactCreator {
             scenarioName,
             dimensions,
             join(scenarioOutputDirectory, 'model-viewer.png'),
-            10);
+            60);
       } catch (error) {
         const errorMessage =
             `❌ Failed to capture model-viewer's screenshot of ${

--- a/packages/render-fidelity-tools/src/artifact-creator.ts
+++ b/packages/render-fidelity-tools/src/artifact-creator.ts
@@ -93,8 +93,16 @@ export class ArtifactCreator {
         continue;
       }
 
-      const analysisResults =
-          await this.analyze(screenshot, goldens, scenario, dimensions);
+      let analysisResults;
+      try {
+        analysisResults =
+            await this.analyze(screenshot, goldens, scenario, dimensions);
+      } catch (error) {
+        const errorMessage = `Fail to analyze scenario :${
+            scenarioName}! Error message: ${error.message}`;
+        modelViewerFidelityErrors.push(errorMessage);
+        continue;
+      }
 
       const modelViewerIndex = 0;
       const modelViewerRmsInDb =

--- a/packages/render-fidelity-tools/src/artifact-creator.ts
+++ b/packages/render-fidelity-tools/src/artifact-creator.ts
@@ -255,7 +255,8 @@ export class ArtifactCreator {
         let timeout: NodeJS.Timeout;
         if (maxTimeInSec > 0) {
           timeout = setTimeout(() => {
-            reject(`Stop capturing screenshot after ${maxTimeInSec} seconds`);
+            reject(new Error(
+                `Stop capturing screenshot after ${maxTimeInSec} seconds`));
           }, maxTimeInSec * 1000);
         }
 
@@ -271,7 +272,7 @@ export class ArtifactCreator {
         await modelBecomesReady;
         return null;
       } catch (error) {
-        return error;
+        return error.message;
       }
     }, maxTimeInSec);
 

--- a/packages/render-fidelity-tools/src/artifact-creator.ts
+++ b/packages/render-fidelity-tools/src/artifact-creator.ts
@@ -252,23 +252,19 @@ export class ArtifactCreator {
     // your code is correct when it isn't.
     const evaluateError =
         await page.evaluate(async (useMaxTime, maxTimeInSec) => {
-          console.log(maxTimeInSec);
-          console.log(useMaxTime);
-          const modelBecomesReady = (self as any).modelLoaded ?
-              Promise.resolve() :
-              new Promise((resolve, reject) => {
-                let timeout: NodeJS.Timeout;
-                if (useMaxTime) {
-                  timeout = setTimeout(reject, maxTimeInSec * 1000);
-                }
+          const modelBecomesReady = new Promise((resolve, reject) => {
+            let timeout: NodeJS.Timeout;
+            if (useMaxTime) {
+              timeout = setTimeout(reject, maxTimeInSec * 1000);
+            }
 
-                self.addEventListener('model-ready', () => {
-                  if (useMaxTime) {
-                    clearTimeout(timeout);
-                  }
-                  resolve();
-                }, {once: true});
-              });
+            self.addEventListener('model-ready', () => {
+              if (useMaxTime) {
+                clearTimeout(timeout);
+              }
+              resolve();
+            }, {once: true});
+          });
 
           try {
             await modelBecomesReady;

--- a/packages/render-fidelity-tools/src/common.ts
+++ b/packages/render-fidelity-tools/src/common.ts
@@ -231,9 +231,7 @@ export class ImageComparator {
     }
 
     let modelPixelCount = 0;
-    let whitePixelCount = 0;
-    let blackPixelCount = 0;
-    let transparentPixelCount = 0;
+    let colorlessPixelCount = 0;
     for (let y = 0; y < height; ++y) {
       for (let x = 0; x < width; ++x) {
         const index = y * width + x;
@@ -243,9 +241,6 @@ export class ImageComparator {
         // is index for its alpha
         const position = index * COMPONENTS_PER_PIXEL;
         const alpha = candidateImage[position + 3];
-        if (alpha != 255) {
-          transparentPixelCount++;
-        }
 
         if (alpha === 0) {
           continue;
@@ -254,22 +249,18 @@ export class ImageComparator {
         let isWhitePixel = true;
         let isBlackPixel = true;
         for (let i = 0; i < 4; i++) {
-          const colorComponent = candidateImage[position + i];
+          const colorComponent = candidateImage[position + i] * alpha;
           if (colorComponent != 255) {
             isWhitePixel = false;
           }
-          if (colorComponent != 255) {
+          if (colorComponent != 0) {
             isBlackPixel = false;
           }
         }
 
-        if (isWhitePixel) {
-          whitePixelCount++;
+        if (isBlackPixel || isWhitePixel) {
+          colorlessPixelCount++;
         }
-        if (isBlackPixel) {
-          blackPixelCount++;
-        }
-
 
         const delta =
             colorDelta(candidateImage, goldenImage, position, position);
@@ -280,10 +271,8 @@ export class ImageComparator {
     }
 
     const imagePixelCount = width * height;
-    if (whitePixelCount === imagePixelCount ||
-        blackPixelCount === imagePixelCount ||
-        transparentPixelCount === imagePixelCount) {
-      throw new Error('Candidate image is colorless!')
+    if (colorlessPixelCount === imagePixelCount) {
+      throw new Error('Candidate image is colorless!');
     }
 
     const rmsDistanceRatio =

--- a/packages/render-fidelity-tools/src/common.ts
+++ b/packages/render-fidelity-tools/src/common.ts
@@ -242,10 +242,6 @@ export class ImageComparator {
         const position = index * COMPONENTS_PER_PIXEL;
         const alpha = candidateImage[position + 3];
 
-        if (alpha === 0) {
-          continue;
-        }
-
         let isWhitePixel = true;
         let isBlackPixel = true;
         for (let i = 0; i < 4; i++) {
@@ -260,6 +256,10 @@ export class ImageComparator {
 
         if (isBlackPixel || isWhitePixel) {
           colorlessPixelCount++;
+        }
+
+        if (alpha === 0) {
+          continue;
         }
 
         const delta =

--- a/packages/render-fidelity-tools/src/common.ts
+++ b/packages/render-fidelity-tools/src/common.ts
@@ -236,7 +236,7 @@ export class ImageComparator {
       for (let x = 0; x < width; ++x) {
         const index = y * width + x;
         // image's pixel data is stored in an 1-D array, 1st row sequentialy,
-        // than 2nd row, .. for each pixel, its data is stored by order of r, g,
+        // then 2nd row, .. for each pixel, its data is stored by order of r, g,
         // b, a.  here position is the index for current pixel's r , position+3
         // is index for its alpha
         const position = index * COMPONENTS_PER_PIXEL;
@@ -244,7 +244,7 @@ export class ImageComparator {
 
         let isWhitePixel = true;
         let isBlackPixel = true;
-        for (let i = 0; i < 4; i++) {
+        for (let i = 0; i < 3; i++) {
           const colorComponent = candidateImage[position + i] * alpha;
           if (colorComponent != 255) {
             isWhitePixel = false;

--- a/packages/render-fidelity-tools/src/common.ts
+++ b/packages/render-fidelity-tools/src/common.ts
@@ -231,6 +231,7 @@ export class ImageComparator {
     }
 
     let modelPixelCount = 0;
+    let whitePixelCount = 0;
     for (let y = 0; y < height; ++y) {
       for (let x = 0; x < width; ++x) {
         const index = y * width + x;
@@ -244,6 +245,16 @@ export class ImageComparator {
           continue;
         }
 
+        let isWhitePixel = true;
+        for (let i = 0; i < 4; i++) {
+          if (candidateImage[position + i] != 255) {
+            isWhitePixel = false;
+            break;
+          }
+        }
+        if (isWhitePixel) {
+          whitePixelCount++;
+        }
 
         const delta =
             colorDelta(candidateImage, goldenImage, position, position);
@@ -251,6 +262,11 @@ export class ImageComparator {
         squareSum += delta * delta;
         modelPixelCount++;
       }
+    }
+
+    const imagePixelCount = width * height;
+    if (whitePixelCount === imagePixelCount) {
+      throw new Error('Candidate image is completely white!')
     }
 
     const rmsDistanceRatio =

--- a/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
+++ b/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
@@ -85,8 +85,8 @@ screenshotCreator.captureAndAnalyzeScreenshots(scenarioWhitelist)
           console.log(error);
         }
 
-        core.warning(
-            `Model Viewer failed the fidelity test! Please try to fix the fidelity error before merging to master!`);
+        throw new Error(
+            'Model Viewer failed the fidelity test! Please fix the fidelity error before merging to master!');
       }
     })
     .catch((error: any) => core.setFailed(error.message));

--- a/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
+++ b/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
@@ -70,9 +70,9 @@ screenshotCreator.captureAndAnalyzeScreenshots(scenarioWhitelist)
       // the test run on.
       const testConfigPath = join(outputDirectory, 'config.json');
       const testConfig = require(testConfigPath);
-      const scenarioCount = testConfig.scenarios.length;
       const failCount = modelViewerFidelityErrors.length;
-      const passCount = scenarioCount - failCount;
+      const passCount = testConfig.scenarios.length;
+      const scenarioCount = failCount + passCount;
 
       console.log(`Fidelity test on ${
           scenarioCount} scenarios finished. Model-Viewer passed ${

--- a/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
+++ b/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
@@ -56,6 +56,9 @@
     harness.addEventListener('scenario-change', () => {
       const {scenario} = harness;
       modelViewer.addEventListener('poster-dismissed', () => {
+        // When the poster-dismissed event fired, one raf has already been requrested. 
+        // Use an additional raf here is to make sure model-ready event fires at the frame that 
+        // the poster has completely faded away. 
         requestAnimationFrame(()=>{
           this.dispatchEvent(new CustomEvent('model-ready'));
         });

--- a/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
+++ b/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
@@ -56,7 +56,9 @@
     harness.addEventListener('scenario-change', () => {
       const {scenario} = harness;
       modelViewer.addEventListener('poster-dismissed', () => {
-        this.dispatchEvent(new CustomEvent('model-ready'));
+        requestAnimationFrame(()=>{
+          this.dispatchEvent(new CustomEvent('model-ready'));
+        });
       }, {once: true});
       
       modelViewer.style.width = `${scenario.dimensions.width}px`;

--- a/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
+++ b/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
@@ -56,11 +56,12 @@
     harness.addEventListener('scenario-change', () => {
       const {scenario} = harness;
       modelViewer.addEventListener('poster-dismissed', () => {
-        // When the poster-dismissed event fired, one raf has already been requrested. 
-        // Use an additional raf here is to make sure model-ready event fires at the frame that 
+        // Use two raf here to make sure model-ready event fires at the frame that 
         // the poster has completely faded away. 
         requestAnimationFrame(()=>{
-          this.dispatchEvent(new CustomEvent('model-ready'));
+          requestAnimationFrame(()=>{
+            this.dispatchEvent(new CustomEvent('model-ready'));
+          })
         });
       }, {once: true});
       


### PR DESCRIPTION
1.  Added two raf when firing the poster-dismissed event, to make sure the event is fired after poster completely disappear
2. Check if model-viewer hang there when rendering golden. If it hang there after some time(maxTime), stop it and report error and keep testing the rest scenarios
3. Check if the golden captured is completely white. If so, report error and keep testing the rest scenarios

A new error emerges. I think 10 seconds is long enough, but i will try longer maxTime later. 
![image](https://user-images.githubusercontent.com/44676379/90050443-2f07a980-dca4-11ea-911a-067e2e403f52.png)

Also, not sure what caused the huge chunk of logging. I think the only thing i did related to model-viewer is adding an additional raf. I will hunt it down
![image](https://user-images.githubusercontent.com/44676379/90050555-5bbbc100-dca4-11ea-80f9-1e2fbbbdcc35.png)
