### PR TITLE
Disable scene-viewer occlusion

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -281,11 +281,8 @@ configuration or device capabilities');
       // modelUrl can contain title/link/sound etc.
       // These are already URL-encoded, so we shouldn't do that again here.
       let intentParams = `?file=${modelUrl.toString()}&mode=ar_only`;
-      if (!gltfSrc.includes('&link=')) {
-        intentParams += `&link=${location}`;
-      }
-      if (!gltfSrc.includes('&title=')) {
-        intentParams += `&title=${encodeURIComponent(this.alt || '')}`;
+      if (!gltfSrc.includes('&disable_occlusion=')) {
+        intentParams += `&disable_occlusion=true`;
       }
       if (this.arScale === 'fixed') {
         intentParams += `&resizable=false`;

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -80,23 +80,6 @@ suite('ModelViewerElementBase with ARMixin', () => {
           expect(url.search).to.match(/(%3F|%26|&)token=foo(%26|&|$)/);
         });
 
-        test('defaults title and link', () => {
-          element.src = 'https://example.com/model.gltf';
-          element.alt = 'alt';
-          (element as any)[$openSceneViewer]();
-
-          expect(intentUrls.length).to.be.equal(1);
-
-          const url = new URL(intentUrls[0]);
-
-          expect(url.search).to.match(/(%3F|%26|&)title=alt(%26|&|$)/);
-
-          const linkRegex =
-              `(%3F|%26|&)link=${self.location.toString()}(%26|&|$)`;
-          linkRegex.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-          expect(url.search).to.match(new RegExp(linkRegex));
-        });
-
         test('keeps title and link when supplied', () => {
           element.src = 'https://example.com/model.gltf?link=foo&title=bar';
           element.alt = 'alt';


### PR DESCRIPTION
Fixes #1733 

Occlusion in scene-viewer is not a great experience with the current sensors, so we're disabling it by default now. It can be enabled by putting a query param on the `src` URL: `https://somewhere.org/model.glb?disable_occlusion=false`. You can also set any other scene-viewer query params in this way, like title, link, etc. This PR has also removed the default values for title and link that used to be set from alt and the source website, as that is rarely what a user would want anyway. Alt text is not a title, and the link was doing the same thing as the exit button, except sucking you into a WebView instead of taking you back to your browser. 