### PR TITLE
show AR button after loading

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -17,7 +17,7 @@ import {property} from 'lit-element';
 import {Event as ThreeEvent} from 'three';
 
 import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
-import ModelViewerElementBase, {$renderer, $scene} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$loaded, $onModelLoad, $renderer, $scene} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
 import {ARStatus} from '../three-components/ARRenderer.js';
 import {Constructor} from '../utilities.js';
@@ -167,7 +167,9 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
         this[$scene].canScale = this.arScale !== 'fixed';
       }
 
-      this[$selectARMode]();
+      if (this[$loaded]) {
+        this[$selectARMode]();
+      }
     }
 
     /**
@@ -193,6 +195,11 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
 configuration or device capabilities');
           break;
       }
+    }
+
+    [$onModelLoad]() {
+      super[$onModelLoad]();
+      this[$selectARMode]();
     }
 
     async[$selectARMode]() {


### PR DESCRIPTION
Fixes #272

The AR button would fail to be hidden if a transparent poster was used. This ensures it only appears once the model is loaded.
