### PR TITLE
fixed npm main

### DIFF
--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -19,13 +19,15 @@
     "Matt Small <mbsmall@google.com>",
     "Yuin Chien <yuin@google.com>"
   ],
-  "main": "dist/model-viewer.min.js",
+  "main": "dist/model-viewer-umd.js",
   "module": "dist/model-viewer.min.js",
   "files": [
     "dist/model-viewer.js",
     "dist/model-viewer.js.map",
     "dist/model-viewer.min.js",
     "dist/model-viewer.min.js.map",
+    "dist/model-viewer-umd.js",
+    "dist/model-viewer-umd.js.map",
     "dist/model-viewer-legacy.js",
     "POLYFILLS.md"
   ],


### PR DESCRIPTION
Fixes #690 
Fixes #1192 
Fixes #1208 
Fixes #1310 

Well, really I'm hoping this is the root of the problem; could use help validating this. Unfortunately it won't be easily testable until we put out a new npm release with this fix, so I'll plan to do that fairly soon. I believe the problem is that `main` is supposed to point to a umd version of the library, instead of the es6 module version it was pointing at. 