### PR TITLE
add external renderer support

### DIFF
--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -89,6 +89,22 @@ interface ToBlobOptions {
   mimeType?: string, qualityArgument?: number, idealAspect?: boolean
 }
 
+export interface FramingInfo {
+  framedRadius: number;
+  fieldOfViewAspect: number;
+}
+
+export interface Camera {
+  viewMatrix: Array<number>;
+  projectionMatrix: Array<number>;
+}
+
+export interface RendererInterface {
+  load(progressCallback: (progress: number) => void): Promise<FramingInfo>;
+  render(camera: Camera): void;
+  resize(width: number, height: number): void;
+}
+
 /**
  * Definition for a basic <model-viewer> element.
  */
@@ -249,20 +265,21 @@ export default class ModelViewerElementBase extends UpdatingElement {
     if (HAS_RESIZE_OBSERVER) {
       // Set up a resize observer so we can scale our canvas
       // if our <model-viewer> changes
-      this[$resizeObserver] = new ResizeObserver((entries) => {
-        // Don't resize anything if in AR mode; otherwise the canvas
-        // scaling to fullscreen on entering AR will clobber the flat/2d
-        // dimensions of the element.
-        if (this[$renderer].isPresenting) {
-          return;
-        }
+      this[$resizeObserver] =
+          new ResizeObserver((entries: Array<ResizeObserverEntry>) => {
+            // Don't resize anything if in AR mode; otherwise the canvas
+            // scaling to fullscreen on entering AR will clobber the flat/2d
+            // dimensions of the element.
+            if (this[$renderer].isPresenting) {
+              return;
+            }
 
-        for (let entry of entries) {
-          if (entry.target === this) {
-            this[$updateSize](entry.contentRect);
-          }
-        }
-      });
+            for (let entry of entries) {
+              if (entry.target === this) {
+                this[$updateSize](entry.contentRect);
+              }
+            }
+          });
     }
 
     if (HAS_INTERSECTION_OBSERVER) {
@@ -441,6 +458,14 @@ export default class ModelViewerElementBase extends UpdatingElement {
     } finally {
       this[$updateSize]({width, height});
     };
+  }
+
+  registerRenderer(renderer: RendererInterface) {
+    this[$scene].externalRenderer = renderer;
+  }
+
+  unregisterRenderer() {
+    this[$scene].externalRenderer = null;
   }
 
   get[$ariaLabel]() {

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -299,7 +299,11 @@ canvas.show {
   <div class="userInput" tabindex="0" role="img"
       aria-label="A depiction of a 3D model"
       aria-live="polite">
-    <canvas></canvas>
+      <div class="slot canvas">
+        <slot name="canvas">
+          <canvas></canvas>
+        </slot>
+      </div>
   </div>
 
   <!-- NOTE(cdata): We need to wrap slots because browsers without ShadowDOM

--- a/packages/model-viewer/src/test/three-components/Renderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/Renderer-spec.ts
@@ -15,7 +15,7 @@
 
 import {USE_OFFSCREEN_CANVAS} from '../../constants.js';
 import {LoadingMixin} from '../../features/loading.js';
-import ModelViewerElementBase, {$canvas, $intersectionObserver, $isElementInViewport, $onResize, $renderer, $scene, $userInputElement} from '../../model-viewer-base.js';
+import ModelViewerElementBase, {$intersectionObserver, $isElementInViewport, $onResize, $renderer, $scene} from '../../model-viewer-base.js';
 import {ModelScene} from '../../three-components/ModelScene.js';
 import {Renderer} from '../../three-components/Renderer.js';
 import {waitForEvent} from '../../utilities.js';
@@ -123,9 +123,9 @@ suite('Renderer', () => {
       expect(renderer.canvasElement.classList.contains('show'))
           .to.be.eq(
               false, 'webgl canvas should not be shown with multiple scenes.');
-      expect(scene.element[$canvas].classList.contains('show'))
+      expect(scene.canvas.classList.contains('show'))
           .to.be.eq(true, 'scene canvas should be shown with multiple scenes.');
-      expect(otherScene.element[$canvas].classList.contains('show'))
+      expect(otherScene.canvas.classList.contains('show'))
           .to.be.eq(
               true, 'otherScene canvas should be shown with multiple scenes.');
 
@@ -135,14 +135,13 @@ suite('Renderer', () => {
       if (USE_OFFSCREEN_CANVAS) {
         expect(renderer.canvasElement.classList.contains('show'))
             .to.be.eq(false);
-        expect(otherScene.element[$canvas].classList.contains('show'))
-            .to.be.eq(true);
+        expect(otherScene.canvas.classList.contains('show')).to.be.eq(true);
       } else {
         expect(renderer.canvasElement.parentElement)
-            .to.be.eq(otherScene.element[$userInputElement]);
+            .to.be.eq(otherScene.canvas.parentElement);
         expect(renderer.canvasElement.classList.contains('show'))
             .to.be.eq(true, 'webgl canvas should be shown with single scene.');
-        expect(otherScene.element[$canvas].classList.contains('show'))
+        expect(otherScene.canvas.classList.contains('show'))
             .to.be.eq(
                 false,
                 'otherScene canvas should not be shown when it is the only scene.');

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -15,7 +15,8 @@
 
 import {AnimationAction, AnimationClip, AnimationMixer, Box3, Camera, Event as ThreeEvent, Matrix3, Object3D, PerspectiveCamera, Raycaster, Scene, Vector2, Vector3} from 'three';
 import {USE_OFFSCREEN_CANVAS} from '../constants.js';
-import ModelViewerElementBase, {$renderer} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$renderer, RendererInterface} from '../model-viewer-base.js';
+import {resolveDpr} from '../utilities.js';
 import {Damper, SETTLING_TIME} from './Damper.js';
 import {ModelViewerGLTFInstance} from './gltf-instance/ModelViewerGLTFInstance.js';
 import {Hotspot} from './Hotspot.js';
@@ -69,6 +70,7 @@ export class ModelScene extends Scene {
   public aspect = 1;
   public isDirty = false;
   public renderCount = 0;
+  public externalRenderer: RendererInterface|null = null;
 
   public activeCamera: Camera;
   // These default camera values are never used, as they are reset once the
@@ -159,15 +161,25 @@ export class ModelScene extends Scene {
    */
 
   async setSource(
-      url: string|null, progressCallback?: (progress: number) => void) {
+      url: string|null,
+      progressCallback: (progress: number) => void = () => {}) {
     if (!url || url === this.url) {
-      if (progressCallback) {
-        progressCallback(1);
-      }
+      progressCallback(1);
       return;
     }
     this.reset();
     this.url = url;
+
+    if (this.externalRenderer != null) {
+      const framingInfo = await this.externalRenderer.load(progressCallback);
+
+      this.idealCameraDistance = framingInfo.framedRadius / SAFE_RADIUS_RATIO;
+      this.fieldOfViewAspect = framingInfo.fieldOfViewAspect;
+      this.frameModel();
+
+      this.dispatchEvent({type: 'model-load', url: this.url});
+      return;
+    }
 
     // If we have pending work due to a previous source change in progress,
     // cancel it so that we do not incur a race condition:
@@ -279,6 +291,11 @@ export class ModelScene extends Scene {
 
     this.aspect = this.width / this.height;
     this.frameModel();
+
+    if (this.externalRenderer != null) {
+      const dpr = resolveDpr();
+      this.externalRenderer.resize(width * dpr, height * dpr);
+    }
 
     this.isDirty = true;
   }


### PR DESCRIPTION
This is experimental, for using model-viewer to control an external renderer instead of using Three.js. This removes any dependence on glTF and even allows non-model-based experiences (e.g. generative systems, etc). Of course the model-dependent parts of our API will also cease to function in this situation.