### PR TITLE
Rotate environment example

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -73,6 +73,7 @@ export interface SphericalPosition {
   theta: number;  // equator angle around the y (up) axis.
   phi: number;    // polar angle from the y (up) axis.
   radius: number;
+  toString(): string;
 }
 
 export type InteractionPromptStrategy = 'auto'|'when-focused'|'none';
@@ -372,7 +373,14 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     getCameraOrbit(): SphericalPosition {
       const {theta, phi, radius} = this[$lastSpherical];
-      return {theta, phi, radius};
+      return {
+        theta,
+        phi,
+        radius,
+        toString() {
+          return `${this.theta}rad ${this.phi}rad ${this.radius}m`;
+        }
+      };
     }
 
     getCameraTarget(): Vector3D {

--- a/packages/model-viewer/src/test/features/animation-spec.ts
+++ b/packages/model-viewer/src/test/features/animation-spec.ts
@@ -103,8 +103,9 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
     });
 
     suite('when configured to autoplay', () => {
-      setup(() => {
+      setup(async () => {
         element.autoplay = true;
+        await timePasses();
       });
 
       test('plays an animation', () => {

--- a/packages/model-viewer/src/test/features/animation-spec.ts
+++ b/packages/model-viewer/src/test/features/animation-spec.ts
@@ -101,23 +101,10 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
         });
       });
     });
-  });
 
-  suite('when configured to autoplay', () => {
-    setup(() => {
-      element = new ModelViewerElement();
-      element.autoplay = true;
-      document.body.insertBefore(element, document.body.firstChild);
-    });
-
-    teardown(() => {
-      document.body.removeChild(element);
-    });
-
-    suite('a model with animations', () => {
-      setup(async () => {
-        element.src = ANIMATED_GLB_PATH;
-        await waitForEvent(element, 'load');
+    suite('when configured to autoplay', () => {
+      setup(() => {
+        element.autoplay = true;
       });
 
       test('plays an animation', () => {
@@ -140,26 +127,26 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
               .to.be.true;
         });
       });
-    });
 
-    suite('a model without animations', () => {
-      setup(async () => {
-        element.src = NON_ANIMATED_GLB_PATH;
-        await waitForEvent(element, 'load');
-      });
-
-      test('does not play an animation', () => {
-        expect(animationIsPlaying(element)).to.be.false;
-      });
-
-      suite('with a specified animation-name', () => {
+      suite('a model without animations', () => {
         setup(async () => {
-          element.animationName = element.availableAnimations[1];
-          await timePasses();
+          element.src = NON_ANIMATED_GLB_PATH;
+          await waitForEvent(element, 'load');
         });
 
         test('does not play an animation', () => {
           expect(animationIsPlaying(element)).to.be.false;
+        });
+
+        suite('with a specified animation-name', () => {
+          setup(async () => {
+            element.animationName = element.availableAnimations[1];
+            await timePasses();
+          });
+
+          test('does not play an animation', () => {
+            expect(animationIsPlaying(element)).to.be.false;
+          });
         });
       });
     });

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -575,7 +575,7 @@
       {
         "name": "getCameraOrbit()",
         "htmlName": "getCameraOrbit",
-        "description": "Returns the realtime orbital position of the camera. Azimuthal (theta) and polar (phi) angles are representred as radians, and the distance (radius) is represented in meters. This value may differ from the value configured with the <span class='attribute'>camera-orbit</span> attribute on account of user interaction or camera interpolation.",
+        "description": "Returns the realtime orbital position of the camera. The retuned object has theta, phi, and radius properties along with a toString() method suitable for putting in the camera-orbit attribute. Azimuthal (theta) and polar (phi) angles are representred as radians, and the distance (radius) is represented in meters. This value may differ from the value configured with the <span class='attribute'>camera-orbit</span> attribute on account of user interaction or camera interpolation.",
         "links": [
           "<a href=\"../examples/stagingandcameras/#panning\"><span class='attribute'>getCameraOrbit</span> example</a>"
         ]

--- a/packages/modelviewer.dev/data/examples.json
+++ b/packages/modelviewer.dev/data/examples.json
@@ -136,7 +136,7 @@
     ]
   },
   {
-    "name": "Lighting & Env",
+    "name": "Lighting & Skybox",
     "htmlName": "lightingandenv",
     "examples": [
       {

--- a/packages/modelviewer.dev/data/examples.json
+++ b/packages/modelviewer.dev/data/examples.json
@@ -114,6 +114,10 @@
       {
         "htmlId": "panning",
         "name": "Panning"
+      },
+      {
+        "htmlId": "turnSkybox",
+        "name": "Turn Skybox"
       }
     ]
   },

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -332,6 +332,82 @@
       </div>
     </div>
 
+    <div class="sample">
+      <div id="turnSkybox" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <div class="heading">
+            <h2 class="demo-title">Add other interactions like rotating environment map</h2>
+            <h4>Use parameters with rest turntable to rotate only the environment light</h4>
+            <p>By using shift key plus left click mouse or touch pad drag, one can rotate
+          the environment map to see how the environment background would cast light
+          onto the object from different angles when it is rotated. Updating orbit to 
+          new theta value and then reseting the theta value to stop turntable from 
+        rotating. </p>
+          </div>
+          <example-snippet stamp-to="turnSkybox" highlight-as="html">
+            <template>
+<model-viewer id="envlight-demo" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf"  skybox-image="../../assets/whipple_creek_regional_park_04_1k.hdr" alt="A 3D model of an astronaut"></model-viewer>
+
+<script type="module">
+    
+  const modelViewer = document.querySelector("#envlight-demo");
+  modelViewer.addEventListener('contextmenu', event => event.preventDefault());
+  
+  let lastX;
+  var orbiting = false;
+  var orbit;
+      
+  const startOrbit = () => {
+    const orbit = modelViewer.getCameraOrbit();
+    const { theta, phi, radius } = orbit;
+    metersPerPixel = 0.15 * radius / modelViewer.getBoundingClientRect().height;
+    modelViewer.interactionPrompt = 'none';
+  };
+  
+  const updateOrbit = (thisX) => {      
+    const dx = (thisX - lastX) * metersPerPixel;
+    lastX = thisX;
+    orbit = modelViewer.getCameraOrbit();
+    orbit.theta += dx;
+    modelViewer.cameraOrbit = `${orbit.theta}rad ${orbit.phi}rad`;
+    modelViewer.resetTurntableRotation(orbit.theta);
+    modelViewer.jumpCameraToGoal();
+  }
+  
+  modelViewer.addEventListener('mousedown', (event) => {
+    startX = event.clientX;
+       
+    orbiting = event.shiftKey;
+    if (!orbiting)
+      return;
+  
+    lastX = startX;
+    startOrbit();
+    event.stopPropagation();
+  }, true);
+  
+  self.addEventListener('mouseup', (event) => {
+    orbiting = false;
+  }, true);
+  
+  modelViewer.addEventListener('mousemove', (event) => {
+    if (!orbiting)
+      return;
+    if (orbiting) {
+      requestAnimationFrame(() => updateOrbit(event.clientX));
+    }
+  
+    event.stopPropagation();
+  }, true);
+  
+</script>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>	
+
     <div class="footer">
       <ul>
         <li class="attribution">

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -337,20 +337,16 @@
       <div class="content">
         <div class="wrapper">
           <div class="heading">
-            <h2 class="demo-title">Add other interactions like rotating environment map</h2>
-            <h4>Use parameters with rest turntable to rotate only the environment light</h4>
-            <p>By using shift key plus left click mouse or touch pad drag, one can rotate
-          the environment map to see how the environment background would cast light
-          onto the object from different angles when it is rotated. Updating orbit to 
-          new theta value and then reseting the theta value to stop turntable from 
-        rotating. </p>
+            <h2 class="demo-title">Add other interactions like rotating the skybox</h2>
+            <p>Using shift-drag or two-finger drag on mobile, one can rotate the
+            skybox to see how the environment would cast light onto the object
+            from different angles.</p>
           </div>
           <example-snippet stamp-to="turnSkybox" highlight-as="html">
             <template>
-<model-viewer id="envlight-demo" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf"  skybox-image="../../assets/whipple_creek_regional_park_04_1k.hdr" alt="A 3D model of an astronaut"></model-viewer>
+<model-viewer id="envlight-demo" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf"  skybox-image="../../shared-assets/environments/spruit_sunrise_1k_HDR.hdr" alt="A 3D model of a damaged helmet"></model-viewer>
 
 <script type="module">
-    
   const modelViewer = document.querySelector("#envlight-demo");
   modelViewer.addEventListener('contextmenu', event => event.preventDefault());
   
@@ -416,13 +412,12 @@
   }, true);
 
   self.addEventListener('mouseup', (event) => {
-    panning=false;
+    panning = false;
   }, true);
   
   self.addEventListener('touchend', (event) => {
-    panning=false;
+    panning = false;
   }, true);
-  
 </script>
             </template>
           </example-snippet>
@@ -435,6 +430,11 @@
         <li class="attribution">
           <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
           licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>.
+        </li>
+
+        <li class="attribution">
+          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet">Damaged Helmet</a> by <a href="https://sketchfab.com/theblueturtle_">theblueturtle_</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by-nc/3.0/us/">Creative Commons Attribution-NonCommercial</a>.
         </li>
       </ul>
       <div style="margin-top:24px;" class="copyright">©Copyright 2018-2020 Google Inc. Licensed under the Apache License 2.0.</div>

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -355,50 +355,72 @@
   modelViewer.addEventListener('contextmenu', event => event.preventDefault());
   
   let lastX;
-  var orbiting = false;
-  var orbit;
+  let panning = false;
+  let skyboxAngle = 0;
+  let radiansPerPixel;
       
-  const startOrbit = () => {
+  const startPan = () => {
     const orbit = modelViewer.getCameraOrbit();
-    const { theta, phi, radius } = orbit;
-    metersPerPixel = 0.15 * radius / modelViewer.getBoundingClientRect().height;
+    const { radius } = orbit;
+    radiansPerPixel = -1 * radius / modelViewer.getBoundingClientRect().height;
     modelViewer.interactionPrompt = 'none';
   };
   
-  const updateOrbit = (thisX) => {      
-    const dx = (thisX - lastX) * metersPerPixel;
+  const updatePan = (thisX) => {      
+    const delta = (thisX - lastX) * radiansPerPixel;
     lastX = thisX;
-    orbit = modelViewer.getCameraOrbit();
-    orbit.theta += dx;
-    modelViewer.cameraOrbit = `${orbit.theta}rad ${orbit.phi}rad`;
-    modelViewer.resetTurntableRotation(orbit.theta);
+    skyboxAngle += delta;
+    const orbit = modelViewer.getCameraOrbit();
+    orbit.theta += delta;
+    modelViewer.cameraOrbit = orbit.toString();
+    modelViewer.resetTurntableRotation(skyboxAngle);
     modelViewer.jumpCameraToGoal();
   }
   
   modelViewer.addEventListener('mousedown', (event) => {
-    startX = event.clientX;
-       
-    orbiting = event.shiftKey;
-    if (!orbiting)
+    panning = event.button === 2 || event.ctrlKey || event.metaKey ||
+        event.shiftKey;
+    if (!panning)
       return;
-  
-    lastX = startX;
-    startOrbit();
+
+    lastX = event.clientX;
+    startPan();
     event.stopPropagation();
   }, true);
-  
-  self.addEventListener('mouseup', (event) => {
-    orbiting = false;
+
+  modelViewer.addEventListener('touchstart', (event) => {
+    panning = event.touches.length === 2;
+    if (!panning)
+      return;
+
+    const {touches} = event;
+    lastX = 0.5 * (touches[0].clientX + touches[1].clientX);
+    startPan();
   }, true);
-  
+
   modelViewer.addEventListener('mousemove', (event) => {
-    if (!orbiting)
+    if (!panning)
       return;
-    if (orbiting) {
-      requestAnimationFrame(() => updateOrbit(event.clientX));
-    }
-  
+
+    updatePan(event.clientX);
     event.stopPropagation();
+  }, true);
+
+  modelViewer.addEventListener('touchmove', (event) => {
+    if (!panning || event.touches.length !== 2)
+      return;
+
+    const {touches} = event;
+    const thisX = 0.5 * (touches[0].clientX + touches[1].clientX);
+    updatePan(thisX);
+  }, true);
+
+  self.addEventListener('mouseup', (event) => {
+    panning=false;
+  }, true);
+  
+  self.addEventListener('touchend', (event) => {
+    panning=false;
   }, true);
   
 </script>


### PR DESCRIPTION
Fixes #1727

This is a new example for rotating the skybox instead of the camera. Thanks to @dhruvadhia-cela as this builds off of his #1570. I also added the missing `toString()` method to `getCameraOrbit` to further simplify this.