### PR TITLE
Change broken link in docs.json

### DIFF
--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -5,7 +5,7 @@
       {
         "name": "src",
         "htmlName": "src",
-        "description": "The URL to the 3D model. Only <a href=\"https://github.com/KhronosGroup/glTF/tree/master/specification/2.0\">glTF</a>/<a href=\"https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification\">GLB</a> models are supported, see <a href=\"https://github.com/google/model-viewer#supported-formats\">Supported Formats</a>.",
+        "description": "The URL to the 3D model. Only <a href=\"https://github.com/KhronosGroup/glTF/tree/master/specification/2.0\">glTF</a>/<a href=\"https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#glb-file-format-specification\">GLB</a> models are supported.",
         "links": [
           "<a href=\"../examples/loading\">Related examples</a>"
         ],


### PR DESCRIPTION
The current link, https://github.com/google/model-viewer#supported-formats, refers to a non-existent anchor. I think this is supposed to refer to GLTFLoader, but I can't find any details on supported formats aside from the GLTF extensions list.