### PR TITLE
quickLook event

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -138,6 +138,7 @@ const $arAnchor = Symbol('arAnchor');
 
 const $onARButtonContainerClick = Symbol('onARButtonContainerClick');
 const $onARStatus = Symbol('onARStatus');
+const $onARTap = Symbol('onARTap');
 
 export declare interface ARInterface {
   ar: boolean;
@@ -196,6 +197,12 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
     };
 
+    private[$onARTap] = (event: Event) => {
+      if ((event as any).data == '_apple_ar_quicklook_button_tapped') {
+        this.dispatchEvent(new CustomEvent('quick-look-button-tapped'));
+      }
+    };
+
     /**
      * Activates AR. Note that for any mode that is not WebXR-based, this
      * method most likely has to be called synchronous from a user
@@ -239,6 +246,8 @@ configuration or device capabilities');
 
       this[$renderer].arRenderer.addEventListener('status', this[$onARStatus]);
       this.setAttribute('ar-status', ARStatus.NOT_PRESENTING);
+
+      this[$arAnchor].addEventListener('message', this[$onARTap]);
     }
 
     disconnectedCallback() {
@@ -246,6 +255,8 @@ configuration or device capabilities');
 
       this[$renderer].arRenderer.removeEventListener(
           'status', this[$onARStatus]);
+
+      this[$arAnchor].removeEventListener('message', this[$onARTap]);
     }
 
     async update(changedProperties: Map<string, any>) {

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -77,15 +77,11 @@ export const openSceneViewer = (() => {
     if (arScale === 'fixed') {
       intentParams += `&resizable=false`;
     }
-
-    console.log("Intent Params: " + intentParams);
     
     const intent = `intent://arvr.google.com/scene-viewer/1.0${
         intentParams}#Intent;scheme=${
         scheme};package=com.google.ar.core;action=android.intent.action.VIEW;S.browser_fallback_url=${
         encodeURIComponent(locationUrl.toString())};end;`;
-
-    console.log("Full Intent: " + intent);
     
     const undoHashChange = () => {
       if (self.location.hash === noArViewerSigil && !fallbackInvoked) {

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -41,48 +41,83 @@ suite('ModelViewerElementBase with ARMixin', () => {
 
     BasicSpecTemplate(() => ModelViewerElement, () => tagName);
 
-    suite('openSceneViewer', () => {
-      test('preserves query parameters in model URLs', () => {
-        const intentUrls: Array<string> = [];
-        const restoreAnchorClick = spy(HTMLAnchorElement.prototype, 'click', {
+    suite('AR intents', () => {
+      let intentUrls: Array<string>;
+      let restoreAnchorClick: () => void;
+
+      setup(() => {
+        intentUrls = [];
+        restoreAnchorClick = spy(HTMLAnchorElement.prototype, 'click', {
           value: function() {
             intentUrls.push((this as HTMLAnchorElement).href);
           }
         });
+      });
 
-        openSceneViewer(
-            'https://example.com/model.gltf?token=foo',
-            'Example model',
-            'auto');
-
-        expect(intentUrls.length).to.be.equal(1);
-
-        const url = new URL(intentUrls[0]);
-
-        expect(url.search).to.match(/(%3F|%26)token%3Dfoo(%26|&|$)/);
-
+      teardown(() => {
         restoreAnchorClick();
       });
-    });
 
-    suite('openQuickLook', () => {
-      test('sets hash for fixed scale', () => {
-        const intentUrls: Array<string> = [];
-        const restoreAnchorClick = spy(HTMLAnchorElement.prototype, 'click', {
-          value: function() {
-            intentUrls.push((this as HTMLAnchorElement).href);
-          }
+      suite('openSceneViewer', () => {
+        test('preserves query parameters in model URLs', () => {
+          openSceneViewer(
+              'https://example.com/model.gltf?token=foo',
+              'Example model',
+              'auto');
+
+          expect(intentUrls.length).to.be.equal(1);
+
+          const url = new URL(intentUrls[0]);
+
+          expect(url.search).to.match(/(%3F|%26|&)token=foo(%26|&|$)/);
         });
 
-        openIOSARQuickLook('https://example.com/model.gltf', 'fixed');
+        test('defaults title and link', () => {
+          openSceneViewer('https://example.com/model.gltf', 'alt', 'auto');
 
-        expect(intentUrls.length).to.be.equal(1);
+          expect(intentUrls.length).to.be.equal(1);
 
-        const url = new URL(intentUrls[0]);
+          const url = new URL(intentUrls[0]);
 
-        expect(url.hash).to.equal('#allowsContentScaling=0');
+          expect(url.search).to.match(/(%3F|%26|&)title=alt(%26|&|$)/);
 
-        restoreAnchorClick();
+          const linkRegex =
+              `(%3F|%26|&)link=${self.location.toString()}(%26|&|$)`;
+          linkRegex.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+          expect(url.search).to.match(new RegExp(linkRegex));
+        });
+
+        test('keeps title and link when supplied', () => {
+          openSceneViewer(
+              'https://example.com/model.gltf?link=foo&title=bar',
+              'alt',
+              'auto');
+
+          expect(intentUrls.length).to.be.equal(1);
+
+          const url = new URL(intentUrls[0]);
+
+          expect(url.search).to.match(/(%3F|%26|&)title=bar(%26|&|$)/);
+          expect(url.search).to.not.match(/(%3F|%26|&)title=alt(%26|&|$)/);
+
+          expect(url.search).to.match(/(%3F|%26|&)link=foo(%26|&|$)/);
+          const linkRegex =
+              `(%3F|%26|&)link=${self.location.toString()}(%26|&|$)`;
+          linkRegex.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+          expect(url.search).to.not.match(new RegExp(linkRegex));
+        });
+      });
+
+      suite('openQuickLook', () => {
+        test('sets hash for fixed scale', () => {
+          openIOSARQuickLook('https://example.com/model.gltf', 'fixed');
+
+          expect(intentUrls.length).to.be.equal(1);
+
+          const url = new URL(intentUrls[0]);
+
+          expect(url.hash).to.equal('#allowsContentScaling=0');
+        });
       });
     });
 

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -709,6 +709,13 @@
               <p>When loading = "eager" this event is fired when preloading is done.</p>
             </li>
             <li>
+              <div>quick-look-button-tapped</div>
+              <p>If the user has entered a quick-look AR session on iOS, this event is fired 
+              when the action button is tapped, see 
+              <a href='https://developer.apple.com/documentation/arkit/adding_an_apple_pay_button_or_a_custom_action_in_ar_quick_look'>Apple's documentation</a>.
+              </p>
+            </li>
+            <li>
               <div>scene-graph-ready</div>
               <p>Dispatched when scene-graph access is available and after the model has
                 been loaded. See the <a href='examples/scene-graph.html'>Scene Graph</a>


### PR DESCRIPTION
Fixes #1030
Fixes #1314

This adds a new `quick-look-button-tapped` event, replacing the work started in #1435; thanks @hybridherbst! I could use some help verifying that this is working for everyone's use cases. 