### PR TITLE
threejs r120.1

### DIFF
--- a/packages/3dom/package-lock.json
+++ b/packages/3dom/package-lock.json
@@ -10101,9 +10101,9 @@
       }
     },
     "three": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.120.0.tgz",
-      "integrity": "sha512-Swffpi3EAHWkmqC1MagKEzR5XgwkDiyeWI3M7vkGbBc0xhq2LcQmJj5DqBruLkrgcZQ+fM/+fSQBU1tDvggO4A==",
+      "version": "0.120.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.120.1.tgz",
+      "integrity": "sha512-ktaCRFUR7JUZcKec+cBRz+oBex5pOVaJhrtxvFF2T7on53o9UkEux+/Nh1g/4zeb4t/pbxIFcADbn/ACu3LC1g==",
       "dev": true
     },
     "through": {

--- a/packages/3dom/package.json
+++ b/packages/3dom/package.json
@@ -45,7 +45,7 @@
     "3d"
   ],
   "devDependencies": {
-    "three": "^0.120.0",
+    "three": "^0.120.1",
     "@google/model-viewer-shared-assets": "*",
     "@open-wc/karma-esm": "^3.0.4",
     "@rollup/plugin-node-resolve": "^9.0.0",

--- a/packages/model-viewer/package-lock.json
+++ b/packages/model-viewer/package-lock.json
@@ -20531,9 +20531,9 @@
       }
     },
     "three": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.120.0.tgz",
-      "integrity": "sha512-Swffpi3EAHWkmqC1MagKEzR5XgwkDiyeWI3M7vkGbBc0xhq2LcQmJj5DqBruLkrgcZQ+fM/+fSQBU1tDvggO4A==",
+      "version": "0.120.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.120.1.tgz",
+      "integrity": "sha512-ktaCRFUR7JUZcKec+cBRz+oBex5pOVaJhrtxvFF2T7on53o9UkEux+/Nh1g/4zeb4t/pbxIFcADbn/ACu3LC1g==",
       "dev": true
     },
     "through": {

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@google/3dom": "0.1.0",
     "lit-element": "^2.4.0",
-    "three": "^0.120.0",
+    "three": "^0.120.1",
     "@types/resize-observer-browser": "^0.1.2",
     "@google/model-viewer-shared-assets": "^0.0.1",
     "@jsantell/event-target": "^1.1.2",

--- a/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
@@ -77,10 +77,8 @@ export class ModelViewerGLTFInstance extends GLTFInstance {
             transparent = true;
             material.side = FrontSide;
           }
-          if (!(material as any).isGLTFSpecularGlossinessMaterial) {
-            Renderer.singleton.roughnessMipmapper.generateMipmaps(
-                material as MeshStandardMaterial);
-          }
+          Renderer.singleton.roughnessMipmapper.generateMipmaps(
+              material as MeshStandardMaterial);
         }
       });
 

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -89,6 +89,8 @@
             <li><a href="examples/tester.html"><h4>Interactive Example</h4></a></li>
 
             <li><a href="editor"><h4>Model Editor</h4></a></li>
+
+            <li><a href="fidelity"><h4>glTF Fidelity Comparison</h4></a></li>
           </ul>
         </div>
 

--- a/packages/space-opera/package-lock.json
+++ b/packages/space-opera/package-lock.json
@@ -37920,9 +37920,9 @@
       }
     },
     "three": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.120.0.tgz",
-      "integrity": "sha512-Swffpi3EAHWkmqC1MagKEzR5XgwkDiyeWI3M7vkGbBc0xhq2LcQmJj5DqBruLkrgcZQ+fM/+fSQBU1tDvggO4A==",
+      "version": "0.120.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.120.1.tgz",
+      "integrity": "sha512-ktaCRFUR7JUZcKec+cBRz+oBex5pOVaJhrtxvFF2T7on53o9UkEux+/Nh1g/4zeb4t/pbxIFcADbn/ACu3LC1g==",
       "dev": true
     },
     "through": {

--- a/packages/space-opera/package.json
+++ b/packages/space-opera/package.json
@@ -37,7 +37,7 @@
     "@google/model-viewer": "^1.1.0",
     "@google/model-viewer-editing-adapter": "^0.0.1",
     "@google/model-viewer-shared-assets": "^0.0.1",
-    "three": "^0.120.0",
+    "three": "^0.120.1",
     "@material/mwc-button": "^0.18.0",
     "@material/mwc-checkbox": "^0.18.0",
     "@material/mwc-icon-button": "^0.18.0",

--- a/packages/space-opera/rollup.config.js
+++ b/packages/space-opera/rollup.config.js
@@ -34,7 +34,7 @@ const plugins = [
       return null;
     },
   },
-  resolve(),
+  resolve({dedupe: ['three']}),
   commonjs()
 ];
 


### PR DESCRIPTION
Removes a small work-around and decreases the editor's bundle size by deduplicating three.js. Also adds a link to our fidelity results from modelviewer.dev.