### PR TITLE
Change Blob to File in file_modal.ts

### DIFF
--- a/packages/space-opera/src/components/file_modal/file_modal.ts
+++ b/packages/space-opera/src/components/file_modal/file_modal.ts
@@ -21,7 +21,7 @@ import {customElement, html, LitElement, property, PropertyValues, query} from '
 import {fileModalStyles} from '../../styles.css.js';
 
 interface BlobArrayResolver {
-  resolve: (fileList?: Blob[]|PromiseLike<Blob[]>) => void;
+  resolve: (fileList?: File[]|PromiseLike<File[]>) => void;
   reject: (error?: Error) => void;
 }
 
@@ -38,7 +38,7 @@ export class FileModalElement extends LitElement {
 
   private blobsResolver?: BlobArrayResolver;
 
-  open(): Promise<Blob[]|undefined> {
+  open(): Promise<File[]|undefined> {
     // The user canceled the previous upload
     if (this.blobsResolver !== undefined) {
       this.blobsResolver.resolve(undefined);
@@ -48,7 +48,7 @@ export class FileModalElement extends LitElement {
     // TODO: When user reloads same file, animations don't run...
     this.fileInput.value = '';
     this.fileInput.click();
-    const promise = new Promise<Blob[]>((resolve, reject) => {
+    const promise = new Promise<File[]|undefined>((resolve, reject) => {
       this.blobsResolver = {resolve, reject};
     });
     return promise;

--- a/packages/space-opera/src/components/file_modal/file_modal.ts
+++ b/packages/space-opera/src/components/file_modal/file_modal.ts
@@ -20,7 +20,7 @@ import '@material/mwc-button';
 import {customElement, html, LitElement, property, PropertyValues, query} from 'lit-element';
 import {fileModalStyles} from '../../styles.css.js';
 
-interface BlobArrayResolver {
+interface FileArrayResolver {
   resolve: (fileList?: File[]|PromiseLike<File[]>) => void;
   reject: (error?: Error) => void;
 }
@@ -36,7 +36,7 @@ export class FileModalElement extends LitElement {
   @property({type: String}) accept = '';
   @query('input#file-input') fileInput!: HTMLInputElement;
 
-  private blobsResolver?: BlobArrayResolver;
+  private blobsResolver?: FileArrayResolver;
 
   open(): Promise<File[]|undefined> {
     // The user canceled the previous upload

--- a/packages/space-opera/src/components/file_modal/file_modal.ts
+++ b/packages/space-opera/src/components/file_modal/file_modal.ts
@@ -36,20 +36,20 @@ export class FileModalElement extends LitElement {
   @property({type: String}) accept = '';
   @query('input#file-input') fileInput!: HTMLInputElement;
 
-  private blobsResolver?: FileArrayResolver;
+  private filesResolver?: FileArrayResolver;
 
   open(): Promise<File[]|undefined> {
     // The user canceled the previous upload
-    if (this.blobsResolver !== undefined) {
-      this.blobsResolver.resolve(undefined);
-      delete this.blobsResolver;
+    if (this.filesResolver !== undefined) {
+      this.filesResolver.resolve(undefined);
+      delete this.filesResolver;
     }
     // Reset this, so the user can reload the same file again.
     // TODO: When user reloads same file, animations don't run...
     this.fileInput.value = '';
     this.fileInput.click();
     const promise = new Promise<File[]|undefined>((resolve, reject) => {
-      this.blobsResolver = {resolve, reject};
+      this.filesResolver = {resolve, reject};
     });
     return promise;
   }
@@ -70,22 +70,22 @@ export class FileModalElement extends LitElement {
   }
 
   async onFileChange() {
-    if (!this.blobsResolver) {
+    if (!this.filesResolver) {
       throw new Error('No file upload resolver found');
     }
 
-    const blobs: Blob[] = [];
+    const fileLists: File[] = [];
     const files = this.fileInput.files;
     if (files) {
       for (let i = 0; i < files.length; i++) {
         if (files[i]) {
-          blobs.push(files[i]);
+          fileLists.push(files[i]);
         }
       }
     }
 
-    this.blobsResolver.resolve(blobs);
-    delete this.blobsResolver;
+    this.filesResolver.resolve(fileLists);
+    delete this.filesResolver;
   }
 }
 

--- a/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
@@ -216,7 +216,7 @@ export class ImportCard extends LitElement {
   @internalProperty() selectedDefaultOption: number = 0;
 
   async onUploadGLB() {
-    const files: any = await this.fileModal.open();
+    const files = await this.fileModal.open();
     if (!files) {
       /// The user canceled the previous upload
       return;

--- a/packages/space-opera/src/test/shared/texture_picker/texture_picker_test.ts
+++ b/packages/space-opera/src/test/shared/texture_picker/texture_picker_test.ts
@@ -66,8 +66,8 @@ describe('texture picker test', () => {
         texturePicker.shadowRoot!.querySelector(
             'me-file-modal#textureUpload')! as FileModalElement;
 
-    const openPromise = new Promise<Blob[]>(resolve => {
-      resolve([new Blob(['test'], {type: 'image/jpeg'})]);
+    const openPromise = new Promise<File[] | undefined>(resolve => {
+      resolve([new File(['test'], 'testname', {type: 'image/jpeg'})]);
     });
 
     spyOn(textureUploadFileModal, 'open').and.returnValue(openPromise);


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue Nothing
<!-- Example: Fixes #1234 -->

https://github.com/google/model-viewer/blob/b5678a4e064356a2ae4fad2712a6fdc2e8e5ac7b/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts#L225
[Blob](https://developer.mozilla.org/ja/docs/Web/API/Blob) does not have `name` prototype and [File.name](https://developer.mozilla.org/ja/docs/Web/API/File/name) exsists, so I guessed `File` is correct.