### PR TITLE
Handle AR failures better

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -252,6 +252,8 @@ configuration or device capabilities');
       console.log('Attempting to present in AR...');
 
       try {
+        this[$arButtonContainer].removeEventListener(
+            'click', this[$onARButtonContainerClick]);
         await this[$renderer].arRenderer.present(this[$scene]);
       } catch (error) {
         console.warn('Error while trying to present to AR');
@@ -260,6 +262,8 @@ configuration or device capabilities');
         isWebXRBlocked = true;
         await this[$selectARMode]();
         this.activateAR();
+      } finally {
+        this[$selectARMode]();
       }
     }
 

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -225,10 +225,16 @@ configuration or device capabilities');
         this[$arButtonContainer].classList.add('enabled');
         this[$arButtonContainer].addEventListener(
             'click', this[$onARButtonContainerClick]);
-      } else {
+      } else if (this[$arButtonContainer].classList.contains('enabled')) {
         this[$arButtonContainer].removeEventListener(
             'click', this[$onARButtonContainerClick]);
         this[$arButtonContainer].classList.remove('enabled');
+
+        // If AR went from working to not, notify the element.
+        const status = ARStatus.FAILED;
+        this.setAttribute('ar-status', status);
+        this.dispatchEvent(
+            new CustomEvent<ARStatusDetails>('ar-status', {detail: {status}}));
       }
     }
 
@@ -252,7 +258,7 @@ configuration or device capabilities');
         console.error(error);
         await this[$renderer].arRenderer.stopPresenting();
         isWebXRBlocked = true;
-        this[$selectARMode]();
+        await this[$selectARMode]();
         this.activateAR();
       }
     }
@@ -290,7 +296,7 @@ configuration or device capabilities');
           encodeURIComponent(locationUrl.toString())};end;`;
 
       const undoHashChange = () => {
-        if (self.location.hash === noArViewerSigil && !isSceneViewerBlocked) {
+        if (self.location.hash === noArViewerSigil) {
           isSceneViewerBlocked = true;
           // The new history will be the current URL with a new hash.
           // Go back one step so that we reset to the expected URL.
@@ -299,7 +305,8 @@ configuration or device capabilities');
           // navigating:
           self.history.back();
           this[$selectARMode]();
-          this.activateAR();
+          // Would be nice to activateAR() here, but webXR fails due to not
+          // seeing a user activation.
         }
       };
 

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -40,12 +40,14 @@ const INTRO_DAMPER_RATE = 0.4;
 const SCALE_SNAP_HIGH = 1.2;
 const SCALE_SNAP_LOW = 1 / SCALE_SNAP_HIGH;
 
-export type ARStatus = 'not-presenting'|'session-started'|'object-placed';
+export type ARStatus =
+    'not-presenting'|'session-started'|'object-placed'|'failed';
 
 export const ARStatus: {[index: string]: ARStatus} = {
   NOT_PRESENTING: 'not-presenting',
   SESSION_STARTED: 'session-started',
-  OBJECT_PLACED: 'object-placed'
+  OBJECT_PLACED: 'object-placed',
+  FAILED: 'failed'
 };
 
 export interface ARStatusEvent extends ThreeEvent {

--- a/packages/modelviewer.dev/examples/augmented-reality.html
+++ b/packages/modelviewer.dev/examples/augmented-reality.html
@@ -105,11 +105,41 @@
       <div class="wrapper">
         <div class="heading">
           <h2 class="demo-title">Scene Viewer</h2>
-          <h4>Here AR is restricted to the Scene Viewer app, to make it easier to compare this with WebXR, above.</h4>
+          <h4>Here the Scene Viewer app is given priority, to make it easier to compare with the default WebXR, above.</h4>
         </div>
         <example-snippet stamp-to="demo-container-2" highlight-as="html">
           <template>
-<model-viewer src="../shared-assets/models/Astronaut.glb" ar ar-modes="scene-viewer" ar-scale="auto" camera-controls alt="A 3D model of an astronaut" skybox-image="../shared-assets/environments/aircraft_workshop_01_1k.hdr"></model-viewer>
+<model-viewer id="model-viewer" src="../shared-assets/models/Astronaut.glb" ar ar-modes="scene-viewer webxr" ar-scale="auto" camera-controls alt="A 3D model of an astronaut" skybox-image="../shared-assets/environments/aircraft_workshop_01_1k.hdr">
+  <div id="error" class="hide">AR is not supported on this device</div>
+</model-viewer>
+<script>
+  document.querySelector("#model-viewer").addEventListener('ar-status', (event) => {
+    if(event.detail.status === 'failed'){
+      const error = document.querySelector("#error");
+      error.classList.remove('hide');
+      error.addEventListener('transitionend',(event) => {
+        error.classList.add('hide');
+      });
+    }
+  });
+</script>
+<style>
+  #error {
+    background-color: #ffffffdd;
+    border-radius: 16px;
+    padding: 16px;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate3d(-50%, -50%, 0);
+    transition: opacity 0.3s;
+  }
+  #error.hide {
+    opacity: 0;
+    visibility: hidden;
+    transition: visibility 2s, opacity 1s 1s;
+  }
+</style>
           </template>
         </example-snippet>
       </div>

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -386,11 +386,12 @@
             <li>
               <div>ar-status</div>
               <p>This read-only attribute enables DOM content to be styled based
-              on the status of the WebXR AR presentation. Possible values include
-              'not-presenting', 'session-started', and 'object-placed'. For instance,
-              a prompt for the user to move their phone until the object is
-              successfully placed in their space can be shown by scoping a CSS rule
-              to model-viewer[ar-status="session-started"]. Setting this attribute
+              on the status of the WebXR AR presentation. Possible values
+              include 'not-presenting', 'session-started', 'object-placed', and
+              'failed'. For instance, a prompt for the user to move their phone
+              until the object is successfully placed in their space can be
+              shown by scoping a CSS rule to
+              model-viewer[ar-status="session-started"]. Setting this attribute
               has no effect.</p>
             </li>
             <li>
@@ -635,10 +636,13 @@
           <ul class="list-attribute">
             <li>
               <div>ar-status</div>
-              <p>Fired when the ar-status attribute above fires. The event.detail.status
-              property will be set to the same value as the ar-status attribute, either
-              'not-presenting', 'session-started', or 'object-placed'. This event is
-              only enabled for WebXR AR sessions.
+              <p>Fired when the ar-status attribute above fires. The
+              event.detail.status property will be set to the same value as the
+              ar-status attribute, either 'not-presenting', 'session-started',
+              'object-placed', or 'failed'. This event is only enabled for WebXR
+              AR sessions, with the exception of 'failed', which will be fired
+              any time ar was initiated but failed to start all of the given
+              modes.
               </p>
             </li>
             <li>


### PR DESCRIPTION
Fixes #1330 
Fixes #1329

We now automatically fallback from webXR to SceneViewer if something goes wrong, and we disable the AR button if none of the requested modes work. When this happens we now set the `ar-status` attribute to `'failed'` and dispatch a similar event. I haven't found a way to detect if QuickLook has failed.