### PR TITLE
temporary dedupe rollback for editor

### DIFF
--- a/packages/space-opera/rollup.config.js
+++ b/packages/space-opera/rollup.config.js
@@ -34,7 +34,7 @@ const plugins = [
       return null;
     },
   },
-  resolve({dedupe: ['three']}),
+  resolve(),
   commonjs()
 ];
 


### PR DESCRIPTION
Fixes #1485 

I thought I tested my deduplication of three.js in this bundle, but clearly not well enough. Rolling it back for now while I work on a proper fix (the current space-opera.js bundle is far larger than it should be). 