### PR TITLE
State Linux is the preferred dev platform in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Check out the README.md files for specific projects to get more details:
 
 ## Development
 
-When developing across all the projects in this repository, first install git,
-Node.js and npm.
+All projects are intended to be developed on Linux. Developing in other environments (macOS, Windows or WSL) may be possible but isn't guaranteed to work, and may result in unexpected errors.
+
+When developing across all the projects in this repository, first install git, Node.js and npm.
 
 Then, perform the following steps to get set up for development:
 


### PR DESCRIPTION
I just went through a loop of trying to build on Windows (got errors), then WSL (got errors) and finally an Ubuntu VM (so far seems to work). Others also seemed to have had issues building on Windows (#1121).

Supposing most contributors build on Linux, this line in readme would've saved me a lot of time, googling and frustration.

Just an idea, feel free to decline.
Have a nice day.