### PR TITLE
add iOS 14 testing, put src, lib back on npm

### DIFF
--- a/packages/3dom/karma.conf.js
+++ b/packages/3dom/karma.conf.js
@@ -135,6 +135,17 @@ module.exports = function(config) {
         // domain so we go there directly instead:
         url: 'http://bs-local.com:9876'
       },
+      'iOS Safari (iOS 14)': {
+        base: 'BrowserStack',
+        os: 'iOS',
+        os_version: '14',
+        device: 'iPhone 11',
+        browser: 'iPhone',
+        real_mobile: 'true',
+        // BrowserStack seems to drop the port when redirecting to this special
+        // domain so we go there directly instead:
+        url: 'http://bs-local.com:9876'
+      },
     };
 
     config.set({

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -164,7 +164,17 @@ module.exports = function(config) {
         // domain so we go there directly instead:
         url: 'http://bs-local.com:9876'
       },
-
+      'iOS Safari (iOS 14)': {
+        base: 'BrowserStack',
+        os: 'iOS',
+        os_version: '14',
+        device: 'iPhone 11',
+        browser: 'iPhone',
+        real_mobile: 'true',
+        // BrowserStack seems to drop the port when redirecting to this special
+        // domain so we go there directly instead:
+        url: 'http://bs-local.com:9876'
+      },
     };
 
     config.set({

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -22,6 +22,8 @@
   "main": "dist/model-viewer-umd.js",
   "module": "dist/model-viewer.min.js",
   "files": [
+    "src",
+    "lib",
     "dist/model-viewer.js",
     "dist/model-viewer.js.map",
     "dist/model-viewer.min.js",


### PR DESCRIPTION
BrowserStack has iOS 14 on iPhone 11, so let's use that in addition to our iPhone 8 on iOS 13. 