### PR TITLE
cloning textures

### DIFF
--- a/packages/model-viewer/src/test/model-viewer-spec.ts
+++ b/packages/model-viewer/src/test/model-viewer-spec.ts
@@ -31,11 +31,13 @@ const setupModelViewer = async (modelViewer: ModelViewerElement) => {
 
 const setupLighting =
     async (modelViewer: ModelViewerElement, lighting: string) => {
+  const posterDismissed = waitForEvent(modelViewer, 'poster-dismissed');
+
   const lightingPath = assetPath(lighting);
   modelViewer.environmentImage = lightingPath;
   modelViewer.skyboxImage = lightingPath;
 
-  await waitForEvent(modelViewer, 'poster-dismissed');
+  await posterDismissed;
 }
 
 // TODO(sun765): this only test whether the screenshot

--- a/packages/model-viewer/src/three-components/gltf-instance/gltf-2.0.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/gltf-2.0.ts
@@ -180,14 +180,6 @@ export interface Node {
   extras?: Extras;
 }
 
-export interface Texture {
-  name?: string;
-  source?: number;
-  sampler?: number;
-  extensions?: ExtensionDictionary;
-  extras?: Extras;
-}
-
 export interface ExternalImage {
   name?: string;
   uri: string;

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -180,21 +180,21 @@ modelViewerParameters.addEventListener("scene-graph-ready", (ev) => {
           </div>
           <example-snippet stamp-to="swapTextures" highlight-as="html">
             <template>
-<model-viewer id="lantern" camera-controls interaction-prompt="none" src="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF-Binary/Lantern.glb" alt="A 3D model of a lantern">
+<model-viewer id="lantern" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb" alt="A 3D model of a helmet">
   <div id="controls">
     <div>
       <p>Diffuse</p>
       <select id="diffuse">
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_baseColor.png">Lantern Pole</option>
         <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_albedo.jpg">Damaged helmet</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_baseColor.png">Lantern Pole</option>
         <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_baseColor.png">Water Bottle</option>
       </select>
     </div>
     <div>
       <p>Metallic-roughness</p>
       <select id="metallicRoughness">
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_roughnessMetallic.png">Lantern Pole</option>
         <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_metalRoughness.jpg">Damaged helmet</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_roughnessMetallic.png">Lantern Pole</option>
         <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
       </select>
     </div>
@@ -236,7 +236,7 @@ modelViewerTexture.addEventListener("scene-graph-ready", (ev) => {
           </div>
           <example-snippet stamp-to="swapTextures2" highlight-as="html">
             <template>
-<model-viewer id="helmet" camera-controls interaction-prompt="none" src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb" alt="A 3D model of an helmet">
+<model-viewer id="helmet" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb" alt="A 3D model of a helmet">
   <div id="controls">
     <div>
       <p>Normals</p>


### PR DESCRIPTION
Fixes #1678 

The material clone is a shallow copy, so now we're cloning the textures as well (but not the underlying images). I've also updated the scene-graph example to demonstrate the bug, so that will now serve as a regression test.