### PR TITLE
Wait to generate roughness mipmaps until after clone

### DIFF
--- a/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
@@ -78,8 +78,6 @@ export class ModelViewerGLTFInstance extends GLTFInstance {
             transparent = true;
             material.side = FrontSide;
           }
-          Renderer.singleton.roughnessMipmapper.generateMipmaps(
-              material as MeshStandardMaterial);
         }
       });
 
@@ -244,6 +242,11 @@ export class ModelViewerGLTFInstance extends GLTFInstance {
     // with the glTF spec.
     if (!clone.alphaTest && !clone.transparent) {
       clone.alphaTest = -0.5;
+    }
+
+    if ((clone as any).isMeshStandardMaterial) {
+      Renderer.singleton.roughnessMipmapper.generateMipmaps(
+          clone as MeshStandardMaterial);
     }
 
     sourceUUIDToClonedMaterial.set(material.uuid, clone);


### PR DESCRIPTION
Some draco compressed models that share metalness and roughness maps resulted in errors cloning models because roughness mipmap generation state isn't properly duplicated. This changes fixes the issue by waiting to generate roughness mipmaps until after the clone has occured.
