### PR TITLE
Add basic error handling in space-opera viewer preview when loading malformed glb.

### DIFF
--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -232,6 +232,9 @@ export class ModelViewerPreview extends ConnectedLitElement {
                 if (this.addHotspotMode) {
                   this.addHotspot(event);
                 }
+              },
+              error: (error: CustomEvent) => {
+                this.gltfError = error.detail;
               }
             },
             childElements)}`;

--- a/packages/space-opera/src/components/utils/render_model_viewer.ts
+++ b/packages/space-opera/src/components/utils/render_model_viewer.ts
@@ -32,6 +32,7 @@ export interface ModelViewerEventHandlers {
   readonly play?: () => void;
   readonly pause?: () => void;
   readonly click?: (event: MouseEvent) => void;
+  readonly error?: (details: CustomEvent) => void;
 }
 
 /**
@@ -74,6 +75,7 @@ export function renderModelViewer(
         @play=${eventHandlers?.play}
         @pause=${eventHandlers?.pause}
         @click=${eventHandlers?.click}
+        @error=${eventHandlers?.error}
       >
       ${childElements}
     </model-viewer>


### PR DESCRIPTION
Trying to load a "malformed" glb into the editor yields a white screen with no information to the end user.
The issue with the attached glb file is that while the model is fine, some materials reference textures from './'. 
three.js tries to `fetch` those files, the requests fail and the "error" custom event is triggered but not listened to from space-opera.

Malformed glb: [Ring.glb.zip](https://github.com/google/model-viewer/files/5874330/Ring.glb.zip)
