### PR TITLE
remove quick-look-browsers

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -16,7 +16,7 @@
 import {property} from 'lit-element';
 import {Event as ThreeEvent} from 'three';
 
-import {IS_AR_QUICKLOOK_CANDIDATE, IS_IOS_CHROME, IS_IOS_SAFARI, IS_SCENEVIEWER_CANDIDATE, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
+import {IS_AR_QUICKLOOK_CANDIDATE, IS_SCENEVIEWER_CANDIDATE, IS_WEBXR_AR_CANDIDATE} from '../constants.js';
 import ModelViewerElementBase, {$loaded, $needsRender, $renderer, $scene, $shouldAttemptPreload, $updateSource} from '../model-viewer-base.js';
 import {enumerationDeserializer} from '../styles/deserializers.js';
 import {ARStatus} from '../three-components/ARRenderer.js';
@@ -25,11 +25,6 @@ import {Constructor, waitForEvent} from '../utilities.js';
 let isWebXRBlocked = false;
 let isSceneViewerBlocked = false;
 const noArViewerSigil = '#model-viewer-no-ar-fallback';
-
-export type QuickLookBrowser = 'safari'|'chrome';
-
-const deserializeQuickLookBrowsers =
-    enumerationDeserializer<QuickLookBrowser>(['safari', 'chrome']);
 
 export type ARMode = 'quick-look'|'scene-viewer'|'webxr'|'none';
 
@@ -56,8 +51,6 @@ export const $openIOSARQuickLook = Symbol('openIOSARQuickLook');
 const $canActivateAR = Symbol('canActivateAR');
 const $arMode = Symbol('arMode');
 const $arModes = Symbol('arModes');
-const $canLaunchQuickLook = Symbol('canLaunchQuickLook');
-const $quickLookBrowsers = Symbol('quickLookBrowsers');
 const $arAnchor = Symbol('arAnchor');
 const $preload = Symbol('preload');
 
@@ -71,7 +64,6 @@ export declare interface ARInterface {
   arModes: string;
   arScale: string;
   iosSrc: string|null;
-  quickLookBrowsers: string;
   readonly canActivateAR: boolean;
   activateAR(): Promise<void>;
 }
@@ -91,9 +83,6 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     @property({type: String, attribute: 'ios-src'}) iosSrc: string|null = null;
 
-    @property({type: String, attribute: 'quick-look-browsers'})
-    quickLookBrowsers: string = 'safari';
-
     get canActivateAR(): boolean {
       return this[$arMode] !== ARMode.NONE;
     }
@@ -110,8 +99,6 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
     protected[$arModes]: Set<ARMode> = new Set();
     protected[$arMode]: ARMode = ARMode.NONE;
     protected[$preload] = false;
-
-    protected[$quickLookBrowsers]: Set<QuickLookBrowser> = new Set();
 
     private[$onARButtonContainerClick] = (event: Event) => {
       event.preventDefault();
@@ -153,11 +140,6 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     async update(changedProperties: Map<string, any>) {
       super.update(changedProperties);
-
-      if (changedProperties.has('quickLookBrowsers')) {
-        this[$quickLookBrowsers] =
-            deserializeQuickLookBrowsers(this.quickLookBrowsers);
-      }
 
       if (changedProperties.has('arScale')) {
         this[$scene].canScale = this.arScale !== 'fixed';
@@ -225,7 +207,7 @@ configuration or device capabilities');
             break;
           } else if (
               value === 'quick-look' && !!this.iosSrc &&
-              this[$canLaunchQuickLook] && IS_AR_QUICKLOOK_CANDIDATE) {
+              IS_AR_QUICKLOOK_CANDIDATE) {
             this[$arMode] = ARMode.QUICK_LOOK;
             break;
           }
@@ -247,16 +229,6 @@ configuration or device capabilities');
         this.dispatchEvent(
             new CustomEvent<ARStatusDetails>('ar-status', {detail: {status}}));
       }
-    }
-
-    get[$canLaunchQuickLook](): boolean {
-      if (IS_IOS_CHROME) {
-        return this[$quickLookBrowsers].has('chrome');
-      } else if (IS_IOS_SAFARI) {
-        return this[$quickLookBrowsers].has('safari');
-      }
-
-      return false;
     }
 
     protected async[$enterARWithWebXR]() {

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -150,13 +150,6 @@ suite('ModelViewerElementBase with ARMixin', () => {
       });
     });
 
-    suite('quick-look-browsers', () => {
-      // TODO(#624,#625): We cannot implement these tests without the ability
-      // to mock our constants
-      test('shows the AR button for allowed browsers');
-      test('hides the AR button for non-allowed browsers');
-    });
-
     suite('with webxr', () => {
       let element: ModelViewerElementBase&ARInterface;
 

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -299,15 +299,6 @@
         "links": [
           "<a href=\"../examples/augmentedreality/#ar\"><span class='attribute'>ios-src</span> example</a>"
         ]
-      },
-      {
-        "name": "quick-look-browsers",
-        "htmlName": "quickLookBrowsers",
-        "description": "Set this attribute to control which iOS browsers will be allowed to launch AR Quick Look on iOS. Allowed values are \"safari\" and \"chrome\". You can specify any number of browsers separated by whitespace, for example: \"safari chrome\".",
-        "default": {
-          "default": "safari",
-          "options": "safari chrome"
-        }
       }
     ],
     "CSS": [

--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -261,7 +261,7 @@
         <div class="wrapper">
           <div class="heading">
             <h2 class="demo-title">Augmented Reality</h2>
-            <h4>This demonstrates several augmented reality modes, including <code>webxr</code>, <code>scene-viewer</code>, <code>quick-look</code> &amp; the accompanying attributes, <code>ios-src</code>, <code>quick-look-browsers</code>.</h4>
+            <h4>This demonstrates several augmented reality modes, including <code>webxr</code>, <code>scene-viewer</code>, <code>quick-look</code> &amp; the accompanying attributes, <code>ar</code>, <code>ar-modes</code>, <code>ar-scale</code>, <code>ios-src</code>.</h4>
           </div>
           <example-snippet stamp-to="ar" highlight-as="html">
             <template>


### PR DESCRIPTION
This removes the `quick-look-browsers` attribute, which was used to screen out iOS Chrome from AR mode because of an old and long-since fixed bug. This seems pretty unnecessary now, so we'll just allow any iOS browser to try and launch AR.
