### PR TITLE
Disable BrowserStack testing until our license recovers

### DIFF
--- a/.github/workflows/unit-tests-third-party.yml
+++ b/.github/workflows/unit-tests-third-party.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
-    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
+    # Remove when BrowserStack testing is operational again
+    if: false
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1


### PR DESCRIPTION
Revert this once our check clears. No releases until this has been reverted and full testing passes. 