### PR TITLE
hide rendering while new model loads

### DIFF
--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -235,12 +235,15 @@ export class ModelScene extends Scene {
 
     this.frameModel();
     this.setShadowIntensity(this.shadowIntensity);
-    this.isDirty = true;
     this.dispatchEvent({type: 'model-load', url: this.url});
   }
 
   reset() {
     this.url = null;
+    this.isDirty = true;
+    if (this.shadow != null) {
+      this.shadow.setIntensity(0);
+    }
     const gltf = this._currentGLTF;
     // Remove all current children
     if (gltf != null) {

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -17,7 +17,7 @@ import {ACESFilmicToneMapping, Event, EventDispatcher, GammaEncoding, PCFSoftSha
 import {RoughnessMipmapper} from 'three/examples/jsm/utils/RoughnessMipmapper';
 
 import {USE_OFFSCREEN_CANVAS} from '../constants.js';
-import {$canvas, $sceneIsReady, $tick, $updateSize, $userInputElement} from '../model-viewer-base.js';
+import {$canvas, $tick, $updateSize, $userInputElement} from '../model-viewer-base.js';
 import {clamp, isDebugMode, resolveDpr} from '../utilities.js';
 
 import {ARRenderer} from './ARRenderer.js';
@@ -390,10 +390,6 @@ export class Renderer extends EventDispatcher {
     const {dpr, scaleFactor} = this;
 
     for (const scene of this.orderedScenes()) {
-      if (!scene.element[$sceneIsReady]()) {
-        continue;
-      }
-
       this.preRender(scene, t, delta);
 
       if (!scene.isDirty) {


### PR DESCRIPTION
This fixes @AdrianAtGoogle's bug where the render would resize while changing models. The problem was that when you update the src, it said the model was no longer loaded and so skipped rendering entirely while the new model was loading. Sounds nice, except that also skips clearing the canvas. Then if the render loop slows down (because of loading stuff) it starts resizing the canvas, but never triggers a new render to match the size. I decided it makes more sense to just stop showing the old model entirely as soon as the src is changed; the state is simpler and it gives immediate visual feedback that something is happening. Now I go ahead and render a scene whenever it is dirty, regardless of whether it currently has a src, which means backgrounds and such will still render properly.

I'm not actually expecting all of you to review this, but figured I'd add you so you have a chance to see the process on Github. 