### PR TITLE
fixed initial variant

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -173,6 +173,7 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
           if (extension != null) {
             this[$variants] =
                 (extension.variants as Variants).map(variant => variant.name);
+            this.requestUpdate('variantName');
           }
         }
       }


### PR DESCRIPTION
If a variant was specified as an attribute it was not being loaded; it would only update when changed after load. 