### PR TITLE
Fix CacheEvictionPolicy retainerCounts  

### DIFF
--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -166,6 +166,7 @@ export class ModelScene extends Scene {
       }
       return;
     }
+    this.url = url;
 
     // If we have pending work due to a previous source change in progress,
     // cancel it so that we do not incur a race condition:
@@ -198,7 +199,6 @@ export class ModelScene extends Scene {
     }
 
     this.reset();
-    this.url = url;
     this._currentGLTF = gltf;
 
     if (gltf != null) {

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -166,6 +166,7 @@ export class ModelScene extends Scene {
       }
       return;
     }
+    this.reset();
     this.url = url;
 
     // If we have pending work due to a previous source change in progress,
@@ -199,6 +200,7 @@ export class ModelScene extends Scene {
     }
 
     this.reset();
+    this.url = url;
     this._currentGLTF = gltf;
 
     if (gltf != null) {

--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {Cache, EquirectangularReflectionMapping, EventDispatcher, GammaEncoding, NearestFilter, PMREMGenerator, RGBEEncoding, Texture, TextureLoader, WebGLRenderer, WebGLRenderTarget} from 'three';
+import {EquirectangularReflectionMapping, EventDispatcher, GammaEncoding, NearestFilter, PMREMGenerator, RGBEEncoding, Texture, TextureLoader, WebGLRenderer, WebGLRenderTarget} from 'three';
 import {RGBELoader} from 'three/examples/jsm/loaders/RGBELoader.js';
 import {deserializeUrl} from '../utilities.js';
 

--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -33,10 +33,6 @@ export interface EnvironmentGenerationConfig {
 
 const GENERATED_SIGMA = 0.04;
 
-// Enable three's loader cache so we don't create redundant
-// Image objects to decode images fetched over the network.
-Cache.enabled = true;
-
 const HDR_FILE_RE = /\.hdr(\.js)?$/;
 const ldrLoader = new TextureLoader();
 const hdrLoader = new RGBELoader();


### PR DESCRIPTION
When a model is in the viewport but hasn't finished loading yet, the intersection observer triggers updateSource multiple times with the same source, resulting in extra retainerCounts for that source's URL in CacheEvictionPolicy. The url check at the top of the function is supposed to avoid that, but wasn't working because this.url is not set until after some async calls.

Fixes #1674 
It's possible there are other leaks still, but I think this was the big one.