### PR TITLE
Fix broken link to tester.html

### DIFF
--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -52,7 +52,7 @@
 </head>
 <body>
 
-<div class="examples-page">  
+<div class="examples-page">
   <div class="sidebar" id="sidenav"></div>
   <div id="toggle"></div>
   <div class="examples-container">
@@ -62,12 +62,12 @@
         <div class="wrapper">
           <h4 id="intro"><span class="font-medium">Annotations. </span></h4>
           <p>
-            Use &lt;model-viewer&gt; to make your models interactive. 
+            Use &lt;model-viewer&gt; to make your models interactive.
             This page showcases how you can add hotspots to your scene. Child elements are hotspots if their slot begins with "hotspot".
             The data-position attribute specifies the 3D position of the hotspot in model coordinates, using the same format as the
             camera-target attribute. The data-normal attribute specifies the normal vector defining the "front" of the hotspot.
-            When this normal is pointed away from the viewer, the hotspot's opacity becomes --min-hotspot-opacity. The 
-            <a href="tester.html">interactive example</a> lets you drag and drop your own models and add hotspots by clicking
+            When this normal is pointed away from the viewer, the hotspot's opacity becomes --min-hotspot-opacity. The
+            <a href="../tester.html">interactive example</a> lets you drag and drop your own models and add hotspots by clicking
             and displays the corresponding position and normal attributes which you can copy into your own page.
           </p>
           <p>


### PR DESCRIPTION
A link in the Annotations Example documentation to the interactive example `tester.html` was broken.