### PR TITLE
set performance example prompt threshold to zero

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -37,21 +37,19 @@ const PROMPT_ANIMATION_TIME = 5000;
 // For timing purposes, a "frame" is a timing agnostic relative unit of time
 // and a "value" is a target value for the keyframe.
 const wiggle = timeline(0, [
-  {frames: 6, value: 0},
   {frames: 5, value: -1},
   {frames: 1, value: -1},
   {frames: 8, value: 1},
   {frames: 1, value: 1},
   {frames: 5, value: 0},
-  {frames: 12, value: 0}
+  {frames: 18, value: 0}
 ]);
 
 const fade = timeline(0, [
-  {frames: 2, value: 0},
   {frames: 1, value: 1},
   {frames: 5, value: 1},
   {frames: 1, value: 0},
-  {frames: 4, value: 0}
+  {frames: 6, value: 0}
 ]);
 
 export const DEFAULT_CAMERA_ORBIT = '0deg 75deg 105%';

--- a/packages/modelviewer.dev/examples/lighthouse.html
+++ b/packages/modelviewer.dev/examples/lighthouse.html
@@ -147,6 +147,7 @@
         id="first"
         src="../assets/ShopifyModels/Chair.glb"
         camera-orbit="1.2195rad 1.362rad auto"
+        interaction-prompt-threshold="0"
         shadow-intensity="1"
         ar
         camera-controls
@@ -199,6 +200,7 @@
     <model-viewer
       src="../assets/ShopifyModels/Mixer.glb"
       camera-orbit="0.9677rad 1.2427rad auto"
+      interaction-prompt-threshold="0"
       shadow-intensity="1"
       ar
       camera-controls


### PR DESCRIPTION
Turns out there was also about 750ms of prompt delay added on top of the threshold, so that's now been removed so that zero means immediately. 