### PR TITLE
Update ZIP

### DIFF
--- a/packages/space-opera/src/components/ibl_selector/ibl_selector.ts
+++ b/packages/space-opera/src/components/ibl_selector/ibl_selector.ts
@@ -87,6 +87,7 @@ export class IblSelector extends ConnectedLitElement {
             this.config.environmentImage) {
       reduxStore.dispatch(dispatchEnvrionmentImage(
           dropdownElement.selectedItem.getAttribute('value') || undefined));
+      // dropdown value equals null when "Default" is selected
       if (dropdownElement.selectedItem.getAttribute('value') === null) {
         reduxStore.dispatch(dispatchSetEnvironmentName(undefined));
       } else {

--- a/packages/space-opera/src/components/ibl_selector/ibl_selector.ts
+++ b/packages/space-opera/src/components/ibl_selector/ibl_selector.ts
@@ -33,6 +33,7 @@ import {State} from '../../types.js';
 import {dispatchEnvrionmentImage, dispatchExposure, dispatchShadowIntensity, dispatchShadowSoftness, dispatchUseEnvAsSkybox, getConfig} from '../config/reducer.js';
 import {ConnectedLitElement} from '../connected_lit_element/connected_lit_element.js';
 import {FileModalElement} from '../file_modal/file_modal.js';
+import {dispatchSetEnvironmentName} from '../relative_file_paths/reducer.js';
 import {CheckboxElement} from '../shared/checkbox/checkbox.js';
 import {Dropdown} from '../shared/dropdown/dropdown.js';
 import {SliderWithInputElement} from '../shared/slider_with_input/slider_with_input.js';
@@ -86,6 +87,14 @@ export class IblSelector extends ConnectedLitElement {
             this.config.environmentImage) {
       reduxStore.dispatch(dispatchEnvrionmentImage(
           dropdownElement.selectedItem.getAttribute('value') || undefined));
+      if (dropdownElement.selectedItem.getAttribute('value') === null) {
+        reduxStore.dispatch(dispatchSetEnvironmentName(undefined));
+      } else {
+        const envImageList =
+            dropdownElement.selectedItem.getAttribute('value')?.split('/');
+        const envImageName = envImageList![envImageList!.length - 1];
+        reduxStore.dispatch(dispatchSetEnvironmentName(envImageName));
+      }
     }
   }
 
@@ -121,6 +130,7 @@ export class IblSelector extends ConnectedLitElement {
     reduxStore.dispatch(
         dispatchAddEnvironmentImage({uri: unsafeUrl, name: file.name}));
     reduxStore.dispatch(dispatchEnvrionmentImage(unsafeUrl));
+    reduxStore.dispatch(dispatchSetEnvironmentName(file.name));
   }
 
   // TODO: On snippet input if IBL is defined, select the

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -328,8 +328,7 @@ export class ModelViewerPreview extends ConnectedLitElement {
         return;
       if (file.name.match(/\.(glb)$/i)) {
         const arrayBuffer = await file.arrayBuffer();
-        const modelName = file.name;
-        reduxStore.dispatch(dispatchSetModelName(modelName));
+        reduxStore.dispatch(dispatchSetModelName(file.name));
         const url = createSafeObjectUrlFromArrayBuffer(arrayBuffer).unsafeUrl;
         reduxStore.dispatch(dispatchGltfUrl(url));
         dispatchConfig(extractStagingConfig(this.config));

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -42,6 +42,7 @@ import {HotspotConfig} from '../hotspot_panel/types.js';
 import {createBlobUrlFromEnvironmentImage, dispatchAddEnvironmentImage} from '../ibl_selector/reducer.js';
 import {getEdits, getOrigEdits} from '../materials_panel/reducer.js';
 import {dispatchConfig} from '../model_viewer_snippet/reducer.js';
+import {dispatchSetEnvironmentName, dispatchSetModelName} from '../relative_file_paths/reducer.js';
 import {styles as hotspotStyles} from '../utils/hotspot/hotspot.css.js';
 import {renderHotspots} from '../utils/hotspot/render_hotspots.js';
 import {renderModelViewer} from '../utils/render_model_viewer.js';
@@ -327,6 +328,8 @@ export class ModelViewerPreview extends ConnectedLitElement {
         return;
       if (file.name.match(/\.(glb)$/i)) {
         const arrayBuffer = await file.arrayBuffer();
+        const modelName = file.name;
+        reduxStore.dispatch(dispatchSetModelName(modelName));
         const url = createSafeObjectUrlFromArrayBuffer(arrayBuffer).unsafeUrl;
         reduxStore.dispatch(dispatchGltfUrl(url));
         dispatchConfig(extractStagingConfig(this.config));
@@ -334,10 +337,10 @@ export class ModelViewerPreview extends ConnectedLitElement {
       }
       if (file.name.match(/\.(hdr|png|jpg|jpeg)$/i)) {
         const unsafeUrl = await createBlobUrlFromEnvironmentImage(file);
-
         reduxStore.dispatch(
             dispatchAddEnvironmentImage({uri: unsafeUrl, name: file.name}));
         reduxStore.dispatch(dispatchEnvrionmentImage(unsafeUrl));
+        reduxStore.dispatch(dispatchSetEnvironmentName(file.name));
       }
     }
   }

--- a/packages/space-opera/src/components/model_viewer_snippet/components/download_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/download_button.ts
@@ -69,12 +69,12 @@ class GenericDownloadButton extends ConnectedLitElement {
   }
 }
 
-async function prepareGlbPayload(gltf: GltfModel): Promise<Payload> {
+async function prepareGlbPayload(
+    gltf: GltfModel, modelName: string): Promise<Payload> {
   const glbBuffer = await gltf.packGlb();
-  // TODO: Give filename that matches original upload/src
   return {
     blob: new Blob([glbBuffer], {type: 'model/gltf-binary'}),
-    filename: 'model.glb',
+    filename: modelName,
     contentType: ''
   };
 }
@@ -86,8 +86,8 @@ async function prepareZipArchive(
     relativeFilePaths: RelativeFilePathsState): Promise<Payload> {
   const zip = new JSZip();
 
-  const glb = await prepareGlbPayload(gltf);
-  zip.file(relativeFilePaths.modelName!, glb.blob);
+  const glb = await prepareGlbPayload(gltf, relativeFilePaths.modelName!);
+  zip.file(glb.filename, glb.blob);
 
   if (config.environmentImage) {
     const response = await fetch(config.environmentImage);
@@ -125,7 +125,9 @@ export class DownloadButton extends GenericDownloadButton {
 
   stateChanged(state: State) {
     const {gltf} = state.entities.gltf;
-    this.preparePayload = gltf ? () => prepareGlbPayload(gltf) : undefined;
+    this.preparePayload = gltf ?
+        () => prepareGlbPayload(gltf, this.relativeFilePaths?.modelName!) :
+        undefined;
   }
 }
 

--- a/packages/space-opera/src/components/model_viewer_snippet/components/download_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/download_button.ts
@@ -46,7 +46,6 @@ class GenericDownloadButton extends ConnectedLitElement {
   }
 
   @internalProperty() buttonLabel = '';
-  @internalProperty() relativeFilePaths?: RelativeFilePathsState;
   @internalProperty() preparePayload?: () => Promise<Payload|null>;
 
   // NOTE: Because this is async, it is possible for multiple downloads to be
@@ -79,6 +78,9 @@ async function prepareGlbPayload(
   };
 }
 
+/**
+ * Add elements to ZIP as necessary.
+ */
 async function prepareZipArchive(
     gltf: GltfModel,
     config: ModelViewerConfig,
@@ -89,6 +91,7 @@ async function prepareZipArchive(
   const glb = await prepareGlbPayload(gltf, relativeFilePaths.modelName!);
   zip.file(glb.filename, glb.blob);
 
+  // check if legal envrionment url
   if (config.environmentImage) {
     const response = await fetch(config.environmentImage);
     if (!response.ok) {
@@ -97,6 +100,7 @@ async function prepareZipArchive(
     zip.file(relativeFilePaths.environmentName!, response.blob());
   }
 
+  // check if legal poster url
   if (config.poster) {
     const response = await fetch(config.poster);
     if (!response.ok) {
@@ -125,9 +129,9 @@ export class DownloadButton extends GenericDownloadButton {
 
   stateChanged(state: State) {
     const {gltf} = state.entities.gltf;
-    this.preparePayload = gltf ?
-        () => prepareGlbPayload(gltf, this.relativeFilePaths?.modelName!) :
-        undefined;
+    const modelName = getRelativeFilePaths(state).modelName!;
+    this.preparePayload =
+        gltf ? () => prepareGlbPayload(gltf, modelName) : undefined;
   }
 }
 

--- a/packages/space-opera/src/components/model_viewer_snippet/components/download_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/download_button.ts
@@ -128,7 +128,7 @@ export class DownloadButton extends GenericDownloadButton {
   }
 
   stateChanged(state: State) {
-    const {gltf} = state.entities.gltf;
+    const gltf = getGltfModel(state);
     const modelName = getRelativeFilePaths(state).modelName!;
     this.preparePayload =
         gltf ? () => prepareGlbPayload(gltf, modelName) : undefined;

--- a/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
@@ -203,8 +203,7 @@ export class ImportCard extends LitElement {
       return;
     }
     const arrayBuffer = await files[0].arrayBuffer();
-    const modelName = files[0].name;
-    reduxStore.dispatch(dispatchSetModelName(modelName));
+    reduxStore.dispatch(dispatchSetModelName(files[0].name));
     const url = createSafeObjectUrlFromArrayBuffer(arrayBuffer).unsafeUrl;
     reduxStore.dispatch(dispatchGltfUrl(url));
     dispatchConfig(extractStagingConfig(getConfig(reduxStore.getState())));

--- a/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
@@ -218,7 +218,7 @@ export class ImportCard extends LitElement {
 
   onDefaultSelect(event: CustomEvent) {
     const dropdown = event.target as Dropdown;
-    const value = dropdown.selectedItem?.getAttribute('value') || undefined;
+    const key = dropdown.selectedItem?.getAttribute('value') || undefined;
     let snippet = '';
     const simpleMap: any = {
       'Astronaut': 1,
@@ -236,22 +236,22 @@ export class ImportCard extends LitElement {
       'Suzanne': 11,
       'SpecGlossVsMetalRough': 12
     };
-    const fileName = `${value}.glb`;
-    if (value !== undefined) {
-      if (value === 'none') {
+    const fileName = `${key}.glb`;
+    if (key !== undefined) {
+      if (key === 'none') {
         this.selectedDefaultOption = 0;
         return;
-      } else if (value in simpleMap) {
-        this.selectedDefaultOption = simpleMap[value];
+      } else if (key in simpleMap) {
+        this.selectedDefaultOption = simpleMap[key];
         snippet = `<model-viewer
   src='https://modelviewer.dev/shared-assets/models/${fileName}'
   shadow-intensity="1" camera-controls>
 </model-viewer>`;
-      } else if (value in advancedMap) {
-        this.selectedDefaultOption = advancedMap[value];
+      } else if (key in advancedMap) {
+        this.selectedDefaultOption = advancedMap[key];
         snippet = `<model-viewer
   src='https://modelviewer.dev/shared-assets/models/glTF-Sample-Models/2.0/${
-            value}/glTF-Binary/${fileName}'
+            key}/glTF-Binary/${fileName}'
   shadow-intensity="1" camera-controls>
 </model-viewer>`;
       }

--- a/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
@@ -101,14 +101,13 @@ export class OpenModal extends ConnectedLitElement {
         config.poster = undefined;
         dispatchSetPosterName(undefined);
 
-        // Keep environment image if is the env image wasn't updated
         if (config.environmentImage && isObjectUrl(config.environmentImage)) {
-          // If new environment image is legal, use it
+          // If new env image is legal, use it
           const engImageList = config.environmentImage.split('/');
           const envImageName = engImageList[engImageList.length - 1];
           reduxStore.dispatch(dispatchSetEnvironmentName(envImageName));
         } else if (this.config.environmentImage) {
-          // if there was an env image already in the state, leave it alone
+          // else, if there was an env image in the state, leave it alone
           config.environmentImage = this.config.environmentImage
         } else {
           // else, reset env image
@@ -205,8 +204,8 @@ export class ImportCard extends LitElement {
     }
     const arrayBuffer = await files[0].arrayBuffer();
     // @ts-ignore
-    const name = files[0].name;
-    reduxStore.dispatch(dispatchSetModelName(name));
+    const modelName = files[0].name;
+    reduxStore.dispatch(dispatchSetModelName(modelName));
     const url = createSafeObjectUrlFromArrayBuffer(arrayBuffer).unsafeUrl;
     reduxStore.dispatch(dispatchGltfUrl(url));
     dispatchConfig(extractStagingConfig(getConfig(reduxStore.getState())));
@@ -260,9 +259,7 @@ export class ImportCard extends LitElement {
   shadow-intensity="1" camera-controls>
 </model-viewer>`;
       }
-
       reduxStore.dispatch(dispatchSetModelName(fileName));
-
       this.openModal.handleSubmitSnippet(snippet);
     }
   }

--- a/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
@@ -197,13 +197,12 @@ export class ImportCard extends LitElement {
   @internalProperty() selectedDefaultOption: number = 0;
 
   async onUploadGLB() {
-    const files = await this.fileModal.open();
+    const files: any = await this.fileModal.open();
     if (!files) {
       /// The user canceled the previous upload
       return;
     }
     const arrayBuffer = await files[0].arrayBuffer();
-    // @ts-ignore
     const modelName = files[0].name;
     reduxStore.dispatch(dispatchSetModelName(modelName));
     const url = createSafeObjectUrlFromArrayBuffer(arrayBuffer).unsafeUrl;
@@ -222,13 +221,13 @@ export class ImportCard extends LitElement {
     const dropdown = event.target as Dropdown;
     const value = dropdown.selectedItem?.getAttribute('value') || undefined;
     let snippet = '';
-    const simpleMap = {
+    const simpleMap: any = {
       'Astronaut': 1,
       'Horse': 2,
       'RobotExpressive': 3,
       'alpha-blend-litmus': 4
     };
-    const advancedMap = {
+    const advancedMap: any = {
       'BoomBox': 5,
       'BrainStem': 6,
       'Corset': 7,
@@ -244,14 +243,12 @@ export class ImportCard extends LitElement {
         this.selectedDefaultOption = 0;
         return;
       } else if (value in simpleMap) {
-        // @ts-ignore
         this.selectedDefaultOption = simpleMap[value];
         snippet = `<model-viewer
   src='https://modelviewer.dev/shared-assets/models/${fileName}'
   shadow-intensity="1" camera-controls>
 </model-viewer>`;
       } else if (value in advancedMap) {
-        // @ts-ignore
         this.selectedDefaultOption = advancedMap[value];
         snippet = `<model-viewer
   src='https://modelviewer.dev/shared-assets/models/glTF-Sample-Models/2.0/${

--- a/packages/space-opera/src/components/model_viewer_snippet/reducer.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/reducer.ts
@@ -24,12 +24,16 @@ import {INITIAL_CAMERA} from '../camera_settings/camera_state.js';
 import {dispatchInitialCameraState, dispatchSetCamera} from '../camera_settings/reducer.js';
 import {dispatchSetConfig} from '../config/reducer.js';
 
+/**
+ * Sets the filepaths of a copy of the config.
+ * Used when displaying and exporting the snippet.
+ * NOT used inside the actual model-viewer element.
+ */
 export function applyRelativeFilePaths(
     editedConfig: ModelViewerConfig,
     gltfUrl: string|undefined,
     relativeFilePaths: RelativeFilePathsState,
     isEditSnippet: boolean) {
-  // If the last loaded URL use file name
   if (gltfUrl) {
     editedConfig.src = relativeFilePaths.modelName
   } else {

--- a/packages/space-opera/src/components/model_viewer_snippet/reducer.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/reducer.ts
@@ -16,11 +16,36 @@
  */
 
 import {ModelViewerConfig} from '@google/model-viewer-editing-adapter/lib/main.js';
+import {isObjectUrl} from '@google/model-viewer-editing-adapter/lib/util/create_object_url.js';
 
 import {reduxStore} from '../../space_opera_base.js';
+import {RelativeFilePathsState} from '../../types.js';
 import {INITIAL_CAMERA} from '../camera_settings/camera_state.js';
 import {dispatchInitialCameraState, dispatchSetCamera} from '../camera_settings/reducer.js';
 import {dispatchSetConfig} from '../config/reducer.js';
+
+export function applyRelativeFilePaths(
+    editedConfig: ModelViewerConfig,
+    gltfUrl: string|undefined,
+    relativeFilePaths: RelativeFilePathsState,
+    isEditSnippet: boolean) {
+  // If the last loaded URL use file name
+  if (gltfUrl) {
+    editedConfig.src = relativeFilePaths.modelName
+  } else {
+    editedConfig.src = 'Upload model...';
+  }
+
+  if (editedConfig.environmentImage) {
+    editedConfig.environmentImage = relativeFilePaths.environmentName;
+  }
+
+  if (isEditSnippet) {
+    editedConfig.poster = undefined;
+  } else if (editedConfig.poster && isObjectUrl(editedConfig.poster)) {
+    editedConfig.poster = relativeFilePaths.posterName;
+  }
+}
 
 /** Use when the user wants to load a new config (probably from a snippet). */
 export function dispatchConfig(config?: ModelViewerConfig) {

--- a/packages/space-opera/src/components/poster_controls/poster_controls.ts
+++ b/packages/space-opera/src/components/poster_controls/poster_controls.ts
@@ -33,6 +33,7 @@ import {dispatchSetPoster, getConfig} from '../config/reducer.js';
 import {ConnectedLitElement} from '../connected_lit_element/connected_lit_element.js';
 import {getModelViewer} from '../model_viewer_preview/model_viewer.js';
 import {getCameraState} from '../model_viewer_preview/model_viewer_preview.js';
+import {dispatchSetPosterName} from '../relative_file_paths/reducer.js';
 
 /** Allow users to create / display a poster. */
 @customElement('me-poster-controls')
@@ -101,6 +102,7 @@ export class PosterControlsElement extends ConnectedLitElement {
           createSafeObjectURL(await modelViewer.toBlob({idealAspect: true}));
       reduxStore.dispatch(dispatchSetPoster(posterUrl.unsafeUrl));
     }
+    reduxStore.dispatch(dispatchSetPosterName('poster.png'));
   }
 
   onDisplayPoster() {
@@ -123,6 +125,7 @@ export class PosterControlsElement extends ConnectedLitElement {
       URL.revokeObjectURL(this.poster);
     }
     reduxStore.dispatch(dispatchSetPoster(undefined));
+    reduxStore.dispatch(dispatchSetPosterName(undefined));
   }
 
   async onDownloadPoster() {

--- a/packages/space-opera/src/components/relative_file_paths/reducer.ts
+++ b/packages/space-opera/src/components/relative_file_paths/reducer.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {Action, RelativeFilePathsState, State} from '../../types';
+
+const SET_MODEL_NAME = 'SET_MODEL_NAME';
+export function dispatchSetModelName(name: string|undefined) {
+  return {type: SET_MODEL_NAME, payload: name};
+}
+
+const SET_ENVIRONMENT_NAME = 'SET_ENVIRONMENT_NAME';
+export function dispatchSetEnvironmentName(name: string|undefined) {
+  return {type: SET_ENVIRONMENT_NAME, payload: name};
+}
+
+const SET_POSTER_NAME = 'SET_POSTER_NAME';
+export function dispatchSetPosterName(name: string|undefined) {
+  return {type: SET_POSTER_NAME, payload: name};
+}
+
+export const getRelativeFilePaths = (state: State) =>
+    state.entities.modelViewerSnippet.relativeFilePaths;
+
+export function relativeFilePathsReducer(
+    state: RelativeFilePathsState = {},
+    action: Action): RelativeFilePathsState {
+  switch (action.type) {
+    case SET_MODEL_NAME:
+      return {
+        ...state, modelName: action.payload
+      }
+    case SET_ENVIRONMENT_NAME:
+      return {
+        ...state, environmentName: action.payload
+      }
+    case SET_POSTER_NAME:
+      return {
+        ...state, posterName: action.payload
+      }
+    default:
+      return state;
+  }
+}

--- a/packages/space-opera/src/reducers.ts
+++ b/packages/space-opera/src/reducers.ts
@@ -24,16 +24,18 @@ import {hotspotsReducer, hotspotsUiReducer} from './components/hotspot_panel/red
 import {environmentReducer} from './components/ibl_selector/reducer.js'
 import {editsReducer, origEditsReducer} from './components/materials_panel/reducer.js';
 import {gltfReducer} from './components/model_viewer_preview/reducer.js';
+import {relativeFilePathsReducer} from './components/relative_file_paths/reducer.js';
 
 const gltfEditsReducer =
-    combineReducers({edits: editsReducer, origEdits: origEditsReducer})
+    combineReducers({edits: editsReducer, origEdits: origEditsReducer});
 
 const modelViewerSnippetReducer = combineReducers({
   animationNames: animationNamesReducer,
   camera: cameraReducer,
   config: configReducer,
-  hotspots: hotspotsReducer
-})
+  hotspots: hotspotsReducer,
+  relativeFilePaths: relativeFilePathsReducer,
+});
 
 const entitiesReducer = combineReducers({
   isDirtyCamera: isDirtyCameraReducer,

--- a/packages/space-opera/src/types.ts
+++ b/packages/space-opera/src/types.ts
@@ -31,6 +31,12 @@ interface UIState {
   hotspots: HotspotsUIState;
 }
 
+export interface RelativeFilePathsState {
+  modelName?: string|undefined;
+  environmentName?: string|undefined;
+  posterName?: string|undefined;
+}
+
 export interface EnvironmentState {
   environmentImages: EnvironmentImage[];
 }
@@ -45,6 +51,7 @@ interface ModelViewerSnippetState {
   camera: Camera;
   config: ModelViewerConfig;
   hotspots: HotspotConfig[];
+  relativeFilePaths: RelativeFilePathsState;
 }
 
 export interface EntitiesState {
@@ -79,6 +86,7 @@ export const INITIAL_STATE: State = {
       config: {},
       hotspots: [],
       camera: INITIAL_CAMERA,
+      relativeFilePaths: {},
     },
     initialCamera: INITIAL_CAMERA,
   },


### PR DESCRIPTION
## Changes to user experience:
* When a user adds a model to the editor, the original name of the file will be displayed in the snippet. And the relative file path of the model will be included in the snippet on export. 
* Similarly, the environment image (skybox, as well, if checked) has the same effect. I.e. relative path will be displayed. 
* Same for poster, except the exported poster name is always, "poster.png"

### Side effects
* Some side effects of this are that the way we handle the import snippet has changed slightly. Importantly, the environment image is retained if the **relative name** in the import snippet isn't changed.