### PR TITLE
update DRACO to match three's version

### DIFF
--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -31,7 +31,7 @@ export const PROGRESS_BAR_UPDATE_THRESHOLD = 100;
 const PROGRESS_MASK_BASE_OPACITY = 0.2;
 
 const DEFAULT_DRACO_DECODER_LOCATION =
-    'https://www.gstatic.com/draco/versioned/decoders/1.3.5/';
+    'https://www.gstatic.com/draco/versioned/decoders/1.3.6/';
 
 const SPACE_KEY = 32;
 const ENTER_KEY = 13;


### PR DESCRIPTION
Fixes DRACO loading error that came with the r121 update.