### PR TITLE
Added read-only 'duration' property to animations

### DIFF
--- a/packages/model-viewer/src/features/animation.ts
+++ b/packages/model-viewer/src/features/animation.ts
@@ -29,6 +29,7 @@ export declare interface AnimationInterface {
   animationCrossfadeDuration: number;
   readonly availableAnimations: Array<string>;
   readonly paused: boolean;
+  readonly duration: number;
   currentTime: number;
   pause(): void;
   play(): void;
@@ -54,6 +55,10 @@ export const AnimationMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       return [];
+    }
+
+    get duration(): number {
+      return this[$scene].model.duration;
     }
 
     get paused(): boolean {

--- a/packages/model-viewer/src/test/features/animation-spec.ts
+++ b/packages/model-viewer/src/test/features/animation-spec.ts
@@ -112,7 +112,7 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
       element = new ModelViewerElement();
       element.autoplay = true;
       document.body.insertBefore(element, document.body.firstChild);
-    });
+    })
 
     teardown(() => {
       document.body.removeChild(element);

--- a/packages/model-viewer/src/test/features/animation-spec.ts
+++ b/packages/model-viewer/src/test/features/animation-spec.ts
@@ -84,10 +84,6 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
         expect(animationIsPlaying(element)).to.be.true;
       });
 
-      test('has a duration greater than 0', () => {
-        expect(element.duration).to.be.greaterThan(0);
-      });
-
       suite('when pause is invoked', () => {
         setup(async () => {
           const animationsPause = waitForEvent(element, 'pause');
@@ -105,23 +101,11 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
         });
       });
     });
-  });
 
-  suite('when configured to autoplay', () => {
-    setup(() => {
-      element = new ModelViewerElement();
-      element.autoplay = true;
-      document.body.insertBefore(element, document.body.firstChild);
-    })
-
-    teardown(() => {
-      document.body.removeChild(element);
-    });
-
-    suite('a model with animations', () => {
+    suite('when configured to autoplay', () => {
       setup(async () => {
-        element.src = ANIMATED_GLB_PATH;
-        await waitForEvent(element, 'load');
+        element.autoplay = true;
+        await timePasses();
       });
 
       test('plays an animation', () => {
@@ -148,30 +132,30 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
               .to.be.true;
         });
       });
-    });
 
-    suite('a model without animations', () => {
-      setup(async () => {
-        element.src = NON_ANIMATED_GLB_PATH;
-        await waitForEvent(element, 'load');
-      });
-
-      test('does not play an animation', () => {
-        expect(animationIsPlaying(element)).to.be.false;
-      });
-
-      test('has a duration of 0', () => {
-        expect(element.duration).to.be.equal(0);
-      });
-
-      suite('with a specified animation-name', () => {
+      suite('a model without animations', () => {
         setup(async () => {
-          element.animationName = element.availableAnimations[1];
-          await timePasses();
+          element.src = NON_ANIMATED_GLB_PATH;
+          await waitForEvent(element, 'load');
         });
 
         test('does not play an animation', () => {
           expect(animationIsPlaying(element)).to.be.false;
+        });
+
+        test('has a duration of 0', () => {
+          expect(element.duration).to.be.equal(0);
+        });
+
+        suite('with a specified animation-name', () => {
+          setup(async () => {
+            element.animationName = element.availableAnimations[1];
+            await timePasses();
+          });
+
+          test('does not play an animation', () => {
+            expect(animationIsPlaying(element)).to.be.false;
+          });
         });
       });
     });

--- a/packages/model-viewer/src/test/features/animation-spec.ts
+++ b/packages/model-viewer/src/test/features/animation-spec.ts
@@ -84,6 +84,10 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
         expect(animationIsPlaying(element)).to.be.true;
       });
 
+      test('has a duration greater than 0', () => {
+        expect(element.duration).to.be.greaterThan(0);
+      });
+
       suite('when pause is invoked', () => {
         setup(async () => {
           const animationsPause = waitForEvent(element, 'pause');

--- a/packages/model-viewer/src/test/features/animation-spec.ts
+++ b/packages/model-viewer/src/test/features/animation-spec.ts
@@ -84,6 +84,10 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
         expect(animationIsPlaying(element)).to.be.true;
       });
 
+      test('has a duration greater than 0', () => {
+        expect(element.duration).to.be.greaterThan(0);
+      });
+
       suite('when pause is invoked', () => {
         setup(async () => {
           const animationsPause = waitForEvent(element, 'pause');
@@ -124,6 +128,10 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
         expect(animationIsPlaying(element)).to.be.true;
       });
 
+      test('has a duration greater than 0', () => {
+        expect(element.duration).to.be.greaterThan(0);
+      });
+
       test('plays the first animation by default', () => {
         expect(animationIsPlaying(element, element.availableAnimations[0]))
             .to.be.true;
@@ -150,6 +158,10 @@ suite('ModelViewerElementBase with AnimationMixin', () => {
 
       test('does not play an animation', () => {
         expect(animationIsPlaying(element)).to.be.false;
+      });
+
+      test('has a duration of 0', () => {
+        expect(element.duration).to.be.equal(0);
       });
 
       suite('with a specified animation-name', () => {

--- a/packages/model-viewer/src/three-components/Model.ts
+++ b/packages/model-viewer/src/three-components/Model.ts
@@ -170,6 +170,15 @@ export default class Model extends Object3D {
     return 0;
   }
 
+  get duration(): number {
+    if (this.currentAnimationAction != null &&
+        this.currentAnimationAction.getClip()) {
+      return this.currentAnimationAction.getClip().duration;
+    }
+
+    return 0;
+  }
+
   get hasActiveAnimation(): boolean {
     return this.currentAnimationAction != null;
   }

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -784,6 +784,11 @@
         "description": "This property reports the current track time of the currently selected animation. If no animations are available, the value is always 0. This property can be set in order to seek along the timeline of the currently playing animation. For example, if you set it to 0, it will reset an animation to the beginning."
       },
       {
+        "name": "duration",
+        "htmlName": "duration",
+        "description": "This property is read-only. It returns the duration of the currently selected animation. If no animations are available, the value is always 0."
+      },
+      {
         "name": "paused",
         "htmlName": "paused",
         "description": "This property is read-only. It returns true if animations are paused. It returns false if animations are playing. Animations always start paused, and remain so unless the autoplay attribute is set or the <span class='attribute'>.play()</span> method is invoked.",


### PR DESCRIPTION
This provides a read-only `duration` property which surfaces the duration of the current animation, in the same way that `currentTime` can be accessed.

This PR is derived from a discussion in an [issue](https://github.com/google/model-viewer/issues/1736) on the same topic.

Documentation has also been updated to include a description of the property.

<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
<!-- Example: Fixes #1234 -->
Implements Issue #1736