### PR TITLE
hide hotspots until model renders

### DIFF
--- a/packages/model-viewer/src/features/animation.ts
+++ b/packages/model-viewer/src/features/animation.ts
@@ -94,6 +94,8 @@ export const AnimationMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     [$onModelLoad]() {
+      super[$onModelLoad]();
+
       this[$paused] = true;
 
       if (this.autoplay) {

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -72,11 +72,13 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
     constructor(...args: Array<any>) {
       super(...args);
 
-      const shadowRoot = this.shadowRoot!;
       const {domElement} = this[$annotationRenderer];
-      domElement.classList.add('annotation-container');
-      shadowRoot.querySelector('.container')!.appendChild(domElement);
-      domElement.appendChild(shadowRoot.querySelector('.default')!);
+      const {style} = domElement;
+      style.display = 'none';
+      style.pointerEvents = 'none';
+      style.position = 'absolute';
+      style.top = '0';
+      this.shadowRoot!.querySelector('.default')!.appendChild(domElement);
     }
 
     connectedCallback() {
@@ -163,6 +165,7 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       if (scene.isDirty) {
         scene.model.updateHotspots(camera.position);
+        this[$annotationRenderer].domElement.style.display = '';
         this[$annotationRenderer].render(scene, camera);
       }
     }

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -41,12 +41,6 @@ template.innerHTML = `
   position: relative;
 }
 
-.annotation-container {
-  position: absolute;
-  pointer-events: none;
-  top: 0;
-}
-
 .userInput {
   width: 100%;
   height: 100%;

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -164,10 +164,8 @@ export class ARRenderer extends EventDispatcher {
         await navigator.xr!.requestSession!('immersive-ar', {
           requiredFeatures: ['hit-test'],
           optionalFeatures: ['dom-overlay'],
-          domOverlay: {
-            root: scene.element.shadowRoot!.querySelector(
-                'div.annotation-container')
-          }
+          domOverlay:
+              {root: scene.element.shadowRoot!.querySelector('div.default')}
         });
 
     const gl = this.threeRenderer.context;

--- a/packages/modelviewer.dev/examples/annotations.html
+++ b/packages/modelviewer.dev/examples/annotations.html
@@ -105,7 +105,7 @@
     display: none;
   }
 </style>
-<model-viewer id="hotspot-demo" ar ar-modes="webxr" camera-controls src="../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut.">
+<model-viewer id="hotspot-demo" ar ar-modes="webxr" camera-controls src="../shared-assets/models/Astronaut.glb" style="--poster-color:#ffffff00;" alt="A 3D model of an astronaut.">
   <button slot="hotspot-visor" data-position="0 1.75 0.35" data-normal="0 0 1"></button>
   <button slot="hotspot-hand" data-position="-0.54 0.93 0.1" data-normal="-0.73 0.05 0.69">
     <div id="annotation">This hotspot disappears completely</div>

--- a/packages/modelviewer.dev/examples/customizing-ui.html
+++ b/packages/modelviewer.dev/examples/customizing-ui.html
@@ -81,8 +81,8 @@
         </div>
         <example-snippet stamp-to="demo-container-2" highlight-as="html">
           <template>
-<div  class="demo" style="background: linear-gradient(#ffffff, #ada996);">
-  <span style="position: absolute; text-align: center; font-size: 140px;">Background</span>
+<div class="demo" style="background: linear-gradient(#ffffff, #ada996);">
+  <span style="position: absolute; text-align: center; font-size: 140px; top:50%;">Background</span>
   <model-viewer camera-controls src="../shared-assets/models/glTF-Sample-Models/2.0/AlphaBlendModeTest/glTF-Binary/AlphaBlendModeTest.glb" alt="A 3D transparency test" style="background-color: unset;"></model-viewer>
 </div>
           </template>

--- a/packages/modelviewer.dev/styles/examples.css
+++ b/packages/modelviewer.dev/styles/examples.css
@@ -283,7 +283,6 @@ model-viewer:focus {
   height: 100vh;
   flex: 1;
   display: flex;
-  align-items: center;
   justify-content: center;
   border: 0px solid #555;
   box-sizing: border-box;


### PR DESCRIPTION
Fixes #1419 

It was by pure luck this ever worked before v1.0; this makes the display much more intentional.