### PR TITLE
add disable-zoom

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -337,6 +337,9 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     @property({type: String, attribute: 'touch-action'})
     touchAction: TouchAction = TouchAction.PAN_Y;
 
+    @property({type: Boolean, attribute: 'disable-zoom'})
+    disableZoom: boolean = false;
+
     protected[$promptElement] =
         this.shadowRoot!.querySelector('.interaction-prompt') as HTMLElement;
     protected[$promptAnimatedContainer] =
@@ -445,6 +448,10 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
           controls.disableInteraction();
           this[$deferInteractionPrompt]();
         }
+      }
+
+      if (changedProperties.has('disableZoom')) {
+        controls.disableZoom = this.disableZoom;
       }
 
       if (changedProperties.has('interactionPrompt') ||

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -122,6 +122,7 @@ export class SmoothControls extends EventDispatcher {
 
   private _interactionEnabled: boolean = false;
   private _options: SmoothControlsOptions;
+  private _disableZoom = false;
   private isUserChange = false;
   private isUserPointing = false;
 
@@ -165,7 +166,9 @@ export class SmoothControls extends EventDispatcher {
       const {element} = this;
       element.addEventListener('mousemove', this.onPointerMove);
       element.addEventListener('mousedown', this.onPointerDown);
-      element.addEventListener('wheel', this.onWheel);
+      if (!this._disableZoom) {
+        element.addEventListener('wheel', this.onWheel);
+      }
       element.addEventListener('keydown', this.onKeyDown);
       element.addEventListener(
           'touchstart', this.onPointerDown, {passive: true});
@@ -185,7 +188,9 @@ export class SmoothControls extends EventDispatcher {
 
       element.removeEventListener('mousemove', this.onPointerMove);
       element.removeEventListener('mousedown', this.onPointerDown);
-      element.removeEventListener('wheel', this.onWheel);
+      if (!this._disableZoom) {
+        element.removeEventListener('wheel', this.onWheel);
+      }
       element.removeEventListener('keydown', this.onKeyDown);
       element.removeEventListener('touchstart', this.onPointerDown);
       element.removeEventListener('touchmove', this.onPointerMove);
@@ -203,6 +208,17 @@ export class SmoothControls extends EventDispatcher {
    */
   get options() {
     return this._options;
+  }
+
+  set disableZoom(disable: boolean) {
+    if (this._disableZoom != disable) {
+      this._disableZoom = disable;
+      if (disable === true) {
+        this.element.removeEventListener('wheel', this.onWheel);
+      } else {
+        this.element.addEventListener('wheel', this.onWheel);
+      }
+    }
   }
 
   /**
@@ -560,7 +576,7 @@ export class SmoothControls extends EventDispatcher {
           this.handleSinglePointerDown(touches[0]);
           break;
         case 2:
-          this.touchMode = 'zoom';
+          this.touchMode = this._disableZoom ? 'scroll' : 'zoom';
           break;
       }
 

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -371,6 +371,32 @@
         ]
       },
       {
+        "name": "touch-action",
+        "htmlName": "touch-action",
+        "description": "Akin to the CSS touch-action property (which does not work due to some iOS bugs), the default 'pan-y' allows touch users to vertically scroll the <span class=\"attribute\">&lt;model-viewer&gt;</span> element, but can interact if their gesture starts horizontal. Legacy behavior can be achieved with 'none', where all scrolling is prevented, while 'pan-x' is the opposite of 'pan-y'. The normal CSS default 'auto' is not allowed here, as this can be achieved by not including the <span class='attribute'>camera-controls</span> attribute.",
+        "default": {
+          "default": "pan-y",
+          "options": "pan-y, pan-x, none"
+        }
+      },
+      {
+        "name": "disable-zoom",
+        "htmlName": "disable-zoom",
+        "description": "Disables user zoom when <span class=\"attribute\">camera-controls</span> is enabled (has no effect otherwise). Has the secondary effect of not swallowing mouse wheel events and pinch gestures, so these will then scroll and zoom the page, respectively.",
+        "links": [
+          "<a href=\"../examples/stagingandcameras/#disableZoom\"><span class='attribute'>disable-zoom</span> example</a>"
+        ]
+      },
+      {
+        "name": "orbit-sensitivity",
+        "htmlName": "orbitSensitivity",
+        "description": "Adjusts the speed of theta and phi orbit interactions. Can also be set negative to reverse, which is helpful when using zero radius to look around the inside of a cave-like model.",
+        "default": {
+          "default": "1",
+          "options": "any number"
+        }
+      },
+      {
         "name": "auto-rotate",
         "htmlName": "autoRotate",
         "description": "Enables the auto-rotation of the model.",
@@ -502,24 +528,6 @@
         "default": {
           "default": "25deg",
           "options": "angle between 0 and 180 degrees"
-        }
-      },
-      {
-        "name": "orbit-sensitivity",
-        "htmlName": "orbitSensitivity",
-        "description": "Adjusts the speed of theta and phi orbit interactions. Can also be set negative to reverse, which is helpful when using zero radius to look around the inside of a cave-like model.",
-        "default": {
-          "default": "1",
-          "options": "any number"
-        }
-      },
-      {
-        "name": "touch-action",
-        "htmlName": "touch-action",
-        "description": "Akin to the CSS touch-action property (which does not work due to some iOS bugs), the default 'pan-y' allows touch users to vertically scroll the <span class=\"attribute\">&lt;model-viewer&gt;</span> element, but can interact if their gesture starts horizontal. Legacy behavior can be achieved with 'none', where all scrolling is prevented, while 'pan-x' is the opposite of 'pan-y'. The normal CSS default 'auto' is not allowed here, as this can be achieved by not including the <span class='attribute'>camera-controls</span> attribute.",
-        "default": {
-          "default": "pan-y",
-          "options": "pan-y, pan-x, none"
         }
       }
     ],

--- a/packages/modelviewer.dev/data/examples.json
+++ b/packages/modelviewer.dev/data/examples.json
@@ -92,6 +92,10 @@
         "name": "Orbit and Scroll"
       },
       {
+        "htmlId": "disableZoom",
+        "name": "Disable Zoom"
+      },
+      {
         "htmlId": "interpolation",
         "name": "Interpolation"
       },

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -109,6 +109,23 @@
     </div>
 
     <div class="sample">
+      <div id="disableZoom" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <div class="heading">
+            <h2 class="demo-title">Disable user zoom so that wheel and pinch interactions have the browser's default behavior.</h2>
+            <h4></h4>
+          </div>
+          <example-snippet stamp-to="disableZoom" highlight-as="html">
+            <template>
+<model-viewer camera-controls disable-zoom src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+    <div class="sample">
       <div id="interpolation" class="demo"></div>
       <div class="content">
         <div class="wrapper">


### PR DESCRIPTION
Fixes #1424 

Also adds an example, to make it clear that default scroll/pinch behavior is reenabled. 