### PR TITLE
manual turntable rotation

### DIFF
--- a/packages/model-viewer/src/features/staging.ts
+++ b/packages/model-viewer/src/features/staging.ts
@@ -47,7 +47,7 @@ export declare interface StagingInterface {
   autoRotate: boolean;
   autoRotateDelay: number;
   readonly turntableRotation: number;
-  resetTurntableRotation(): void;
+  resetTurntableRotation(theta?: number): void;
 }
 
 export const StagingMixin = <T extends Constructor<ModelViewerElementBase>>(
@@ -126,8 +126,8 @@ export const StagingMixin = <T extends Constructor<ModelViewerElementBase>>(
       return this[$scene].yaw;
     }
 
-    resetTurntableRotation() {
-      this[$scene].yaw = 0;
+    resetTurntableRotation(theta = 0) {
+      this[$scene].yaw = theta;
     }
   }
 

--- a/packages/model-viewer/src/test/features/staging-spec.ts
+++ b/packages/model-viewer/src/test/features/staging-spec.ts
@@ -60,6 +60,14 @@ suite('ModelViewerElementBase with StagingMixin', () => {
       document.body.removeChild(element);
     });
 
+    test('can manually rotate turntable', () => {
+      element.resetTurntableRotation(3);
+      expect(element.turntableRotation).to.be.equal(3);
+
+      element.resetTurntableRotation();
+      expect(element.turntableRotation).to.be.equal(0);
+    });
+
     suite('auto-rotate', () => {
       setup(async () => {
         element.autoRotate = true;

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -596,11 +596,12 @@
               currentTime property to 0.</p>
             </li>
             <li>
-              <div>resetTurntableRotation()</div>
-              <p>Resets the turntable that rotates the model when auto-rotate
-              is enabled. The new value of the turntable rotation will be 0 after
-              this method is invoked, but the model may not update until the next
-              render frame.</p>
+              <div>resetTurntableRotation(theta)</div>
+              <p>Resets the turntable that rotates the model when auto-rotate is
+              enabled. The new value of the turntable rotation will be theta
+              radians after this method is invoked, but the model may not update
+              until the next render frame. If no argument is supplied, theta
+              defaults to zero.</p>
             </li>
             <li>
               <div>resetInteractionPrompt()</div>


### PR DESCRIPTION
Fixes #1541 

Now the `resetTurntableRotation()` method takes an option argument for the desired value in radians. This will allow scriptable rotation relative to the environment. 