### PR TITLE
Respect existing query parameters on gltfSrc URL

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -77,15 +77,11 @@ export const openSceneViewer = (() => {
     if (arScale === 'fixed') {
       intentParams += `&resizable=false`;
     }
-
-    console.log("Intent Params: " + intentParams);
     
     const intent = `intent://arvr.google.com/scene-viewer/1.0${
         intentParams}#Intent;scheme=${
         scheme};package=com.google.ar.core;action=android.intent.action.VIEW;S.browser_fallback_url=${
         encodeURIComponent(locationUrl.toString())};end;`;
-
-    console.log("Full Intent: " + intent);
     
     const undoHashChange = () => {
       if (self.location.hash === noArViewerSigil && !fallbackInvoked) {


### PR DESCRIPTION
* Properly append query parameters of original glftSrc
* Check if gltfSrc contains link/title and only append them if not

### Reference Issue
Fixes issues with custom sound, link, title query parameters not working anymore (and probably others mentioned [here](https://developers.google.com/ar/develop/java/scene-viewer#supported_intent_parameters)).

Examples (with custom model-viewer build):
https://glitch.com/edit/#!/modelviewer-custom-link
https://glitch.com/edit/#!/pfc-modelviewer-audio-tests