### PR TITLE
Revert "swap to basic testing (#1595)"

### DIFF
--- a/.github/workflows/unit-tests-third-party.yml
+++ b/.github/workflows/unit-tests-third-party.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
-    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
-    # Remove when BrowserStack testing is operational again
-    if: false
-
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1


### PR DESCRIPTION
This reverts #1595 

Our BrowserStack license should be good to go now, so enabling our cross-browser testing again.


