### PR TITLE
AR button before load

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -17,7 +17,7 @@ import {property} from 'lit-element';
 import {Event as ThreeEvent} from 'three';
 
 import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
-import ModelViewerElementBase, {$loaded, $renderer, $scene} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$loaded, $renderer, $scene, $shouldAttemptPreload, $updateSource} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
 import {ARStatus} from '../three-components/ARRenderer.js';
 import {Constructor, waitForEvent} from '../utilities.js';
@@ -59,6 +59,7 @@ const $arModes = Symbol('arModes');
 const $canLaunchQuickLook = Symbol('canLaunchQuickLook');
 const $quickLookBrowsers = Symbol('quickLookBrowsers');
 const $arAnchor = Symbol('arAnchor');
+const $preload = Symbol('preload');
 
 const $onARButtonContainerClick = Symbol('onARButtonContainerClick');
 const $onARStatus = Symbol('onARStatus');
@@ -105,6 +106,7 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     protected[$arModes]: Set<ARMode> = new Set();
     protected[$arMode]: ARMode = ARMode.NONE;
+    protected[$preload] = false;
 
     protected[$quickLookBrowsers]: Set<QuickLookBrowser> = new Set();
 
@@ -252,8 +254,10 @@ configuration or device capabilities');
       console.log('Attempting to present in AR...');
 
       if (!this[$loaded]) {
-        (this as any).dismissPoster();
+        this[$preload] = true;
+        this[$updateSource]();
         await waitForEvent(this, 'load');
+        this[$preload] = false;
       }
 
       try {
@@ -270,6 +274,10 @@ configuration or device capabilities');
       } finally {
         this[$selectARMode]();
       }
+    }
+
+    [$shouldAttemptPreload](): boolean {
+      return super[$shouldAttemptPreload]() || this[$preload];
     }
 
     /**

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -17,10 +17,10 @@ import {property} from 'lit-element';
 import {Event as ThreeEvent} from 'three';
 
 import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
-import ModelViewerElementBase, {$renderer, $scene} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$loaded, $renderer, $scene} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
 import {ARStatus} from '../three-components/ARRenderer.js';
-import {Constructor} from '../utilities.js';
+import {Constructor, waitForEvent} from '../utilities.js';
 
 let isWebXRBlocked = false;
 let isSceneViewerBlocked = false;
@@ -250,6 +250,11 @@ configuration or device capabilities');
 
     protected async[$enterARWithWebXR]() {
       console.log('Attempting to present in AR...');
+
+      if (!this[$loaded]) {
+        (this as any).dismissPoster();
+        await waitForEvent(this, 'load');
+      }
 
       try {
         this[$arButtonContainer].removeEventListener(

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -17,7 +17,7 @@ import {property} from 'lit-element';
 import {Event as ThreeEvent} from 'three';
 
 import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
-import ModelViewerElementBase, {$loaded, $onModelLoad, $renderer, $scene} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$renderer, $scene} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
 import {ARStatus} from '../three-components/ARRenderer.js';
 import {Constructor} from '../utilities.js';
@@ -167,9 +167,7 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
         this[$scene].canScale = this.arScale !== 'fixed';
       }
 
-      if (this[$loaded]) {
-        this[$selectARMode]();
-      }
+      this[$selectARMode]();
     }
 
     /**
@@ -195,11 +193,6 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
 configuration or device capabilities');
           break;
       }
-    }
-
-    [$onModelLoad]() {
-      super[$onModelLoad]();
-      this[$selectARMode]();
     }
 
     async[$selectARMode]() {

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -111,7 +111,6 @@ canvas.show {
 }
 
 .slot.poster {
-  z-index: 1000;
   opacity: 0;
   transition: opacity 0.3s 0.3s;
   background-color: inherit;
@@ -265,7 +264,6 @@ canvas.show {
 }
 
 .slot.default {
-  z-index: 1001;
   pointer-events: none;
 }
 

--- a/packages/model-viewer/src/test/features/animation-spec.ts
+++ b/packages/model-viewer/src/test/features/animation-spec.ts
@@ -15,7 +15,8 @@
 
 import {AnimationMixin} from '../../features/animation.js';
 import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
-import {assetPath, timePasses, waitForEvent} from '../helpers.js';
+import {waitForEvent} from '../../utilities.js';
+import {assetPath, timePasses} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -19,7 +19,8 @@ import {AnnotationInterface, AnnotationMixin} from '../../features/annotation';
 import ModelViewerElementBase, {$loaded, $needsRender, $scene, Vector3D} from '../../model-viewer-base';
 import {Hotspot} from '../../three-components/Hotspot.js';
 import {ModelScene} from '../../three-components/ModelScene';
-import {assetPath, rafPasses, timePasses, waitForEvent} from '../helpers';
+import {waitForEvent} from '../../utilities';
+import {assetPath, rafPasses, timePasses} from '../helpers';
 import {BasicSpecTemplate} from '../templates';
 
 const expect = chai.expect;

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -16,8 +16,8 @@
 import {IS_IE11, IS_IOS} from '../../constants.js';
 import {$openIOSARQuickLook, $openSceneViewer, ARInterface, ARMixin} from '../../features/ar.js';
 import ModelViewerElementBase from '../../model-viewer-base.js';
-import {Constructor} from '../../utilities.js';
-import {assetPath, spy, timePasses, waitForEvent} from '../helpers.js';
+import {Constructor, waitForEvent} from '../../utilities.js';
+import {assetPath, spy, timePasses} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -20,8 +20,8 @@ import {$controls, $promptAnimatedContainer, $promptElement, CameraChangeDetails
 import ModelViewerElementBase, {$canvas, $scene, $userInputElement, Vector3D} from '../../model-viewer-base.js';
 import {StyleEvaluator} from '../../styles/evaluators.js';
 import {ChangeSource, SmoothControls} from '../../three-components/SmoothControls.js';
-import {Constructor, step} from '../../utilities.js';
-import {assetPath, dispatchSyntheticEvent, rafPasses, timePasses, until, waitForEvent} from '../helpers.js';
+import {Constructor, step, waitForEvent} from '../../utilities.js';
+import {assetPath, dispatchSyntheticEvent, rafPasses, timePasses, until} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 import {settleControls} from '../three-components/SmoothControls-spec.js';
 

--- a/packages/model-viewer/src/test/features/environment-spec.ts
+++ b/packages/model-viewer/src/test/features/environment-spec.ts
@@ -20,7 +20,8 @@ import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
 import {$shadow} from '../../three-components/Model.js';
 import {ModelScene} from '../../three-components/ModelScene.js';
 import {Renderer} from '../../three-components/Renderer.js';
-import {assetPath, rafPasses, textureMatchesMeta, timePasses, waitForEvent} from '../helpers.js';
+import {waitForEvent} from '../../utilities.js';
+import {assetPath, rafPasses, textureMatchesMeta, timePasses} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;

--- a/packages/model-viewer/src/test/features/loading-spec.ts
+++ b/packages/model-viewer/src/test/features/loading-spec.ts
@@ -16,7 +16,8 @@
 import {$defaultPosterElement, $posterContainerElement, LoadingInterface, LoadingMixin, POSTER_TRANSITION_TIME} from '../../features/loading.js';
 import ModelViewerElementBase, {$userInputElement} from '../../model-viewer-base.js';
 import {CachingGLTFLoader} from '../../three-components/CachingGLTFLoader.js';
-import {assetPath, dispatchSyntheticEvent, pickShadowDescendant, timePasses, until, waitForEvent} from '../helpers.js';
+import {waitForEvent} from '../../utilities.js';
+import {assetPath, dispatchSyntheticEvent, pickShadowDescendant, timePasses, until} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;

--- a/packages/model-viewer/src/test/features/loading/status-announcer-spec.ts
+++ b/packages/model-viewer/src/test/features/loading/status-announcer-spec.ts
@@ -15,7 +15,8 @@
 import {LoadingMixin} from '../../../features/loading.js';
 import {FINISHED_LOADING_ANNOUNCEMENT, INITIAL_STATUS_ANNOUNCEMENT, LoadingStatusAnnouncer} from '../../../features/loading/status-announcer.js';
 import ModelViewerElementBase from '../../../model-viewer-base.js';
-import {assetPath, isInDocumentTree, until, waitForEvent} from '../../helpers.js';
+import {waitForEvent} from '../../../utilities.js';
+import {assetPath, isInDocumentTree, until} from '../../helpers.js';
 
 const expect = chai.expect;
 

--- a/packages/model-viewer/src/test/features/scene-graph-spec.ts
+++ b/packages/model-viewer/src/test/features/scene-graph-spec.ts
@@ -18,7 +18,8 @@ import {Mesh, MeshStandardMaterial} from 'three';
 import {IS_IE11} from '../../constants.js';
 import {SceneGraphInterface, SceneGraphMixin} from '../../features/scene-graph.js';
 import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
-import {assetPath, rafPasses, waitForEvent} from '../helpers.js';
+import {waitForEvent} from '../../utilities.js';
+import {assetPath, rafPasses} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;

--- a/packages/model-viewer/src/test/features/staging-spec.ts
+++ b/packages/model-viewer/src/test/features/staging-spec.ts
@@ -17,7 +17,8 @@ import {CameraChangeDetails} from '../../features/controls.js';
 import {StagingMixin} from '../../features/staging.js';
 import ModelViewerElementBase from '../../model-viewer-base.js';
 import {ChangeSource} from '../../three-components/SmoothControls.js';
-import {assetPath, rafPasses, timePasses, waitForEvent} from '../helpers.js';
+import {waitForEvent} from '../../utilities.js';
+import {assetPath, rafPasses, timePasses,} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;

--- a/packages/model-viewer/src/test/helpers.ts
+++ b/packages/model-viewer/src/test/helpers.ts
@@ -12,11 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {EventDispatcher, Group, Texture} from 'three';
+import {Group, Texture} from 'three';
 import {GLTFParser} from 'three/examples/jsm/loaders/GLTFLoader.js';
 
 import {ExpressionNode, ExpressionTerm, FunctionNode, HexNode, IdentNode, Operator, OperatorNode} from '../styles/parsers.js';
-import {deserializeUrl} from '../utilities.js';
+import {deserializeUrl, PredicateFunction} from '../utilities.js';
 
 export const elementFromLocalPoint =
     (document: Document|ShadowRoot, x: number, y: number): Element|null => {
@@ -40,14 +40,6 @@ export const pickShadowDescendant =
 
 export const timePasses = (ms: number = 0): Promise<void> =>
     new Promise(resolve => setTimeout(resolve, ms));
-
-export type PredicateFunction<T = void> = (value: T) => boolean;
-
-/**
- * Three.js EventDispatcher and DOM EventTarget use different event patterns,
- * so AnyEvent covers the shape of both event types.
- */
-export type AnyEvent = Event|CustomEvent<any>|{[index: string]: string};
 
 export const until =
     async (predicate: PredicateFunction) => {
@@ -74,25 +66,6 @@ export const textureMatchesMeta =
            Object.keys(meta).reduce((matches, key) => {
              return matches && meta[key] === (texture as any).userData[key];
            }, true));
-
-/**
- * @param {EventTarget|EventDispatcher} target
- * @param {string} eventName
- * @param {?Function} predicate
- */
-export const waitForEvent = <T extends AnyEvent = Event>(
-    target: EventTarget|EventDispatcher,
-    eventName: string,
-    predicate: PredicateFunction<T>|null = null): Promise<T> =>
-    new Promise(resolve => {
-      function handler(event: AnyEvent) {
-        if (!predicate || predicate(event as T)) {
-          resolve(event as T);
-          target.removeEventListener(eventName, handler);
-        }
-      }
-      target.addEventListener(eventName, handler);
-    });
 
 export interface SyntheticEventProperties {
   clientX?: number;

--- a/packages/model-viewer/src/test/model-viewer-base-spec.ts
+++ b/packages/model-viewer/src/test/model-viewer-base-spec.ts
@@ -16,9 +16,9 @@
 import {IS_IE11} from '../constants.js';
 import ModelViewerElementBase, {$renderer, $scene, $userInputElement} from '../model-viewer-base.js';
 import {Renderer} from '../three-components/Renderer.js';
-import {Constructor} from '../utilities.js';
+import {Constructor, waitForEvent} from '../utilities.js';
 
-import {assetPath, spy, timePasses, until, waitForEvent} from './helpers.js';
+import {assetPath, spy, timePasses, until} from './helpers.js';
 import {BasicSpecTemplate} from './templates.js';
 
 

--- a/packages/model-viewer/src/test/model-viewer-spec.ts
+++ b/packages/model-viewer/src/test/model-viewer-spec.ts
@@ -1,8 +1,8 @@
 import {$renderer} from '../model-viewer-base.js';
 import {ModelViewerElement} from '../model-viewer.js';
-import {Constructor} from '../utilities.js';
+import {Constructor, waitForEvent} from '../utilities.js';
 
-import {assetPath, waitForEvent} from './helpers.js';
+import {assetPath} from './helpers.js';
 import {BasicSpecTemplate} from './templates.js';
 
 const expect = chai.expect;

--- a/packages/model-viewer/src/test/three-components/Hotspot-spec.ts
+++ b/packages/model-viewer/src/test/three-components/Hotspot-spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import {Hotspot, HotspotVisibilityDetails} from '../../three-components/Hotspot.js';
-import {waitForEvent} from '../helpers.js';
+import {waitForEvent} from '../../utilities.js';
 
 const expect = chai.expect;
 

--- a/packages/model-viewer/src/test/three-components/Renderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/Renderer-spec.ts
@@ -17,7 +17,8 @@ import {USE_OFFSCREEN_CANVAS} from '../../constants.js';
 import ModelViewerElementBase, {$canvas, $loaded, $onResize, $scene, $userInputElement} from '../../model-viewer-base.js';
 import {ModelScene} from '../../three-components/ModelScene.js';
 import {Renderer} from '../../three-components/Renderer.js';
-import {assetPath, waitForEvent} from '../helpers.js';
+import {waitForEvent} from '../../utilities.js';
+import {assetPath} from '../helpers.js';
 
 const expect = chai.expect;
 

--- a/packages/model-viewer/src/test/three-components/SmoothControls-spec.ts
+++ b/packages/model-viewer/src/test/three-components/SmoothControls-spec.ts
@@ -16,7 +16,8 @@
 import {PerspectiveCamera, Vector3} from 'three';
 
 import {ChangeSource, DEFAULT_OPTIONS, KeyCode, SmoothControls} from '../../three-components/SmoothControls.js';
-import {dispatchSyntheticEvent, waitForEvent} from '../helpers.js';
+import {waitForEvent} from '../../utilities.js';
+import {dispatchSyntheticEvent} from '../helpers.js';
 
 const expect = chai.expect;
 

--- a/packages/model-viewer/src/test/utilities/focus-visible-spec.ts
+++ b/packages/model-viewer/src/test/utilities/focus-visible-spec.ts
@@ -14,8 +14,9 @@
  */
 
 import ModelViewerElementBase from '../../model-viewer-base.js';
+import {waitForEvent} from '../../utilities.js';
 import {FocusVisiblePolyfillMixin} from '../../utilities/focus-visible.js';
-import {assetPath, waitForEvent} from '../helpers.js';
+import {assetPath} from '../helpers.js';
 import {BasicSpecTemplate} from '../templates.js';
 
 const expect = chai.expect;

--- a/packages/model-viewer/src/test/utilities/progress-tracker-spec.ts
+++ b/packages/model-viewer/src/test/utilities/progress-tracker-spec.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
+import {waitForEvent} from '../../utilities.js';
 import {Activity, ProgressDetails, ProgressTracker} from '../../utilities/progress-tracker.js';
-import {waitForEvent} from '../helpers.js';
 
 const expect = chai.expect;
 

--- a/packages/modelviewer.dev/examples/loading/index.html
+++ b/packages/modelviewer.dev/examples/loading/index.html
@@ -315,7 +315,7 @@ ModelViewerElement.dracoDecoderLocation = 'http://example.com/location/of/draco/
           </div>
           <example-snippet stamp-to="demo-container-9" highlight-as="html">
             <template>
-<model-viewer camera-controls alt="A 3D model of an astronaut" ios-src="../../shared-assets/models/Astronaut.usdz">
+<model-viewer camera-controls alt="A 3D model of an astronaut" ar ios-src="../../shared-assets/models/Astronaut.usdz">
 </model-viewer>
             </template>
           </example-snippet>

--- a/packages/modelviewer.dev/examples/model-formats.html
+++ b/packages/modelviewer.dev/examples/model-formats.html
@@ -167,7 +167,7 @@ ModelViewerElement.dracoDecoderLocation =
         </div>
         <example-snippet stamp-to="demo-container-4" highlight-as="html">
           <template>
-<model-viewer camera-controls alt="A 3D model of an astronaut" ios-src="../shared-assets/models/Astronaut.usdz">
+<model-viewer camera-controls alt="A 3D model of an astronaut" ar ios-src="../shared-assets/models/Astronaut.usdz">
 </model-viewer>
           </template>
         </example-snippet>


### PR DESCRIPTION
Fixes #1627 
Fixes #568

Reverts #1567 and #1401 as these were not great fixes, especially after some other work fixed up the hotspot/poster issue better. This also moves `waitForEvent()` from test helpers to utilities, as I'm now using it in the main code base. 

Now using `reveal="manual"`, the poster will remain and AR can be activated before downloading the model. In this way scene-viewer and quick-look can be activated while only downloading the model once (this is always true with webXR). In this way the model-viewer element can become just a customizable "Enter AR" button if desired. 