### PR TITLE
Expose default-poster, default-ar-button and default-exit-webxr-ar-button with ::part()

### DIFF
--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -312,7 +312,7 @@ canvas.show {
 
   <div class="slot ar-button">
     <slot name="ar-button">
-      <a id="default-ar-button" class="fab"
+      <a id="default-ar-button" part="default-ar-button" class="fab"
           tabindex="2"
           aria-label="View this 3D model up close">
         ${ARGlyph}

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -333,7 +333,7 @@ canvas.show {
 
     <div class="slot progress-bar">
       <slot name="progress-bar">
-        <div id="default-progress-bar" part="default-progress-bar" aria-hidden="true">
+        <div id="default-progress-bar" aria-hidden="true">
           <div class="mask"></div>
           <div class="bar"></div>
         </div>

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -306,7 +306,7 @@ canvas.show {
         will have their <slot> elements removed by ShadyCSS -->
   <div class="slot poster">
     <slot name="poster">
-      <button type="button" id="default-poster" aria-hidden="true" aria-label="Activate to view in 3D!"></button>
+      <button type="button" id="default-poster" part="default-poster" aria-hidden="true" aria-label="Activate to view in 3D!"></button>
     </slot>
   </div>
 
@@ -333,7 +333,7 @@ canvas.show {
 
     <div class="slot progress-bar">
       <slot name="progress-bar">
-        <div id="default-progress-bar" aria-hidden="true">
+        <div id="default-progress-bar" part="default-progress-bar" aria-hidden="true">
           <div class="mask"></div>
           <div class="bar"></div>
         </div>
@@ -343,6 +343,7 @@ canvas.show {
     <div class="slot exit-webxr-ar-button">
       <slot name="exit-webxr-ar-button">
         <a id="default-exit-webxr-ar-button"
+            part="default-exit-webxr-ar-button"
             tabindex="3"
             aria-label="Exit AR"
             aria-hidden="true">


### PR DESCRIPTION
For the viewer in https://www.hicetnunc.xyz/ we need to move the ar button to the left side.

Not sure if this is the best solution but with this change we'll be able to do this:

```css
model-viewer::part(default-ar-button) {
    left: 16px;
}
```

https://developer.mozilla.org/en-US/docs/Web/CSS/::part