### PR TITLE
3DOM Return types

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -31,6 +31,9 @@ rules:
   # Remove if we switch away from clang-format:
   keyword-spacing: off
 
+  # clang-format wants async(foo) => {} without a space
+  space-before-function-paren: off
+
   "@typescript-eslint/explicit-member-accessibility": [error, {"accessibility": "no-public"}]
 
   no-new: warn

--- a/packages/3dom/src/api/image.ts
+++ b/packages/3dom/src/api/image.ts
@@ -28,7 +28,7 @@ export class Image extends ThreeDOMElement implements ImageInterface {
 
   private[$uri]: string|null;
 
-  private[$name]?: string;
+  private[$name]: string|undefined;
 
   constructor(kernel: ModelKernelInterface, serialized: SerializedImage) {
     super(kernel);
@@ -39,15 +39,15 @@ export class Image extends ThreeDOMElement implements ImageInterface {
     this[$name] = serialized.name;
   }
 
-  get name() {
+  get name(): string|undefined {
     return this[$name];
   }
 
-  get type() {
+  get type(): 'embedded'|'external' {
     return this.uri != null ? 'external' : 'embedded';
   }
 
-  get uri() {
+  get uri(): string|null {
     return this[$uri];
   }
 

--- a/packages/3dom/src/api/image.ts
+++ b/packages/3dom/src/api/image.ts
@@ -28,7 +28,7 @@ export class Image extends ThreeDOMElement implements ImageInterface {
 
   private[$uri]: string|null;
 
-  private[$name]: string|undefined;
+  private[$name]: string;
 
   constructor(kernel: ModelKernelInterface, serialized: SerializedImage) {
     super(kernel);
@@ -36,7 +36,9 @@ export class Image extends ThreeDOMElement implements ImageInterface {
     this[$kernel] = kernel;
 
     this[$uri] = serialized.uri || null;
-    this[$name] = serialized.name;
+    if (serialized.name != null) {
+      this[$name] = serialized.name;
+    }
   }
 
   get name(): string|undefined {

--- a/packages/3dom/src/api/material.ts
+++ b/packages/3dom/src/api/material.ts
@@ -78,18 +78,18 @@ export class Material extends ThreeDOMElement implements MaterialInterface {
   /**
    * The PBR properties that are assigned to this material, if any.
    */
-  get pbrMetallicRoughness() {
+  get pbrMetallicRoughness(): PBRMetallicRoughness {
     return this[$pbrMetallicRoughness];
   }
 
-  get normalTexture() {
+  get normalTexture(): TextureInfo|null {
     return this[$normalTexture];
   }
 
-  get occlusionTexture() {
+  get occlusionTexture(): TextureInfo|null {
     return this[$occlusionTexture];
   }
-  get emissiveTexture() {
+  get emissiveTexture(): TextureInfo|null {
     return this[$emissiveTexture];
   }
 
@@ -97,7 +97,7 @@ export class Material extends ThreeDOMElement implements MaterialInterface {
    * The name of the material. Note that names are optional and not
    * guaranteed to be unique.
    */
-  get name() {
+  get name(): string {
     return this[$name];
   }
 }

--- a/packages/3dom/src/api/model-kernel.ts
+++ b/packages/3dom/src/api/model-kernel.ts
@@ -56,7 +56,6 @@ interface Deferred {
 }
 
 const $onMessageEvent = Symbol('onMessageEvent');
-const $messageEventHandler = Symbol('messageEventHandler');
 const $port = Symbol('port');
 const $model = Symbol('model');
 
@@ -86,8 +85,6 @@ export class ModelKernel implements ModelKernelInterface {
 
   protected[$elementsByType]: ElementsByType = new Map();
 
-  protected[$messageEventHandler] = (event: MessageEvent) =>
-      this[$onMessageEvent](event);
   protected[$port]: MessagePort;
 
   protected[$model]: ModelAPI;
@@ -111,7 +108,7 @@ export class ModelKernel implements ModelKernelInterface {
     }
 
     this[$port] = port;
-    this[$port].addEventListener('message', this[$messageEventHandler]);
+    this[$port].addEventListener('message', this[$onMessageEvent]);
     this[$port].start();
 
     this[$model] = this.deserialize('model', serialized);
@@ -121,7 +118,7 @@ export class ModelKernel implements ModelKernelInterface {
    * The root scene graph element, a Model, that is the entrypoint for the
    * entire scene graph that is backed by this kernel.
    */
-  get model() {
+  get model(): ModelAPI {
     return this[$model];
   }
 
@@ -225,12 +222,12 @@ export class ModelKernel implements ModelKernelInterface {
    * The ModelKernel should be deactivated before it is disposed of, or else
    * it will leak in memory.
    */
-  deactivate() {
+  deactivate(): void {
     this[$port].close();
-    this[$port].removeEventListener('message', this[$messageEventHandler]);
+    this[$port].removeEventListener('message', this[$onMessageEvent]);
   }
 
-  protected[$onMessageEvent](event: MessageEvent) {
+  protected[$onMessageEvent] = (event: MessageEvent): void => {
     const {data} = event;
 
     switch (data && data.type) {
@@ -247,5 +244,5 @@ export class ModelKernel implements ModelKernelInterface {
         break;
       }
     }
-  }
+  };
 }

--- a/packages/3dom/src/api/model.ts
+++ b/packages/3dom/src/api/model.ts
@@ -48,14 +48,14 @@ export class Model extends ThreeDOMElement implements ModelInterface {
    *
    * TODO(#1002): This value needs to be sensitive to scene graph order
    */
-  get materials() {
+  get materials(): Readonly<Material[]> {
     return this[$kernel].getElementsByType('material');
   }
 
   /**
    * A Model has no owner model; it owns itself.
    */
-  get ownerModel() {
+  get ownerModel(): Model {
     return this;
   }
 }

--- a/packages/3dom/src/api/pbr-metallic-roughness.ts
+++ b/packages/3dom/src/api/pbr-metallic-roughness.ts
@@ -64,29 +64,29 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
   /**
    * The base color factor of the material in RGBA format.
    */
-  get baseColorFactor() {
+  get baseColorFactor(): Readonly<RGBA> {
     return this[$baseColorFactor];
   }
 
   /**
    * The metalness factor of the material in range [0,1].
    */
-  get metallicFactor() {
+  get metallicFactor(): number {
     return this[$metallicFactor];
   }
 
   /**
    * The roughness factor of the material in range [0,1].
    */
-  get roughnessFactor() {
+  get roughnessFactor(): number {
     return this[$roughnessFactor];
   }
 
-  get baseColorTexture() {
+  get baseColorTexture(): TextureInfo|null {
     return this[$baseColorTexture];
   }
 
-  get metallicRoughnessTexture() {
+  get metallicRoughnessTexture(): TextureInfo|null {
     return this[$metallicRoughnessTexture];
   }
 
@@ -95,7 +95,7 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
    *
    * @see ../api.ts
    */
-  async setBaseColorFactor(color: RGBA) {
+  async setBaseColorFactor(color: RGBA): Promise<void> {
     await this[$kernel].mutate(this, 'baseColorFactor', color);
     this[$baseColorFactor] = Object.freeze(color) as RGBA;
   }
@@ -105,7 +105,7 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
    *
    * @see ../api.ts
    */
-  async setMetallicFactor(factor: number) {
+  async setMetallicFactor(factor: number): Promise<void> {
     await this[$kernel].mutate(this, 'metallicFactor', factor);
     this[$metallicFactor] = factor;
   }
@@ -115,7 +115,7 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
    *
    * @see ../api.ts
    */
-  async setRoughnessFactor(factor: number) {
+  async setRoughnessFactor(factor: number): Promise<void> {
     await this[$kernel].mutate(this, 'roughnessFactor', factor);
     this[$roughnessFactor] = factor;
   }

--- a/packages/3dom/src/api/sampler.ts
+++ b/packages/3dom/src/api/sampler.ts
@@ -36,14 +36,16 @@ export class Sampler extends ThreeDOMElement implements SamplerInterface {
   private[$wrapS]: WrapMode;
   private[$wrapT]: WrapMode;
 
-  private[$name]?: string;
+  private[$name]: string;
 
   constructor(kernel: ModelKernelInterface, serialized: SerializedSampler) {
     super(kernel);
 
     this[$kernel] = kernel;
 
-    this[$name] = serialized.name;
+    if (serialized.name != null) {
+      this[$name] = serialized.name;
+    }
 
     this[$minFilter] = serialized.minFilter || null;
     this[$magFilter] = serialized.magFilter || null;
@@ -51,23 +53,23 @@ export class Sampler extends ThreeDOMElement implements SamplerInterface {
     this[$wrapT] = serialized.wrapT || 10497;
   }
 
-  get name() {
+  get name(): string {
     return this[$name];
   }
 
-  get minFilter() {
+  get minFilter(): MinFilter|null {
     return this[$minFilter];
   }
 
-  get magFilter() {
+  get magFilter(): MagFilter|null {
     return this[$magFilter];
   }
 
-  get wrapS() {
+  get wrapS(): WrapMode {
     return this[$wrapS];
   }
 
-  get wrapT() {
+  get wrapT(): WrapMode {
     return this[$wrapT];
   }
 

--- a/packages/3dom/src/api/texture-info.ts
+++ b/packages/3dom/src/api/texture-info.ts
@@ -40,7 +40,7 @@ export class TextureInfo extends ThreeDOMElement implements
     }
   }
 
-  get texture() {
+  get texture(): Texture|null {
     return this[$texture];
   }
 

--- a/packages/3dom/src/api/texture.ts
+++ b/packages/3dom/src/api/texture.ts
@@ -30,7 +30,7 @@ export class Texture extends ThreeDOMElement implements TextureInterface {
   private[$source]: Image|null = null;
   private[$sampler]: Sampler|null = null;
 
-  private[$name]?: string;
+  private[$name]: string;
 
   constructor(kernel: ModelKernelInterface, serialized: SerializedTexture) {
     super(kernel);
@@ -39,7 +39,9 @@ export class Texture extends ThreeDOMElement implements TextureInterface {
 
     const {sampler, source, name} = serialized;
 
-    this[$name] = name;
+    if (name != null) {
+      this[$name] = name;
+    }
 
     if (sampler != null) {
       this[$sampler] = kernel.deserialize('sampler', sampler);
@@ -50,15 +52,15 @@ export class Texture extends ThreeDOMElement implements TextureInterface {
     }
   }
 
-  get name() {
+  get name(): string {
     return this[$name];
   }
 
-  get sampler() {
+  get sampler(): Sampler|null {
     return this[$sampler];
   }
 
-  get source() {
+  get source(): Image|null {
     return this[$source];
   }
 

--- a/packages/3dom/src/api/three-dom-element.ts
+++ b/packages/3dom/src/api/three-dom-element.ts
@@ -40,7 +40,7 @@ export class ThreeDOMElement implements ThreeDOMElementInterface {
    * The Model of provenance for this scene graph element, or undefined if
    * element is itself a Model.
    */
-  get ownerModel() {
+  get ownerModel(): Model {
     return this[$ownerModel];
   }
 }

--- a/packages/3dom/src/facade/model-graft-manipulator.ts
+++ b/packages/3dom/src/facade/model-graft-manipulator.ts
@@ -20,7 +20,6 @@ import {ModelGraft} from './api.js';
 const $modelGraft = Symbol('modelGraft');
 const $port = Symbol('port');
 
-const $messageEventHandler = Symbol('messageEventHandler');
 const $onMessageEvent = Symbol('onMessageEvent');
 
 /**
@@ -33,13 +32,10 @@ export class ModelGraftManipulator {
   protected[$port]: MessagePort;
   protected[$modelGraft]: ModelGraft;
 
-  protected[$messageEventHandler] = (event: MessageEvent) =>
-      this[$onMessageEvent](event);
-
   constructor(modelGraft: ModelGraft, port: MessagePort) {
     this[$modelGraft] = modelGraft;
     this[$port] = port;
-    this[$port].addEventListener('message', this[$messageEventHandler]);
+    this[$port].addEventListener('message', this[$onMessageEvent]);
     this[$port].start();
   }
 
@@ -47,12 +43,12 @@ export class ModelGraftManipulator {
    * Clean up internal state so that the ModelGraftManipulator can be properly
    * garbage collected.
    */
-  dispose() {
-    this[$port].removeEventListener('message', this[$messageEventHandler]);
+  dispose(): void {
+    this[$port].removeEventListener('message', this[$onMessageEvent]);
     this[$port].close();
   }
 
-  async[$onMessageEvent](event: MessageEvent) {
+  [$onMessageEvent] = async(event: MessageEvent): Promise<void> => {
     const {data} = event;
     if (data && data.type) {
       if (data.type === ThreeDOMMessageType.MUTATE) {
@@ -67,5 +63,5 @@ export class ModelGraftManipulator {
         }
       }
     }
-  }
+  };
 }

--- a/packages/3dom/src/facade/three-js/correlated-scene-graph.ts
+++ b/packages/3dom/src/facade/three-js/correlated-scene-graph.ts
@@ -186,14 +186,14 @@ export class CorrelatedSceneGraph {
   /**
    * The source Three.js GLTF result given to us by a Three.js GLTFLoader.
    */
-  get threeGLTF() {
+  get threeGLTF(): ThreeGLTF {
     return this[$threeGLTF];
   }
 
   /**
    * The in-memory deserialized source glTF.
    */
-  get gltf() {
+  get gltf(): GLTF {
     return this[$gltf];
   }
 
@@ -203,7 +203,7 @@ export class CorrelatedSceneGraph {
    * cases where more than one Three.js object corresponds to a single glTF
    * element.
    */
-  get gltfElementMap() {
+  get gltfElementMap(): GLTFElementToThreeObjectMap {
     return this[$gltfElementMap];
   }
 
@@ -211,7 +211,7 @@ export class CorrelatedSceneGraph {
    * A map of individual Three.js objects to corresponding elements in the
    * source glTF.
    */
-  get threeObjectMap() {
+  get threeObjectMap(): ThreeObjectToGLTFElementHandleMap {
     return this[$threeObjectMap];
   }
 

--- a/packages/3dom/src/facade/three-js/image.ts
+++ b/packages/3dom/src/facade/three-js/image.ts
@@ -49,7 +49,7 @@ export class Image extends ThreeDOMElement implements ImageInterface {
     }
   }
 
-  async mutate(property: 'uri', value: string|null) {
+  async mutate(property: 'uri', value: string|null): Promise<void> {
     let image: HTMLImageElement|null = null;
 
     if (property !== 'uri') {

--- a/packages/3dom/src/facade/three-js/material.ts
+++ b/packages/3dom/src/facade/three-js/material.ts
@@ -93,19 +93,19 @@ export class Material extends ThreeDOMElement implements MaterialInterface {
     }
   }
 
-  get pbrMetallicRoughness() {
+  get pbrMetallicRoughness(): PBRMetallicRoughness|null {
     return this[$pbrMetallicRoughness];
   }
 
-  get normalTexture() {
+  get normalTexture(): TextureInfo|null {
     return this[$normalTexture];
   }
 
-  get occlusionTexture() {
+  get occlusionTexture(): TextureInfo|null {
     return this[$occlusionTexture];
   }
 
-  get emissiveTexture() {
+  get emissiveTexture(): TextureInfo|null {
     return this[$emissiveTexture];
   }
 

--- a/packages/3dom/src/facade/three-js/model-graft.ts
+++ b/packages/3dom/src/facade/three-js/model-graft.ts
@@ -85,11 +85,11 @@ export class ModelGraft implements EventTarget, ModelGraftInterface {
     this[$model] = new Model(this, modelUri, correlatedSceneGraph);
   }
 
-  get correlatedSceneGraph() {
+  get correlatedSceneGraph(): CorrelatedSceneGraph {
     return this[$correlatedSceneGraph];
   }
 
-  get model() {
+  get model(): Model {
     return this[$model];
   }
 
@@ -103,11 +103,11 @@ export class ModelGraft implements EventTarget, ModelGraftInterface {
     return element;
   }
 
-  adopt(element: ThreeDOMElement) {
+  adopt(element: ThreeDOMElement): void {
     this[$elementsByInternalId].set(element.internalID, element);
   }
 
-  async mutate(id: number, property: string, value: unknown) {
+  async mutate(id: number, property: string, value: unknown): Promise<void> {
     const element = this.getElementByInternalId(id);
 
     await element!.mutate(property, value);

--- a/packages/3dom/src/facade/three-js/model.ts
+++ b/packages/3dom/src/facade/three-js/model.ts
@@ -65,7 +65,7 @@ export class Model extends ThreeDOMElement implements ModelInterface {
    * TODO(#1003): How do we handle non-active scenes?
    * TODO(#1002): Desctibe and enforce traversal order
    */
-  get materials() {
+  get materials(): Array<Material> {
     return this[$materials];
   }
 

--- a/packages/3dom/src/facade/three-js/pbr-metallic-roughness.ts
+++ b/packages/3dom/src/facade/three-js/pbr-metallic-roughness.ts
@@ -87,11 +87,11 @@ export class PBRMetallicRoughness extends ThreeDOMElement implements
     return (this.sourceObject as PBRMetallicRoughness).roughnessFactor || 0;
   }
 
-  get baseColorTexture() {
+  get baseColorTexture(): TextureInfo|null {
     return this[$baseColorTexture];
   }
 
-  get metallicRoughnessTexture() {
+  get metallicRoughnessTexture(): TextureInfo|null {
     return this[$metallicRoughnessTexture];
   }
 

--- a/packages/3dom/src/facade/three-js/sampler.ts
+++ b/packages/3dom/src/facade/three-js/sampler.ts
@@ -86,7 +86,7 @@ export class Sampler extends ThreeDOMElement implements SamplerInterface {
   }
 
   async mutate<P extends 'minFilter'|'magFilter'|'wrapS'|'wrapT'>(
-      property: P, value: MinFilter|MagFilter|WrapMode|null) {
+      property: P, value: MinFilter|MagFilter|WrapMode|null): Promise<void> {
     const sampler = this.sourceObject as GLTFSampler;
 
     if (value != null) {

--- a/packages/3dom/src/facade/three-js/texture-info.ts
+++ b/packages/3dom/src/facade/three-js/texture-info.ts
@@ -49,7 +49,7 @@ export class TextureInfo extends ThreeDOMElement implements
     }
   }
 
-  get texture() {
+  get texture(): Texture|null {
     return this[$texture];
   }
 

--- a/packages/3dom/src/facade/three-js/texture.ts
+++ b/packages/3dom/src/facade/three-js/texture.ts
@@ -60,11 +60,11 @@ export class Texture extends ThreeDOMElement implements TextureInterface {
     }
   }
 
-  get sampler() {
+  get sampler(): Sampler|null {
     return this[$sampler];
   }
 
-  get source() {
+  get source(): Image|null {
     return this[$source];
   }
 

--- a/packages/3dom/src/facade/three-js/three-dom-element.ts
+++ b/packages/3dom/src/facade/three-js/three-dom-element.ts
@@ -18,7 +18,7 @@ import {Material, Object3D, Texture} from 'three';
 import {GLTF, GLTFElement} from '../../gltf-2.0.js';
 import {SerializedThreeDOMElement} from '../../protocol.js';
 import {getLocallyUniqueId} from '../../utilities.js';
-import {ThreeDOMElement as ThreeDOMElementInterface} from '../api.js';
+import {Model, ThreeDOMElement as ThreeDOMElementInterface} from '../api.js';
 
 import {ModelGraft} from './model-graft.js';
 
@@ -57,7 +57,7 @@ export class ThreeDOMElement implements ThreeDOMElementInterface {
   /**
    * The Model of provenance for this scene graph element.
    */
-  get ownerModel() {
+  get ownerModel(): Model {
     return this[$graft].model;
   }
 
@@ -66,7 +66,7 @@ export class ThreeDOMElement implements ThreeDOMElementInterface {
    * considered unique to the element in the context of its scene graph. These
    * IDs are not guaranteed to be stable across script executions.
    */
-  get internalID() {
+  get internalID(): number {
     return this[$id];
   }
 
@@ -76,21 +76,21 @@ export class ThreeDOMElement implements ThreeDOMElementInterface {
    * We only want to expose a name that is set in the source glTF, so Three.js
    * generated names are ignored.
    */
-  get name() {
+  get name(): string|null {
     return (this[$sourceObject] as unknown as {name?: string}).name || null;
   }
 
   /**
    * The backing Three.js scene graph construct for this element.
    */
-  get correlatedObjects() {
+  get correlatedObjects(): CorrelatedObjects|null {
     return this[$correlatedObjects];
   }
 
   /**
    * The canonical GLTF or GLTFElement represented by this facade.
    */
-  get sourceObject() {
+  get sourceObject(): GLTFElement|GLTF {
     return this[$sourceObject];
   }
 

--- a/packages/3dom/src/test-helpers.ts
+++ b/packages/3dom/src/test-helpers.ts
@@ -37,19 +37,19 @@ export class FakePBRMetallicRoughness implements PBRMetallicRoughness {
           FakePBRMetallicRoughness.count++}`) {
   }
 
-  get ownerModel() {
+  get ownerModel(): Model {
     return this.kernel.model;
   }
 
-  setBaseColorFactor(_value: RGBA) {
+  setBaseColorFactor(_value: RGBA): Promise<void> {
     return Promise.resolve();
   }
 
-  setMetallicFactor(_value: number) {
+  setMetallicFactor(_value: number): Promise<void> {
     return Promise.resolve();
   }
 
-  setRoughnessFactor(_value: number) {
+  setRoughnessFactor(_value: number): Promise<void> {
     return Promise.resolve();
   }
 }
@@ -73,7 +73,7 @@ export class FakeMaterial extends FakeThreeDOMElement implements Material {
     super();
   }
 
-  get ownerModel() {
+  get ownerModel(): Model {
     return this.kernel.model;
   }
 }
@@ -98,7 +98,7 @@ export class FakeImage extends FakeThreeDOMElement implements Image {
   private static count = 0;
   uri: string|null = null;
 
-  get type() {
+  get type(): 'external'|'embedded' {
     return this.uri ? 'external' : 'embedded';
   }
 
@@ -202,7 +202,8 @@ export class FakeModelKernel implements ModelKernelInterface {
   }
 }
 
-export const assetPath = (asset: string) => `./base/shared-assets/${asset}`;
+export const assetPath = (asset: string): string =>
+    `./base/shared-assets/${asset}`;
 
 export const loadThreeGLTF = (url: string): Promise<ThreeGLTF> => {
   const loader = new GLTFLoader();
@@ -211,7 +212,7 @@ export const loadThreeGLTF = (url: string): Promise<ThreeGLTF> => {
   });
 };
 
-export const createFakeThreeGLTF = () => {
+export const createFakeThreeGLTF = (): ThreeGLTF => {
   const scene = new Group();
 
   return {

--- a/packages/3dom/src/utilities.ts
+++ b/packages/3dom/src/utilities.ts
@@ -117,7 +117,7 @@ export class GLTFTreeVisitor {
    * Sparse traversal can also be specified, in which case elements that
    * re-appear multiple times in the scene graph will only be visited once.
    */
-  visit(gltf: GLTF, options: VisitOptions = {}) {
+  visit(gltf: GLTF, options: VisitOptions = {}): void {
     const allScenes = !!options.allScenes;
     const sparse = !!options.sparse;
     const scenes = allScenes ?

--- a/packages/model-viewer/src/test/three-components/Renderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/Renderer-spec.ts
@@ -93,13 +93,13 @@ suite('Renderer', () => {
 
     test('renders only dirty scenes', () => {
       renderer.render(performance.now());
-      expect(scene.renderCount).to.be.equal(1);
-      expect(otherScene.renderCount).to.be.equal(1);
+      expect(scene.renderCount).to.be.equal(1, 'scene first render');
+      expect(otherScene.renderCount).to.be.equal(1, 'otherScene first render');
 
       scene.isDirty = true;
       renderer.render(performance.now());
-      expect(scene.renderCount).to.be.equal(2);
-      expect(otherScene.renderCount).to.be.equal(1);
+      expect(scene.renderCount).to.be.equal(2, 'scene second render');
+      expect(otherScene.renderCount).to.be.equal(1, 'otherScene second render');
     });
 
     test('does not render scenes that have not been loaded', () => {


### PR DESCRIPTION
ESLint got pickier about specifying return types, which I think is good practice anyway. I've added them all across 3dom where they were missing to remove the warnings.