### PR TITLE
deflake Renderer test

### DIFF
--- a/packages/model-viewer/src/test/three-components/Renderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/Renderer-spec.ts
@@ -28,9 +28,6 @@ const ModelViewerElement = class extends ModelViewerElementBase {
   }
 };
 
-// Ensure tests are not rescaling
-ModelViewerElement.minimumRenderScale = 1;
-
 customElements.define('model-viewer-renderer', ModelViewerElement);
 
 async function createScene(): Promise<ModelScene> {
@@ -54,6 +51,8 @@ suite('Renderer', () => {
 
   setup(async () => {
     renderer = Renderer.singleton;
+    // Ensure tests are not rescaling
+    ModelViewerElement.minimumRenderScale = 1;
     scene = await createScene();
   });
 


### PR DESCRIPTION
I think the gl context loss test was resetting the renderer and so the minimum render scale setting was being lost. I moved it into the setup function of the renderer tests so that it's more assured. Hopefully this deflakes the "only renders dirty scenes" test, since I think it was getting erroneous renders due to the render scale changing if the hardware was too slow.