### PR TITLE
removed fancy default for pan-y

### DIFF
--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -516,12 +516,8 @@ export class SmoothControls extends EventDispatcher {
             const {clientX, clientY} = touches[0];
             const dx = Math.abs(clientX - this.lastPointerPosition.clientX);
             const dy = Math.abs(clientY - this.lastPointerPosition.clientY);
-            // If motion is mostly vertical, assume scrolling is the intent,
-            // unless scrolling is not possible. Use window.innerHeight
-            // instead of body.clientHeight so that a full-screen element will
-            // still scroll the URL bar out of the way before locking.
-            if ((touchAction === 'pan-y' && dy > dx &&
-                 document.body.scrollHeight > window.innerHeight) ||
+            // If motion is mostly vertical, assume scrolling is the intent.
+            if ((touchAction === 'pan-y' && dy > dx) ||
                 (touchAction === 'pan-x' && dx > dy)) {
               this.touchMode = 'scroll';
               return;


### PR DESCRIPTION
There was built into the default `touch-action: "pan-y"` a special case to effectively turn it into `touch-action: "none"` when the modelviewer element was fullscreen. However, this doesn't work well at all for iframes and it's honestly a little confusing anyway. From now on, if you know your page doesn't need to scroll, you'll have to remember to set `touch-action: "none"` manually.