### PR TITLE
Prevent error on 'progress' event with default progress bar.

### DIFF
--- a/packages/space-opera/src/components/best_practices/render_best_practices.ts
+++ b/packages/space-opera/src/components/best_practices/render_best_practices.ts
@@ -34,9 +34,12 @@ export function renderProgressBar(isEditor) {
 export const onProgress = (event) => {
   const progressBar = event.target.querySelector('.progress-bar');
   const updatingBar = event.target.querySelector('.update-bar');
+  if (!progressBar || !updatingBar)
+    return;
   updatingBar.style.width = `${event.detail.totalProgress * 100}%`;
   if (event.detail.totalProgress === 1) {
     progressBar.classList.add('hide');
+    event.target.removeEventListener('progress', onProgress);
   } else {
     progressBar.classList.remove('hide');
     if (event.detail.totalProgress === 0) {


### PR DESCRIPTION
A dangling event handler dispatches an error when the "Use Custom Progress Bar" checkbox is not selected and the user is trying to switch to another HDR or even another model.

### Repro steps directly at https://modelviewer.dev/editor/:

- Select a model from the dropdown
- Uncheck "Progress bar" in "Best practice" section.
- Switch to "Lighting" tab
- Select any other HDR from the dropdown

```
Uncaught TypeError: Cannot read property 'style' of null
    at HTMLElement.onProgress (space-opera.js:36313)
    at DocumentFragment.LoadingModelViewerElement.<computed> (space-opera.js:98778)
    at ProgressTracker.dispatchEvent (space-opera.js:95316)
    at ProgressTracker.[announceTotalProgress] (space-opera.js:95374)
    at ProgressTracker.beginActivity (space-opera.js:95346)
    at TextureUtils.generateEnvironmentMapAndSkybox (space-opera.js:94736)
    at environment (space-opera.js:98373)
    at new Promise (<anonymous>)
    at HTMLElement.[updateEnvironment] (space-opera.js:98372)
    at HTMLElement.updated (space-opera.js:98352)
```

### Solution:

Automatically detach event handler on progress complete and null-check both incriminated nodes. 
An even better solution would be to link the attaching/detaching mechanism to the `SET_PROGRESS_BAR` mutation.