### PR TITLE
Mobile Bridge Cleanup

### DIFF
--- a/packages/space-opera/editor/index.html
+++ b/packages/space-opera/editor/index.html
@@ -139,8 +139,8 @@
         <me-tabbed-panel icon="import_export">
           <me-export-panel></me-export-panel>
           <div class="privacy">
-            This &lt;model-viewer&gt; editor does not send any imported content to servers:
-            <a href="https://policies.google.com/privacy" class="privacy-link">
+            This &lt;model-viewer&gt; editor does not send any imported content to servers except to deploy to your mobile device:
+            <a href="https://policies.google.com/privacy" class="privacy-link" target="_blank">
               Privacy
             </a>
           </div>

--- a/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
+++ b/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
@@ -139,7 +139,7 @@ export class MobileExpanadableSection extends LitElement {
                                                html``
     return html`
     <div style="font-size: 14px; font-weight: 500; margin: 16px 0px 10px 0px;">
-      iOS Settings:
+      To enable AR on iOS, upload:
     </div> 
     <mwc-button unelevated icon="file_upload" @click=${this.onUploadUSDZ} 
       style="--mdc-theme-primary: ${needUsdzButton}">

--- a/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
+++ b/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
@@ -143,7 +143,7 @@ export class MobileExpanadableSection extends LitElement {
     </div> 
     <mwc-button unelevated icon="file_upload" @click=${this.onUploadUSDZ} 
       style="--mdc-theme-primary: ${needUsdzButton}">
-      USDZ
+      USDZ / REALITY
     </mwc-button>
     ${uploadUsdzText}
     `;

--- a/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
+++ b/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
@@ -122,7 +122,7 @@ export class MobileExpanadableSection extends LitElement {
     </me-checkbox>
     <me-checkbox
       id="ar-modes"
-      label="Default AR Modes to Scene Viewer"
+      label="Default AR Mode to Scene Viewer"
       ?checked="${this.defaultToSceneViewer}"
       @change=${this.selectArMode}
       >

--- a/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
+++ b/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
@@ -114,20 +114,20 @@ export class MobileExpanadableSection extends LitElement {
       AR Settings:
     </div> 
     <me-checkbox
-      id="ar-modes"
-      label="Default AR Modes to Scene Viewer"
-      ?checked="${this.defaultToSceneViewer}"
-      @change=${this.selectArMode}
-      >
-    </me-checkbox>
-    <me-checkbox
       id="ar"
       label="Enable AR"
       ?checked="${!!this.arConfig!.ar}"
       @change=${this.enableARChange}
       >
     </me-checkbox>
-    `
+    <me-checkbox
+      id="ar-modes"
+      label="Default AR Modes to Scene Viewer"
+      ?checked="${this.defaultToSceneViewer}"
+      @change=${this.selectArMode}
+      >
+    </me-checkbox>
+    `;
   }
 
   renderIos() {

--- a/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
+++ b/packages/space-opera/src/components/mobile_view/components/mobile_expandable_section.ts
@@ -105,6 +105,11 @@ export class MobileExpanadableSection extends LitElement {
       </mwc-button>
       ${this.optionalMessage}
     </div>
+    `;
+  }
+
+  renderAR() {
+    return html`
     <div style="font-size: 14px; font-weight: 500; margin: 16px 0px 10px 0px;">
       AR Settings:
     </div> 
@@ -122,7 +127,7 @@ export class MobileExpanadableSection extends LitElement {
       @change=${this.enableARChange}
       >
     </me-checkbox>
-    `;
+    `
   }
 
   renderIos() {
@@ -148,6 +153,7 @@ export class MobileExpanadableSection extends LitElement {
     return html`
       ${!this.isDeployed ? this.renderDeployButton() : html``}
       ${this.isDeployed ? this.renderMobileInfo() : html``}
+      ${this.renderAR()}
       ${this.renderIos()}
     `
   }

--- a/packages/space-opera/src/components/mobile_view/components/mobile_modal.ts
+++ b/packages/space-opera/src/components/mobile_view/components/mobile_modal.ts
@@ -66,6 +66,9 @@ export class MobileModal extends ConnectedLitElement {
     <div class="modal-text">
       This uses a third-party <a href="https://github.com/nwtgck/piping-server" target="_blank" class="piping-link">piping server</a> to deploy to your mobile device. This server does not store data.
     </div>
+    <div class="modal-text">
+      We use this server: <a href="https://piping.glitch.me/" target="_blank" class="piping-link">https://piping.glitch.me/</a>
+    </div>
   </div>
   <div class="FileModalCancel">
     <mwc-button unelevated icon="cancel" 

--- a/packages/space-opera/src/components/mobile_view/components/mobile_modal.ts
+++ b/packages/space-opera/src/components/mobile_view/components/mobile_modal.ts
@@ -58,11 +58,14 @@ export class MobileModal extends ConnectedLitElement {
     <div class="FileModalHeader">
       <div>Mobile View</div>
     </div>
-    <div style="font-size: 14px; font-weight: 500; margin: 10px 0px; color: white; word-wrap: break-word; width: 100%;">
+    <div class="modal-text">
       Use the QR Code to open your edited model, environment image, and &ltmodel-viewer&gt snippet on a mobile device to test out AR features. 
       After every subsequent change, click the "Refresh Mobile" button.
     </div>
     <canvas id="qr" style="display: block; margin-bottom: 90px;"></canvas>
+    <div class="modal-text">
+      This uses a third-party <a href="https://github.com/nwtgck/piping-server" target="_blank" class="piping-link">piping server</a> to deploy to your mobile device. This server does not store data.
+    </div>
   </div>
   <div class="FileModalCancel">
     <mwc-button unelevated icon="cancel" 

--- a/packages/space-opera/src/components/mobile_view/mobile_view.ts
+++ b/packages/space-opera/src/components/mobile_view/mobile_view.ts
@@ -31,6 +31,8 @@ import {styles} from './styles.css.js';
 import {EditorUpdates, MobilePacket, MobileSession} from './types.js';
 import {envToSession, getMobileOperatingSystem, getPingUrl, getRandomInt, getSessionUrl, getWithTimeout, gltfToSession, post, prepareGlbBlob, usdzToSession} from './utils.js';
 
+// On drag, default camera controls on.
+
 const TOAST_TIME = 7000;  // 7s
 
 /**

--- a/packages/space-opera/src/components/mobile_view/mobile_view.ts
+++ b/packages/space-opera/src/components/mobile_view/mobile_view.ts
@@ -31,8 +31,6 @@ import {styles} from './styles.css.js';
 import {EditorUpdates, MobilePacket, MobileSession, URLs} from './types.js';
 import {envToSession, getMobileOperatingSystem, getPingUrl, getRandomInt, getSessionUrl, getWithTimeout, gltfToSession, post, prepareGlbBlob, usdzToSession} from './utils.js';
 
-// TODO: Fix, out of sync on multi failure gets.
-
 const TOAST_TIME = 7000;  // 7s
 
 /**
@@ -126,7 +124,6 @@ export class MobileView extends LitElement {
       this.updateState(json.snippet, json.urls);
     }
 
-    // TODO: Handle env image is undefined
     if (updatedContent.envChanged) {
       this.envImageUrl =
           envToSession(this.pipeId, this.sessionId, updatedContent.envIsHdr);

--- a/packages/space-opera/src/components/mobile_view/mobile_view.ts
+++ b/packages/space-opera/src/components/mobile_view/mobile_view.ts
@@ -31,8 +31,6 @@ import {styles} from './styles.css.js';
 import {EditorUpdates, MobilePacket, MobileSession} from './types.js';
 import {envToSession, getMobileOperatingSystem, getPingUrl, getRandomInt, getSessionUrl, getWithTimeout, gltfToSession, post, prepareGlbBlob, usdzToSession} from './utils.js';
 
-// On drag, default camera controls on.
-
 const TOAST_TIME = 7000;  // 7s
 
 /**

--- a/packages/space-opera/src/components/mobile_view/open_mobile_view.ts
+++ b/packages/space-opera/src/components/mobile_view/open_mobile_view.ts
@@ -199,7 +199,8 @@ export class OpenMobileView extends ConnectedLitElement {
     }
     session.isStale = true;
 
-    const packet: MobilePacket = {updatedContent: updatedContent};
+    const packet:
+        MobilePacket = {updatedContent: updatedContent, urls: this.urls};
     if (updatedContent.stateChanged) {
       packet.snippet = this.snippet;
     }

--- a/packages/space-opera/src/components/mobile_view/open_mobile_view.ts
+++ b/packages/space-opera/src/components/mobile_view/open_mobile_view.ts
@@ -38,6 +38,8 @@ import {dispatchAr, dispatchArModes, dispatchIosSrc, getArConfig} from './reduce
 import {EditorUpdates, MobilePacket, MobileSession, URLs} from './types.js';
 import {envToSession, getPingUrl, getRandomInt, getSessionUrl, getWithTimeout, gltfToSession, post, prepareGlbBlob, prepareUSDZ, usdzToSession} from './utils.js';
 
+// TODO: Handle excessive timeout issues, check if they only occur locally...
+
 const REFRESH_DELAY = 20000;  // 20s
 
 /**

--- a/packages/space-opera/src/components/mobile_view/open_mobile_view.ts
+++ b/packages/space-opera/src/components/mobile_view/open_mobile_view.ts
@@ -34,7 +34,7 @@ import {getGltfModel, getGltfUrl} from '../model_viewer_preview/reducer.js';
 import {dispatchSetIosName} from '../relative_file_paths/reducer.js';
 import {MobileModal} from './components/mobile_modal.js';
 
-import {dispatchAr, dispatchArModes, dispatchIosSrc, dispatchSetRefreshable, getArConfig, getRefreshable} from './reducer.js';
+import {dispatchAr, dispatchArModes, dispatchIosSrc, dispatchSetForcePost, dispatchSetRefreshable, getArConfig, getForcePost, getRefreshable} from './reducer.js';
 import {EditorUpdates, MobilePacket, MobileSession, URLs} from './types.js';
 import {envToSession, getPingUrl, getRandomInt, getSessionUrl, getWithTimeout, gltfToSession, post, prepareGlbBlob, prepareUSDZ, usdzToSession} from './utils.js';
 
@@ -117,6 +117,11 @@ export class OpenMobileView extends ConnectedLitElement {
     this.defaultToSceneViewer =
         this.arConfig.arModes === 'scene-viewer webxr quick-look';
     this.iosAndNoUsdz = this.openedIOS && this.arConfig.iosSrc === undefined;
+
+    if (getForcePost(state) === true) {
+      this.postInfo();
+      reduxStore.dispatch(dispatchSetForcePost(false));
+    }
   }
 
   // True if any content we'd send to the mobile view has changed.

--- a/packages/space-opera/src/components/mobile_view/open_mobile_view.ts
+++ b/packages/space-opera/src/components/mobile_view/open_mobile_view.ts
@@ -38,8 +38,6 @@ import {dispatchAr, dispatchArModes, dispatchIosSrc, dispatchSetForcePost, dispa
 import {EditorUpdates, MobilePacket, MobileSession, URLs} from './types.js';
 import {envToSession, getPingUrl, getRandomInt, getSessionUrl, getWithTimeout, gltfToSession, post, prepareGlbBlob, prepareUSDZ, usdzToSession} from './utils.js';
 
-// TODO: Handle excessive timeout issues, check if they only occur locally...
-
 const REFRESH_DELAY = 20000;  // 20s
 
 /**

--- a/packages/space-opera/src/components/mobile_view/reducer.ts
+++ b/packages/space-opera/src/components/mobile_view/reducer.ts
@@ -16,6 +16,7 @@
  */
 
 import {Action, ArConfigState, State} from '../../types.js';
+import {MobileState} from './types.js';
 
 const SET_IOS_SRC = 'SET_IOS_SRC';
 export function dispatchIosSrc(iosSrc: string) {
@@ -61,13 +62,26 @@ export function dispatchSetRefreshable(canRefresh: boolean) {
   return {type: SET_REFRESHABLE, payload: canRefresh};
 }
 
-export const getRefreshable = (state: State) => state.entities.isRefreshable;
+const SET_FORCE_POST = 'SET_FORCE_POST';
+export function dispatchSetForcePost(forcePost: boolean) {
+  return {type: SET_FORCE_POST, payload: forcePost};
+}
 
-export function isRefreshableReducer(
-    state: boolean = false, action: Action): boolean {
+export const getRefreshable = (state: State) =>
+    state.entities.mobile.isRefreshable;
+export const getForcePost = (state: State) => state.entities.mobile.forcePost;
+
+export function mobileReducer(
+    state: MobileState = {
+      isRefreshable: false,
+      forcePost: false
+    },
+    action: Action): MobileState {
   switch (action.type) {
     case SET_REFRESHABLE:
-      return action.payload;
+      return {...state, isRefreshable: action.payload};
+    case SET_FORCE_POST:
+      return {...state, forcePost: action.payload};
     default:
       return state;
   }

--- a/packages/space-opera/src/components/mobile_view/reducer.ts
+++ b/packages/space-opera/src/components/mobile_view/reducer.ts
@@ -55,3 +55,20 @@ export function arReducer(
       return state;
   }
 }
+
+const SET_REFRESHABLE = 'SET_REFRESHABLE';
+export function dispatchSetRefreshable(canRefresh: boolean) {
+  return {type: SET_REFRESHABLE, payload: canRefresh};
+}
+
+export const getRefreshable = (state: State) => state.entities.isRefreshable;
+
+export function isRefreshableReducer(
+    state: boolean = false, action: Action): boolean {
+  switch (action.type) {
+    case SET_REFRESHABLE:
+      return action.payload;
+    default:
+      return state;
+  }
+}

--- a/packages/space-opera/src/components/mobile_view/styles.css.ts
+++ b/packages/space-opera/src/components/mobile_view/styles.css.ts
@@ -41,4 +41,16 @@ model-viewer {
   user-select: none;
   width: 100%;
 }
+
+.ios-message {
+  padding: 5px 16px;
+  margin: 10px;
+  position: absolute;
+  bottom: 0;
+  font-size: small;
+  color: black;
+  background-color: rgb(255, 204, 203);
+  word-wrap: break-word;
+  width: 100%;
+}
 `;

--- a/packages/space-opera/src/components/mobile_view/types.ts
+++ b/packages/space-opera/src/components/mobile_view/types.ts
@@ -40,6 +40,7 @@ export interface EditorUpdates {
 
 export interface MobilePacket {
   updatedContent: EditorUpdates;
+  urls: URLs;
   snippet?: any;
 }
 

--- a/packages/space-opera/src/components/mobile_view/types.ts
+++ b/packages/space-opera/src/components/mobile_view/types.ts
@@ -42,3 +42,8 @@ export interface MobilePacket {
   updatedContent: EditorUpdates;
   snippet?: any;
 }
+
+export interface MobileState {
+  isRefreshable: boolean;
+  forcePost: boolean;
+}

--- a/packages/space-opera/src/components/mobile_view/types.ts
+++ b/packages/space-opera/src/components/mobile_view/types.ts
@@ -31,6 +31,7 @@ export interface EditorUpdates {
   gltfChanged: boolean;
   gltfId: number;
   iosChanged: boolean;
+  iosSrcIsReality: boolean;
   usdzId: number;
   stateChanged: boolean;
   envChanged: boolean;

--- a/packages/space-opera/src/components/mobile_view/utils.ts
+++ b/packages/space-opera/src/components/mobile_view/utils.ts
@@ -19,15 +19,6 @@ import {GltfModel} from '@google/model-viewer-editing-adapter/lib/main';
 
 export const DOMAIN = 'https://piping.glitch.me/';
 
-export function outsidePostInfo() {
-  document.querySelector('open-mobile-view')?.postInfo();
-}
-
-export function outsideCanRefresh(): boolean|undefined {
-  console.log('open exsts', document.querySelector('open-mobile-view'));
-  return document.querySelector('open-mobile-view')?.canRefresh;
-}
-
 export function getRandomInt(max: number): number {
   return Math.floor(Math.random() * Math.floor(max));
 }

--- a/packages/space-opera/src/components/mobile_view/utils.ts
+++ b/packages/space-opera/src/components/mobile_view/utils.ts
@@ -49,8 +49,12 @@ export function envToSession(
 
 // ex: 'https://piping.nwtgck.repl.co/123-456-789'
 export function usdzToSession(
-    pipeId: number|string, sessionID: number, modelId: number): string {
-  return `${DOMAIN}${pipeId}-${sessionID}-${modelId}.usdz`;
+    pipeId: number|string,
+    sessionID: number,
+    modelId: number,
+    iosSrcIsReality: boolean): string {
+  const fileType = iosSrcIsReality ? 'reality' : 'usdz';
+  return `${DOMAIN}${pipeId}-${sessionID}-${modelId}.${fileType}`;
 }
 
 export async function prepareGlbBlob(gltf: GltfModel) {

--- a/packages/space-opera/src/components/mobile_view/utils.ts
+++ b/packages/space-opera/src/components/mobile_view/utils.ts
@@ -19,6 +19,15 @@ import {GltfModel} from '@google/model-viewer-editing-adapter/lib/main';
 
 export const DOMAIN = 'https://piping.glitch.me/';
 
+export function outsidePostInfo() {
+  document.querySelector('open-mobile-view')?.postInfo();
+}
+
+export function outsideCanRefresh(): boolean|undefined {
+  console.log('open exsts', document.querySelector('open-mobile-view'));
+  return document.querySelector('open-mobile-view')?.canRefresh;
+}
+
 export function getRandomInt(max: number): number {
   return Math.floor(Math.random() * Math.floor(max));
 }

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -33,7 +33,7 @@ import {modelViewerPreviewStyles} from '../../styles.css.js';
 import {extractStagingConfig, State} from '../../types.js';
 import {applyCameraEdits, Camera, INITIAL_CAMERA} from '../camera_settings/camera_state.js';
 import {dispatchCameraIsDirty, getCamera} from '../camera_settings/reducer.js';
-import {dispatchEnvrionmentImage, getConfig} from '../config/reducer.js';
+import {dispatchCameraControlsEnabled, dispatchEnvrionmentImage, getConfig} from '../config/reducer.js';
 import {ConnectedLitElement} from '../connected_lit_element/connected_lit_element.js';
 import {dispatchAddHotspot, dispatchSetHotspots, dispatchUpdateHotspotMode, generateUniqueHotspotName, getHotspotMode, getHotspots} from '../hotspot_panel/reducer.js';
 import {HotspotConfig} from '../hotspot_panel/types.js';
@@ -305,6 +305,7 @@ export class ModelViewerPreview extends ConnectedLitElement {
         const url = createSafeObjectUrlFromArrayBuffer(arrayBuffer).unsafeUrl;
         reduxStore.dispatch(dispatchGltfUrl(url));
         dispatchConfig(extractStagingConfig(this.config));
+        reduxStore.dispatch(dispatchCameraControlsEnabled(true));
         reduxStore.dispatch(dispatchSetHotspots([]));
       }
       if (file.name.match(/\.(hdr|png|jpg|jpeg)$/i)) {

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -39,8 +39,7 @@ import {dispatchAddHotspot, dispatchSetHotspots, dispatchUpdateHotspotMode, gene
 import {HotspotConfig} from '../hotspot_panel/types.js';
 import {createBlobUrlFromEnvironmentImage, dispatchAddEnvironmentImage} from '../ibl_selector/reducer.js';
 import {getEdits, getOrigEdits} from '../materials_panel/reducer.js';
-import {getRefreshable} from '../mobile_view/reducer.js';
-import {outsidePostInfo} from '../mobile_view/utils.js';
+import {dispatchSetForcePost, getRefreshable} from '../mobile_view/reducer.js';
 import {dispatchConfig} from '../model_viewer_snippet/reducer.js';
 import {dispatchSetEnvironmentName, dispatchSetModelName} from '../relative_file_paths/reducer.js';
 import {styles as hotspotStyles} from '../utils/hotspot/hotspot.css.js';
@@ -168,6 +167,10 @@ export class ModelViewerPreview extends ConnectedLitElement {
     }
   }
 
+  forcePost() {
+    reduxStore.dispatch(dispatchSetForcePost(true));
+  }
+
   protected render() {
     // If the gltf model has a URL, it must be more recent
     const currentSrc = this[$gltf]?.getModelViewerSource() ?? this[$gltfUrl];
@@ -187,7 +190,7 @@ export class ModelViewerPreview extends ConnectedLitElement {
     </mwc-icon-button>`;
     const refreshMobileButton = this.refreshButtonIsReady === true ? html
     `<mwc-icon-button icon="cached" class="RefreshMobileButton"
-      title="Refresh Mobile" @click=${outsidePostInfo}>
+      title="Refresh Mobile" @click=${this.forcePost}>
     </mwc-icon-button>`: html``;
     const childElements = [
       ...renderHotspots(this.hotspots),

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -24,7 +24,6 @@ import '@material/mwc-icon-button';
 
 import {GltfModel, ModelViewerConfig, unpackGlb} from '@google/model-viewer-editing-adapter/lib/main.js'
 import {createSafeObjectUrlFromArrayBuffer} from '@google/model-viewer-editing-adapter/lib/util/create_object_url.js'
-import {safeDownloadCallback} from '@google/model-viewer-editing-adapter/lib/util/safe_download_callback.js'
 import {ModelViewerElement} from '@google/model-viewer/lib/model-viewer';
 import {customElement, html, internalProperty, PropertyValues, query} from 'lit-element';
 
@@ -184,19 +183,13 @@ export class ModelViewerPreview extends ConnectedLitElement {
 
     const hasModel = !!editedConfig.src;
 
-    const screenshotButton = !hasModel ? html`` : html
-    `<mwc-icon-button icon="photo_camera" class="ScreenShotButton"
-      title="Take screenshot" @click=${this.downloadScreenshot}>
-    </mwc-icon-button>`;
     const refreshMobileButton = this.refreshButtonIsReady === true ? html
-    `<mwc-icon-button icon="cached" class="RefreshMobileButton"
-      title="Refresh Mobile" @click=${this.forcePost}>
-    </mwc-icon-button>`: html``;
-    const childElements = [
-      ...renderHotspots(this.hotspots),
-      screenshotButton,
-      refreshMobileButton
-    ];
+    `<mwc-button icon="cached" @click=${this.forcePost}
+      style="--mdc-theme-primary: #DC143C; border: #DC143C" class="RefreshMobileButton">
+      Refresh Mobile
+    </mwc-button>`: html``;
+    const childElements =
+        [...renderHotspots(this.hotspots), refreshMobileButton];
 
     if (this.gltfError) {
       childElements.push(html`<div class="ErrorText">Error loading GLB:<br/>${
@@ -289,13 +282,6 @@ export class ModelViewerPreview extends ConnectedLitElement {
       normal: positionAndNormal.normal,
     }));
     reduxStore.dispatch(dispatchUpdateHotspotMode(false));
-  }
-
-  private async downloadScreenshot() {
-    if (!this.modelViewer)
-      return;
-    safeDownloadCallback(
-        await this.modelViewer.toBlob(), 'Space Opera Screenshot.png', '')();
   }
 
   private onDragover(event: DragEvent) {

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -39,6 +39,8 @@ import {dispatchAddHotspot, dispatchSetHotspots, dispatchUpdateHotspotMode, gene
 import {HotspotConfig} from '../hotspot_panel/types.js';
 import {createBlobUrlFromEnvironmentImage, dispatchAddEnvironmentImage} from '../ibl_selector/reducer.js';
 import {getEdits, getOrigEdits} from '../materials_panel/reducer.js';
+import {getRefreshable} from '../mobile_view/reducer.js';
+import {outsidePostInfo} from '../mobile_view/utils.js';
 import {dispatchConfig} from '../model_viewer_snippet/reducer.js';
 import {dispatchSetEnvironmentName, dispatchSetModelName} from '../relative_file_paths/reducer.js';
 import {styles as hotspotStyles} from '../utils/hotspot/hotspot.css.js';
@@ -74,6 +76,8 @@ export class ModelViewerPreview extends ConnectedLitElement {
   @internalProperty()[$gltfUrl]?: string;
   @internalProperty() gltfError: string = '';
 
+  @internalProperty() refreshButtonIsReady: boolean = false;
+
   stateChanged(state: State) {
     this.addHotspotMode = getHotspotMode(state) || false;
     this.camera = getCamera(state);
@@ -84,6 +88,7 @@ export class ModelViewerPreview extends ConnectedLitElement {
     this[$gltf] = getGltfModel(state);
     this[$gltfUrl] = getGltfUrl(state);
     this[$autoplay] = getConfig(state).autoplay;
+    this.refreshButtonIsReady = getRefreshable(state);
   }
 
   firstUpdated() {
@@ -178,10 +183,17 @@ export class ModelViewerPreview extends ConnectedLitElement {
 
     const screenshotButton = !hasModel ? html`` : html
     `<mwc-icon-button icon="photo_camera" class="ScreenShotButton"
-      title="Take screenshot"
-      @click=${this.downloadScreenshot}>
+      title="Take screenshot" @click=${this.downloadScreenshot}>
     </mwc-icon-button>`;
-    const childElements = [...renderHotspots(this.hotspots), screenshotButton];
+    const refreshMobileButton = this.refreshButtonIsReady === true ? html
+    `<mwc-icon-button icon="cached" class="RefreshMobileButton"
+      title="Refresh Mobile" @click=${outsidePostInfo}>
+    </mwc-icon-button>`: html``;
+    const childElements = [
+      ...renderHotspots(this.hotspots),
+      screenshotButton,
+      refreshMobileButton
+    ];
 
     if (this.gltfError) {
       childElements.push(html`<div class="ErrorText">Error loading GLB:<br/>${

--- a/packages/space-opera/src/reducers.ts
+++ b/packages/space-opera/src/reducers.ts
@@ -23,7 +23,7 @@ import {configReducer} from './components/config/reducer.js';
 import {hotspotsReducer, hotspotsUiReducer} from './components/hotspot_panel/reducer.js';
 import {environmentReducer} from './components/ibl_selector/reducer.js'
 import {editsReducer, origEditsReducer} from './components/materials_panel/reducer.js';
-import {arReducer} from './components/mobile_view/reducer.js';
+import {arReducer, isRefreshableReducer} from './components/mobile_view/reducer.js';
 import {gltfReducer} from './components/model_viewer_preview/reducer.js';
 import {relativeFilePathsReducer} from './components/relative_file_paths/reducer.js';
 
@@ -41,6 +41,7 @@ const modelViewerSnippetReducer = combineReducers({
 
 const entitiesReducer = combineReducers({
   isDirtyCamera: isDirtyCameraReducer,
+  isRefreshable: isRefreshableReducer,
   environment: environmentReducer,
   gltf: gltfReducer,
   gltfEdits: gltfEditsReducer,

--- a/packages/space-opera/src/reducers.ts
+++ b/packages/space-opera/src/reducers.ts
@@ -23,7 +23,7 @@ import {configReducer} from './components/config/reducer.js';
 import {hotspotsReducer, hotspotsUiReducer} from './components/hotspot_panel/reducer.js';
 import {environmentReducer} from './components/ibl_selector/reducer.js'
 import {editsReducer, origEditsReducer} from './components/materials_panel/reducer.js';
-import {arReducer, isRefreshableReducer} from './components/mobile_view/reducer.js';
+import {arReducer, mobileReducer} from './components/mobile_view/reducer.js';
 import {gltfReducer} from './components/model_viewer_preview/reducer.js';
 import {relativeFilePathsReducer} from './components/relative_file_paths/reducer.js';
 
@@ -41,7 +41,7 @@ const modelViewerSnippetReducer = combineReducers({
 
 const entitiesReducer = combineReducers({
   isDirtyCamera: isDirtyCameraReducer,
-  isRefreshable: isRefreshableReducer,
+  mobile: mobileReducer,
   environment: environmentReducer,
   gltf: gltfReducer,
   gltfEdits: gltfEditsReducer,

--- a/packages/space-opera/src/styles.css.ts
+++ b/packages/space-opera/src/styles.css.ts
@@ -218,6 +218,19 @@ input[type="file"] {
   padding-top: 10px;
   width: 100%;
 }
+
+.modal-text {
+  font-size: 14px;
+  font-weight: 500;
+  margin: 10px 0px;
+  color: white;
+  word-wrap: break-word;
+  width: 100%;
+}
+
+.piping-link {
+  color: #6495ED;
+}
 `;
 
 // https://www.w3schools.com/howto/howto_js_snackbar.asp

--- a/packages/space-opera/src/styles.css.ts
+++ b/packages/space-opera/src/styles.css.ts
@@ -286,8 +286,8 @@ export const toastStyles: CSSResult = css`
 
 #snackbar-mobile.show {
   visibility: visible;
-  -webkit-animation: fadein 0.5s, fadeout 0.5s 5.5s;
-  animation: fadein 0.5s, fadeout 0.5s 5.5s;
+  -webkit-animation: fadein 0.5s, fadeout 0.5s 6.5s;
+  animation: fadein 0.5s, fadeout 0.5s 6.5s;
 }
 
 @-webkit-keyframes fadein {

--- a/packages/space-opera/src/styles.css.ts
+++ b/packages/space-opera/src/styles.css.ts
@@ -277,8 +277,8 @@ export const toastStyles: CSSResult = css`
 
 #snackbar-mobile.show {
   visibility: visible;
-  -webkit-animation: fadein 0.5s, fadeout 0.5s 4.5s;
-  animation: fadein 0.5s, fadeout 0.5s 4.5s;
+  -webkit-animation: fadein 0.5s, fadeout 0.5s 5.5s;
+  animation: fadein 0.5s, fadeout 0.5s 5.5s;
 }
 
 @-webkit-keyframes fadein {

--- a/packages/space-opera/src/styles.css.ts
+++ b/packages/space-opera/src/styles.css.ts
@@ -132,19 +132,7 @@ model-viewer {
 }
 
 .RefreshMobileButton {
-  border-radius: 50%;
-  border: 1px #DC143C solid;
-  bottom: 100px;
-  color: #DC143C;
-  position: absolute;
-  right: 25px;
-}
-
-.ScreenShotButton {
-  border-radius: 50%;
-  border: 1px #4285f4 solid;
   bottom: 25px;
-  color: #4285f4; /* MATERIAL_COLOR_GOOGLE_BLUE_500 */;
   position: absolute;
   right: 25px;
 }

--- a/packages/space-opera/src/styles.css.ts
+++ b/packages/space-opera/src/styles.css.ts
@@ -131,6 +131,15 @@ model-viewer {
   width: 100%;
 }
 
+.RefreshMobileButton {
+  border-radius: 50%;
+  border: 1px #DC143C solid;
+  bottom: 100px;
+  color: #DC143C;
+  position: absolute;
+  right: 25px;
+}
+
 .ScreenShotButton {
   border-radius: 50%;
   border: 1px #4285f4 solid;

--- a/packages/space-opera/src/types.ts
+++ b/packages/space-opera/src/types.ts
@@ -64,6 +64,7 @@ export interface ModelViewerSnippetState {
 
 export interface EntitiesState {
   isDirtyCamera: boolean;
+  isRefreshable: boolean;
   environment: EnvironmentState;
   gltf: GltfState;
   gltfEdits: GltfEditsState;
@@ -82,6 +83,7 @@ export const INITIAL_STATE: State = {
   ui: {hotspots: {addHotspot: false}},
   entities: {
     isDirtyCamera: false,
+    isRefreshable: false,
     environment: {environmentImages: INITIAL_ENVIRONMENT_IMAGES},
     gltf: {gltfJsonString: ''},
     gltfEdits: {

--- a/packages/space-opera/src/types.ts
+++ b/packages/space-opera/src/types.ts
@@ -21,6 +21,7 @@ import * as Redux from 'redux';  // from //third_party/javascript/redux:redux_cl
 import {Camera, INITIAL_CAMERA} from './components/camera_settings/camera_state.js';
 import {HotspotConfig} from './components/hotspot_panel/types.js';
 import {EnvironmentImage, INITIAL_ENVIRONMENT_IMAGES} from './components/ibl_selector/types.js';
+import {MobileState} from './components/mobile_view/types.js';
 import {GltfEdits, GltfState, INITIAL_GLTF_EDITS} from './components/model_viewer_preview/types.js';
 
 interface HotspotsUIState {
@@ -64,7 +65,7 @@ export interface ModelViewerSnippetState {
 
 export interface EntitiesState {
   isDirtyCamera: boolean;
-  isRefreshable: boolean;
+  mobile: MobileState;
   environment: EnvironmentState;
   gltf: GltfState;
   gltfEdits: GltfEditsState;
@@ -83,7 +84,10 @@ export const INITIAL_STATE: State = {
   ui: {hotspots: {addHotspot: false}},
   entities: {
     isDirtyCamera: false,
-    isRefreshable: false,
+    mobile: {
+      isRefreshable: false,
+      forcePost: false,
+    },
     environment: {environmentImages: INITIAL_ENVIRONMENT_IMAGES},
     gltf: {gltfJsonString: ''},
     gltfEdits: {


### PR DESCRIPTION
- [x] Enable camera controls on model drag
- [x] Add way to refresh mobile if on different tab
- [x] Cleanup environment image / skybox situation
- [x] Cleanup any situation of URLs with mobile, how they don't update if they become undefined
- [x] Check if timing out is happening on deployed version
- [x] Make AR settings visible before deploy
- [x] Enable AR should be before Default AR mode 
- [x]  change iOS Settings --> To enable AR on iOS, upload:
- [x] Change iOS upload button to usdz / .reality
- [x] Change wording for explanations
- [x] Add message on iOS device to upload a usdz/.reality if one isn't uploaded
- [x] Remove camera button, add REFRSH MOBILE text to button
