### PR TITLE
Update TextureUtils.ts

### DIFF
--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -34,7 +34,7 @@ const GENERATED_SIGMA = 0.04;
 // Image objects to decode images fetched over the network.
 Cache.enabled = true;
 
-const HDR_FILE_RE = /\.hdr$/;
+const HDR_FILE_RE = /\.hdr(\.js)?$/;
 const ldrLoader = new TextureLoader();
 const hdrLoader = new RGBELoader();
 


### PR DESCRIPTION
Allow HDR image files with an optional '.js' extension.