### PR TITLE
Pan example

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -17,7 +17,7 @@ import {property} from 'lit-element';
 import {Event, PerspectiveCamera, Spherical, Vector3} from 'three';
 
 import {style} from '../decorators.js';
-import ModelViewerElementBase, {$ariaLabel, $container, $hasTransitioned, $loadedTime, $needsRender, $onModelLoad, $onResize, $renderer, $scene, $tick, $userInputElement, Vector3D} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$ariaLabel, $container, $hasTransitioned, $loadedTime, $needsRender, $onModelLoad, $onResize, $renderer, $scene, $tick, $userInputElement, toVector3D, Vector3D} from '../model-viewer-base.js';
 import {degreesToRadians, normalizeUnit} from '../styles/conversions.js';
 import {EvaluatedStyle, Intrinsics, SphericalIntrinsics, StyleEvaluator, Vector3Intrinsics} from '../styles/evaluators.js';
 import {IdentNode, NumberNode, numberNode, parseExpressions} from '../styles/parsers.js';
@@ -365,7 +365,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     getCameraTarget(): Vector3D {
-      return this[$scene].getTarget();
+      return toVector3D(this[$scene].getTarget());
     }
 
     getFieldOfView(): number {

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -201,7 +201,8 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
         settleControls(controls);
 
-        expect(element.getCameraTarget()).to.be.eql(target);
+        expect(element.getCameraTarget().toString())
+            .to.be.equal(target.toString());
       });
 
       test('causes the camera to look at the target', () => {
@@ -226,8 +227,10 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
       });
 
       test('defaults FOV limits correctly', async () => {
-        expect(element.getMinimumFieldOfView()).to.be.closeTo(DEFAULT_MIN_FOV, 0.00001);
-        expect(element.getMaximumFieldOfView()).to.be.closeTo(DEFAULT_MAX_FOV, 0.00001);
+        expect(element.getMinimumFieldOfView())
+            .to.be.closeTo(DEFAULT_MIN_FOV, 0.00001);
+        expect(element.getMaximumFieldOfView())
+            .to.be.closeTo(DEFAULT_MAX_FOV, 0.00001);
       });
 
       test('can independently adjust FOV', async () => {

--- a/packages/modelviewer.dev/examples/staging-and-camera-control.html
+++ b/packages/modelviewer.dev/examples/staging-and-camera-control.html
@@ -177,7 +177,7 @@
 <script>
 (() => {
   const modelViewer = document.querySelector('#pan-demo');
-  const tapDistance = 0.1;
+  const tapDistance = 2;
   let panning = false;
   let panX, panY;
   let firstX, firstY;
@@ -208,8 +208,6 @@
 
   const recenter=(pointer)=>{
     panning = false;
-    console.log(startX);
-    console.log(pointer.clientX-startX, pointer.clientY-startY);
     if(Math.abs(pointer.clientX-startX)>tapDistance||Math.abs(pointer.clientY-startY)>tapDistance)return;
     const rect = modelViewer.getBoundingClientRect();
     const x = event.clientX - rect.left;
@@ -243,14 +241,14 @@
     if(!panning) return;
 
     const {touches} = event;
-    const lastX=0.5*(touches[0].clientX+touches[1].clientX);
-    const lastY=0.5*(touches[0].clientY+touches[1].clientY);
+    lastX=0.5*(touches[0].clientX+touches[1].clientX);
+    lastY=0.5*(touches[0].clientY+touches[1].clientY);
     startPan();
   }, true);
 
   modelViewer.addEventListener('mousemove', (event)=>{
     if(!panning) return;
-    
+
     movePan(event.clientX,event.clientY);
     event.stopPropagation();
   }, true);

--- a/packages/modelviewer.dev/examples/staging-and-camera-control.html
+++ b/packages/modelviewer.dev/examples/staging-and-camera-control.html
@@ -130,6 +130,63 @@
   </div>
 
   <div class="sample">
+    <div id="demo-container-4.5" class="demo"></div>
+    <div class="content">
+      <div class="wrapper">
+        <div class="heading">
+          <h2 class="demo-title">Add other interactions like pan</h2>
+          <h4></h4>
+        </div>
+        <example-snippet stamp-to="demo-container-4.5" highlight-as="html">
+          <template>
+<model-viewer id="pan-demo" camera-controls src="../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
+<script>
+(() => {
+  const modelViewer = document.querySelector('#pan-demo');
+  let panning = false;
+  let panX, panY;
+  let lastPointer;
+  const gain=0.003;
+
+  modelViewer.addEventListener('mousedown', (event)=>{
+    panning = event.button === 2 || event.ctrlKey || event.metaKey || event.shiftKey;
+    if(!panning) return;
+    
+    const orbit = modelViewer.getCameraOrbit();
+    const {theta, phi} = orbit;
+    panX=[-Math.cos(theta), 0, Math.sin(theta)];
+    panY=[-Math.cos(phi)*Math.sin(theta), Math.sin(phi),-Math.cos(phi)*Math.cos(theta)];
+    lastPointer=event;
+    event.stopPropagation();
+  }, true);
+
+  modelViewer.addEventListener('mouseup', (event)=>{
+    panning = false;
+  }, true);
+
+  modelViewer.addEventListener('mousemove', (event)=>{
+    if(!panning) return;
+    
+    const target=modelViewer.getCameraTarget();
+    const dx=(event.clientX-lastPointer.clientX)*gain;
+    const dy=(event.clientY-lastPointer.clientY)*gain;
+    lastPointer=event;
+    
+    target.x+=dx*panX[0]+dy*panY[0];
+    target.y+=dx*panX[1]+dy*panY[1];
+    target.z+=dx*panX[2]+dy*panY[2];
+    modelViewer.cameraTarget=target.toString();
+    event.stopPropagation();
+  }, true);
+})();
+</script>
+          </template>
+        </example-snippet>
+      </div>
+    </div>
+  </div>
+
+  <div class="sample">
     <div id="demo-container-5" class="demo"></div>
     <div class="content">
       <div class="wrapper">

--- a/packages/modelviewer.dev/examples/staging-and-camera-control.html
+++ b/packages/modelviewer.dev/examples/staging-and-camera-control.html
@@ -130,63 +130,6 @@
   </div>
 
   <div class="sample">
-    <div id="demo-container-4.5" class="demo"></div>
-    <div class="content">
-      <div class="wrapper">
-        <div class="heading">
-          <h2 class="demo-title">Add other interactions like pan</h2>
-          <h4></h4>
-        </div>
-        <example-snippet stamp-to="demo-container-4.5" highlight-as="html">
-          <template>
-<model-viewer id="pan-demo" camera-controls src="../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
-<script>
-(() => {
-  const modelViewer = document.querySelector('#pan-demo');
-  let panning = false;
-  let panX, panY;
-  let lastPointer;
-  const gain=0.003;
-
-  modelViewer.addEventListener('mousedown', (event)=>{
-    panning = event.button === 2 || event.ctrlKey || event.metaKey || event.shiftKey;
-    if(!panning) return;
-    
-    const orbit = modelViewer.getCameraOrbit();
-    const {theta, phi} = orbit;
-    panX=[-Math.cos(theta), 0, Math.sin(theta)];
-    panY=[-Math.cos(phi)*Math.sin(theta), Math.sin(phi),-Math.cos(phi)*Math.cos(theta)];
-    lastPointer=event;
-    event.stopPropagation();
-  }, true);
-
-  modelViewer.addEventListener('mouseup', (event)=>{
-    panning = false;
-  }, true);
-
-  modelViewer.addEventListener('mousemove', (event)=>{
-    if(!panning) return;
-    
-    const target=modelViewer.getCameraTarget();
-    const dx=(event.clientX-lastPointer.clientX)*gain;
-    const dy=(event.clientY-lastPointer.clientY)*gain;
-    lastPointer=event;
-    
-    target.x+=dx*panX[0]+dy*panY[0];
-    target.y+=dx*panX[1]+dy*panY[1];
-    target.z+=dx*panX[2]+dy*panY[2];
-    modelViewer.cameraTarget=target.toString();
-    event.stopPropagation();
-  }, true);
-})();
-</script>
-          </template>
-        </example-snippet>
-      </div>
-    </div>
-  </div>
-
-  <div class="sample">
     <div id="demo-container-5" class="demo"></div>
     <div class="content">
       <div class="wrapper">
@@ -214,6 +157,65 @@
         <example-snippet stamp-to="demo-container-6" highlight-as="html">
           <template>
 <model-viewer camera-controls camera-target="0m 0m 0m" auto-rotate src="../shared-assets/models/odd-shape-labeled.glb" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1" ar></model-viewer>
+          </template>
+        </example-snippet>
+      </div>
+    </div>
+  </div>
+
+  <div class="sample">
+    <div id="demo-container-7" class="demo"></div>
+    <div class="content">
+      <div class="wrapper">
+        <div class="heading">
+          <h2 class="demo-title">Add other interactions like pan</h2>
+          <h4></h4>
+        </div>
+        <example-snippet stamp-to="demo-container-7" highlight-as="html">
+          <template>
+<model-viewer id="pan-demo" camera-controls src="../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
+<script>
+(() => {
+  const modelViewer = document.querySelector('#pan-demo');
+  let panning = false;
+  let panX, panY;
+  let lastPointer;
+  let gain;
+
+  modelViewer.addEventListener('mousedown', (event)=>{
+    panning = event.button === 2 || event.ctrlKey || event.metaKey || event.shiftKey;
+    if(!panning) return;
+    
+    const orbit = modelViewer.getCameraOrbit();
+    const {theta, phi, radius} = orbit;
+    gain = 0.75*radius/modelViewer.getBoundingClientRect().height;
+    panX=[-Math.cos(theta), 0, Math.sin(theta)];
+    panY=[-Math.cos(phi)*Math.sin(theta), Math.sin(phi),-Math.cos(phi)*Math.cos(theta)];
+    lastPointer=event;
+    modelViewer.interactionPrompt='none';
+    event.stopPropagation();
+  }, true);
+
+  modelViewer.addEventListener('mouseup', (event)=>{
+    panning = false;
+  }, true);
+
+  modelViewer.addEventListener('mousemove', (event)=>{
+    if(!panning) return;
+    
+    const target=modelViewer.getCameraTarget();
+    const dx=(event.clientX-lastPointer.clientX)*gain;
+    const dy=(event.clientY-lastPointer.clientY)*gain;
+    lastPointer=event;
+    
+    target.x+=dx*panX[0]+dy*panY[0];
+    target.y+=dx*panX[1]+dy*panY[1];
+    target.z+=dx*panX[2]+dy*panY[2];
+    modelViewer.cameraTarget=`${target.x}m ${target.y}m ${target.z}m`;
+    event.stopPropagation();
+  }, true);
+})();
+</script>
           </template>
         </example-snippet>
       </div>

--- a/packages/modelviewer.dev/examples/staging-and-camera-control.html
+++ b/packages/modelviewer.dev/examples/staging-and-camera-control.html
@@ -179,40 +179,71 @@
   const modelViewer = document.querySelector('#pan-demo');
   let panning = false;
   let panX, panY;
-  let lastPointer;
+  let lastX, lastY;
   let gain;
 
-  modelViewer.addEventListener('mousedown', (event)=>{
-    panning = event.button === 2 || event.ctrlKey || event.metaKey || event.shiftKey;
-    if(!panning) return;
-    
+  const startPan=(event)=>{
     const orbit = modelViewer.getCameraOrbit();
     const {theta, phi, radius} = orbit;
     gain = 0.75*radius/modelViewer.getBoundingClientRect().height;
     panX=[-Math.cos(theta), 0, Math.sin(theta)];
     panY=[-Math.cos(phi)*Math.sin(theta), Math.sin(phi),-Math.cos(phi)*Math.cos(theta)];
-    lastPointer=event;
+    lastX=event.clientX;
+    lastY=event.clientY;
     modelViewer.interactionPrompt='none';
+  };
+
+  const movePan=(thisX, thisY)=>{
+    const dx=(thisX-lastX)*gain;
+    const dy=(thisY-lastY)*gain;
+    lastX=thisX;
+    lastY=thisY;
+    
+    const target=modelViewer.getCameraTarget();
+    target.x+=dx*panX[0]+dy*panY[0];
+    target.y+=dx*panX[1]+dy*panY[1];
+    target.z+=dx*panX[2]+dy*panY[2];
+    modelViewer.cameraTarget=`${target.x}m ${target.y}m ${target.z}m`;
+  };
+
+  modelViewer.addEventListener('mousedown', (event)=>{
+    panning = event.button === 2 || event.ctrlKey || event.metaKey || event.shiftKey;
+    if(!panning) return;
+
+    startPan(event);
     event.stopPropagation();
   }, true);
 
-  modelViewer.addEventListener('mouseup', (event)=>{
+  modelViewer.addEventListener('touchstart', (event)=>{
+    panning = event.touches.length === 2;
+    if(!panning) return;
+
+    startPan(event);
+  }, true);
+
+  modelViewer.addEventListener('mouseup', ()=>{
+    panning = false;
+  }, true);
+
+  modelViewer.addEventListener('touchend', ()=>{
     panning = false;
   }, true);
 
   modelViewer.addEventListener('mousemove', (event)=>{
     if(!panning) return;
     
-    const target=modelViewer.getCameraTarget();
-    const dx=(event.clientX-lastPointer.clientX)*gain;
-    const dy=(event.clientY-lastPointer.clientY)*gain;
-    lastPointer=event;
-    
-    target.x+=dx*panX[0]+dy*panY[0];
-    target.y+=dx*panX[1]+dy*panY[1];
-    target.z+=dx*panX[2]+dy*panY[2];
-    modelViewer.cameraTarget=`${target.x}m ${target.y}m ${target.z}m`;
+    movePan(event.clientX,event.clientY);
     event.stopPropagation();
+  }, true);
+
+  modelViewer.addEventListener('touchmove', (event)=>{
+    panning = event.touches.length === 2;
+    if(!panning) return;
+    
+    const {touches} = event;
+    const thisX=0.5*(touches[0].clientX+touches[1].clientX);
+    const thisY=0.5*(touches[0].clientY+touches[1].clientY);
+    movePan(thisX,thisY);
   }, true);
 })();
 </script>

--- a/packages/modelviewer.dev/examples/staging-and-camera-control.html
+++ b/packages/modelviewer.dev/examples/staging-and-camera-control.html
@@ -169,7 +169,16 @@
       <div class="wrapper">
         <div class="heading">
           <h2 class="demo-title">Add other interactions like pan</h2>
-          <h4></h4>
+          <h4>Event listeners can cooperate with camera-controls</h4>
+          <p>By using capture on your event listeners you can make sure the
+          events are also passed in as usual to the built in camera controls.
+          This can be selectively disabled by calling stopPropagation() on the
+          event.</p>
+          <p>This is one of many possible implementations of panning around a
+          model, including the ability to set the target by clicking. It is left
+          as an example here as there are too many possible variations to make a
+          reasonable API around. It also tends to be confusing to users in cases
+          where it is not necessary.</p>
         </div>
         <example-snippet stamp-to="demo-container-7" highlight-as="html">
           <template>
@@ -182,12 +191,12 @@
   let panX, panY;
   let firstX, firstY;
   let lastX, lastY;
-  let gain;
+  let metersPerPixel;
 
   const startPan = () => {
     const orbit = modelViewer.getCameraOrbit();
     const {theta, phi, radius} = orbit;
-    gain = 0.75 * radius / modelViewer.getBoundingClientRect().height;
+    metersPerPixel = 0.75 * radius / modelViewer.getBoundingClientRect().height;
     panX = [-Math.cos(theta), 0, Math.sin(theta)];
     panY = [
       -Math.cos(phi) * Math.sin(theta),
@@ -198,8 +207,8 @@
   };
 
   const movePan = (thisX, thisY) => {
-    const dx = (thisX - lastX) * gain;
-    const dy = (thisY - lastY) * gain;
+    const dx = (thisX - lastX) * metersPerPixel;
+    const dy = (thisY - lastY) * metersPerPixel;
     lastX = thisX;
     lastY = thisY;
 

--- a/packages/modelviewer.dev/examples/staging-and-camera-control.html
+++ b/packages/modelviewer.dev/examples/staging-and-camera-control.html
@@ -177,19 +177,19 @@
 <script>
 (() => {
   const modelViewer = document.querySelector('#pan-demo');
+  const tapDistance = 0.1;
   let panning = false;
   let panX, panY;
+  let firstX, firstY;
   let lastX, lastY;
   let gain;
 
-  const startPan=(event)=>{
+  const startPan=()=>{
     const orbit = modelViewer.getCameraOrbit();
     const {theta, phi, radius} = orbit;
     gain = 0.75*radius/modelViewer.getBoundingClientRect().height;
     panX=[-Math.cos(theta), 0, Math.sin(theta)];
     panY=[-Math.cos(phi)*Math.sin(theta), Math.sin(phi),-Math.cos(phi)*Math.cos(theta)];
-    lastX=event.clientX;
-    lastY=event.clientY;
     modelViewer.interactionPrompt='none';
   };
 
@@ -206,27 +206,46 @@
     modelViewer.cameraTarget=`${target.x}m ${target.y}m ${target.z}m`;
   };
 
+  const recenter=(pointer)=>{
+    panning = false;
+    console.log(startX);
+    console.log(pointer.clientX-startX, pointer.clientY-startY);
+    if(Math.abs(pointer.clientX-startX)>tapDistance||Math.abs(pointer.clientY-startY)>tapDistance)return;
+    const rect = modelViewer.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const hit = modelViewer.positionAndNormalFromPoint(x,y);
+    modelViewer.cameraTarget=hit==null?'auto auto auto':hit.position.toString();
+  };
+
+  const onPointerUp=(event)=>{
+    const pointer = event.clientX? event:event.changedTouches[0];
+    if(Math.abs(pointer.clientX-startX)<tapDistance&&Math.abs(pointer.clientY-startY)<tapDistance){
+      recenter(pointer);
+    }
+    panning = false;
+  };
+
   modelViewer.addEventListener('mousedown', (event)=>{
+    startX=event.clientX;
+    startY=event.clientY;
     panning = event.button === 2 || event.ctrlKey || event.metaKey || event.shiftKey;
     if(!panning) return;
 
-    startPan(event);
+    startPan();
     event.stopPropagation();
   }, true);
 
   modelViewer.addEventListener('touchstart', (event)=>{
+    startX=event.touches[0].clientX;
+    startY=event.touches[0].clientY;
     panning = event.touches.length === 2;
     if(!panning) return;
 
-    startPan(event);
-  }, true);
-
-  modelViewer.addEventListener('mouseup', ()=>{
-    panning = false;
-  }, true);
-
-  modelViewer.addEventListener('touchend', ()=>{
-    panning = false;
+    const {touches} = event;
+    const lastX=0.5*(touches[0].clientX+touches[1].clientX);
+    const lastY=0.5*(touches[0].clientY+touches[1].clientY);
+    startPan();
   }, true);
 
   modelViewer.addEventListener('mousemove', (event)=>{
@@ -237,13 +256,21 @@
   }, true);
 
   modelViewer.addEventListener('touchmove', (event)=>{
-    panning = event.touches.length === 2;
-    if(!panning) return;
+    if(!panning || event.touches.length !== 2) return;
     
     const {touches} = event;
     const thisX=0.5*(touches[0].clientX+touches[1].clientX);
     const thisY=0.5*(touches[0].clientY+touches[1].clientY);
     movePan(thisX,thisY);
+  }, true);
+
+  modelViewer.addEventListener('mouseup', (event)=>{
+recenter(event);
+  }, true);
+  modelViewer.addEventListener('touchend', (event)=>{
+    if(event.touches.length===0){
+      recenter(event.changedTouches[0]);
+    }
   }, true);
 })();
 </script>

--- a/packages/modelviewer.dev/examples/staging-and-camera-control.html
+++ b/packages/modelviewer.dev/examples/staging-and-camera-control.html
@@ -184,89 +184,102 @@
   let lastX, lastY;
   let gain;
 
-  const startPan=()=>{
+  const startPan = () => {
     const orbit = modelViewer.getCameraOrbit();
     const {theta, phi, radius} = orbit;
-    gain = 0.75*radius/modelViewer.getBoundingClientRect().height;
-    panX=[-Math.cos(theta), 0, Math.sin(theta)];
-    panY=[-Math.cos(phi)*Math.sin(theta), Math.sin(phi),-Math.cos(phi)*Math.cos(theta)];
-    modelViewer.interactionPrompt='none';
+    gain = 0.75 * radius / modelViewer.getBoundingClientRect().height;
+    panX = [-Math.cos(theta), 0, Math.sin(theta)];
+    panY = [
+      -Math.cos(phi) * Math.sin(theta),
+      Math.sin(phi),
+      -Math.cos(phi) * Math.cos(theta)
+    ];
+    modelViewer.interactionPrompt = 'none';
   };
 
-  const movePan=(thisX, thisY)=>{
-    const dx=(thisX-lastX)*gain;
-    const dy=(thisY-lastY)*gain;
-    lastX=thisX;
-    lastY=thisY;
-    
-    const target=modelViewer.getCameraTarget();
-    target.x+=dx*panX[0]+dy*panY[0];
-    target.y+=dx*panX[1]+dy*panY[1];
-    target.z+=dx*panX[2]+dy*panY[2];
-    modelViewer.cameraTarget=`${target.x}m ${target.y}m ${target.z}m`;
+  const movePan = (thisX, thisY) => {
+    const dx = (thisX - lastX) * gain;
+    const dy = (thisY - lastY) * gain;
+    lastX = thisX;
+    lastY = thisY;
+
+    const target = modelViewer.getCameraTarget();
+    target.x += dx * panX[0] + dy * panY[0];
+    target.y += dx * panX[1] + dy * panY[1];
+    target.z += dx * panX[2] + dy * panY[2];
+    modelViewer.cameraTarget = `${target.x}m ${target.y}m ${target.z}m`;
   };
 
-  const recenter=(pointer)=>{
+  const recenter = (pointer) => {
     panning = false;
-    if(Math.abs(pointer.clientX-startX)>tapDistance||Math.abs(pointer.clientY-startY)>tapDistance)return;
+    if (Math.abs(pointer.clientX - startX) > tapDistance ||
+        Math.abs(pointer.clientY - startY) > tapDistance)
+      return;
     const rect = modelViewer.getBoundingClientRect();
     const x = event.clientX - rect.left;
     const y = event.clientY - rect.top;
-    const hit = modelViewer.positionAndNormalFromPoint(x,y);
-    modelViewer.cameraTarget=hit==null?'auto auto auto':hit.position.toString();
+    const hit = modelViewer.positionAndNormalFromPoint(x, y);
+    modelViewer.cameraTarget =
+        hit == null ? 'auto auto auto' : hit.position.toString();
   };
 
-  const onPointerUp=(event)=>{
-    const pointer = event.clientX? event:event.changedTouches[0];
-    if(Math.abs(pointer.clientX-startX)<tapDistance&&Math.abs(pointer.clientY-startY)<tapDistance){
+  const onPointerUp = (event) => {
+    const pointer = event.clientX ? event : event.changedTouches[0];
+    if (Math.abs(pointer.clientX - startX) < tapDistance &&
+        Math.abs(pointer.clientY - startY) < tapDistance) {
       recenter(pointer);
     }
     panning = false;
   };
 
-  modelViewer.addEventListener('mousedown', (event)=>{
-    startX=event.clientX;
-    startY=event.clientY;
-    panning = event.button === 2 || event.ctrlKey || event.metaKey || event.shiftKey;
-    if(!panning) return;
+  modelViewer.addEventListener('mousedown', (event) => {
+    startX = event.clientX;
+    startY = event.clientY;
+    panning = event.button === 2 || event.ctrlKey || event.metaKey ||
+        event.shiftKey;
+    if (!panning)
+      return;
 
     startPan();
     event.stopPropagation();
   }, true);
 
-  modelViewer.addEventListener('touchstart', (event)=>{
-    startX=event.touches[0].clientX;
-    startY=event.touches[0].clientY;
+  modelViewer.addEventListener('touchstart', (event) => {
+    startX = event.touches[0].clientX;
+    startY = event.touches[0].clientY;
     panning = event.touches.length === 2;
-    if(!panning) return;
+    if (!panning)
+      return;
 
     const {touches} = event;
-    lastX=0.5*(touches[0].clientX+touches[1].clientX);
-    lastY=0.5*(touches[0].clientY+touches[1].clientY);
+    lastX = 0.5 * (touches[0].clientX + touches[1].clientX);
+    lastY = 0.5 * (touches[0].clientY + touches[1].clientY);
     startPan();
   }, true);
 
-  modelViewer.addEventListener('mousemove', (event)=>{
-    if(!panning) return;
+  modelViewer.addEventListener('mousemove', (event) => {
+    if (!panning)
+      return;
 
-    movePan(event.clientX,event.clientY);
+    movePan(event.clientX, event.clientY);
     event.stopPropagation();
   }, true);
 
-  modelViewer.addEventListener('touchmove', (event)=>{
-    if(!panning || event.touches.length !== 2) return;
-    
+  modelViewer.addEventListener('touchmove', (event) => {
+    if (!panning || event.touches.length !== 2)
+      return;
+
     const {touches} = event;
-    const thisX=0.5*(touches[0].clientX+touches[1].clientX);
-    const thisY=0.5*(touches[0].clientY+touches[1].clientY);
-    movePan(thisX,thisY);
+    const thisX = 0.5 * (touches[0].clientX + touches[1].clientX);
+    const thisY = 0.5 * (touches[0].clientY + touches[1].clientY);
+    movePan(thisX, thisY);
   }, true);
 
-  modelViewer.addEventListener('mouseup', (event)=>{
-recenter(event);
+  modelViewer.addEventListener('mouseup', (event) => {
+    recenter(event);
   }, true);
-  modelViewer.addEventListener('touchend', (event)=>{
-    if(event.touches.length===0){
+  modelViewer.addEventListener('touchend', (event) => {
+    if (event.touches.length === 0) {
       recenter(event.changedTouches[0]);
     }
   }, true);


### PR DESCRIPTION
Fixes #447 

I've added an example of pan to the staging-and-camera-control examples. This is a decent generic pan example, but there are a lot of possible variations that are use-case specific, so hopefully this gives everyone enough to go on to build their own. I don't see this entering our API, as it can be confusing in many cases and it doesn't work for all scenarios that require pan - for instance a city model might constrain pan to the horizontal plane instead of screen space.