### PR TITLE
Disable scene-viewer on browsers that don't handle intents

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
     "husky": "^4.2.1",
     "lerna": "^3.20.2",
     "typescript": "4.0.3"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -78,6 +78,7 @@ export const IS_AR_QUICKLOOK_CANDIDATE = (() => {
 
 // @see https://developer.chrome.com/multidevice/user-agent
 export const IS_SAFARI = /Safari\//.test(navigator.userAgent);
+export const IS_FIREFOX = /firefox/i.test(navigator.userAgent);
 export const IS_IOS_CHROME = IS_IOS && /CriOS\//.test(navigator.userAgent);
 export const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
 export const IS_IE11 =

--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -79,7 +79,10 @@ export const IS_AR_QUICKLOOK_CANDIDATE = (() => {
 // @see https://developer.chrome.com/multidevice/user-agent
 export const IS_SAFARI = /Safari\//.test(navigator.userAgent);
 export const IS_FIREFOX = /firefox/i.test(navigator.userAgent);
+export const IS_OCULUS = /OculusBrowser/.test(navigator.userAgent);
 export const IS_IOS_CHROME = IS_IOS && /CriOS\//.test(navigator.userAgent);
 export const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
 export const IS_IE11 =
     !((window as any).ActiveXObject) && 'ActiveXObject' in window;
+
+export const IS_SCENEVIEWER_CANDIDATE = IS_ANDROID && !IS_FIREFOX && !IS_OCULUS;

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -16,7 +16,7 @@
 import {property} from 'lit-element';
 import {Event as ThreeEvent} from 'three';
 
-import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
+import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_FIREFOX, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
 import ModelViewerElementBase, {$loaded, $renderer, $scene, $shouldAttemptPreload, $updateSource} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
 import {ARStatus} from '../three-components/ARRenderer.js';
@@ -211,7 +211,8 @@ configuration or device capabilities');
             this[$arMode] = ARMode.WEBXR;
             break;
           } else if (
-              value === 'scene-viewer' && IS_ANDROID && !isSceneViewerBlocked) {
+              value === 'scene-viewer' && IS_ANDROID && !IS_FIREFOX &&
+              !isSceneViewerBlocked) {
             this[$arMode] = ARMode.SCENE_VIEWER;
             break;
           } else if (

--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -16,7 +16,7 @@
 import {property} from 'lit-element';
 import {Event as ThreeEvent} from 'three';
 
-import {IS_ANDROID, IS_AR_QUICKLOOK_CANDIDATE, IS_FIREFOX, IS_IOS_CHROME, IS_IOS_SAFARI, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
+import {IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_SCENEVIEWER_CANDIDATE, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
 import ModelViewerElementBase, {$loaded, $renderer, $scene, $shouldAttemptPreload, $updateSource} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
 import {ARStatus} from '../three-components/ARRenderer.js';
@@ -211,7 +211,7 @@ configuration or device capabilities');
             this[$arMode] = ARMode.WEBXR;
             break;
           } else if (
-              value === 'scene-viewer' && IS_ANDROID && !IS_FIREFOX &&
+              value === 'scene-viewer' && IS_SCENEVIEWER_CANDIDATE &&
               !isSceneViewerBlocked) {
             this[$arMode] = ARMode.SCENE_VIEWER;
             break;


### PR DESCRIPTION
Fixes #1640 
Fixes #1093 

App intents do not work properly on Firefox android or Oculus browser, so we're disabling scene-viewer for those browsers. 
