### PR TITLE
Fix hotspots

### DIFF
--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -66,18 +66,6 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
     };
     private[$observer] = new MutationObserver(this[$mutationCallback]);
 
-    constructor(...args: Array<any>) {
-      super(...args);
-
-      const {domElement} = this[$scene].annotationRenderer;
-      const {style} = domElement;
-      style.display = 'none';
-      style.pointerEvents = 'none';
-      style.position = 'absolute';
-      style.top = '0';
-      this.shadowRoot!.querySelector('.default')!.appendChild(domElement);
-    }
-
     connectedCallback() {
       super.connectedCallback();
 
@@ -174,10 +162,6 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
         });
         this[$hotspotMap].set(node.slot, hotspot);
         this[$scene].addHotspot(hotspot);
-        // This happens automatically in render(), but we do it early so that
-        // the slots appear in the shadow DOM and the elements get attached,
-        // allowing us to dispatch events on them.
-        this[$scene].annotationRenderer.domElement.appendChild(hotspot.element);
       }
       this[$scene].isDirty = true;
     }

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -15,13 +15,11 @@
  */
 
 import {Matrix3, Matrix4, Vector2} from 'three';
-import {CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
-import ModelViewerElementBase, {$needsRender, $onResize, $scene, $tick, toVector3D, Vector3D} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$needsRender, $scene, toVector3D, Vector3D} from '../model-viewer-base.js';
 import {Hotspot, HotspotConfiguration} from '../three-components/Hotspot.js';
 import {Constructor} from '../utilities.js';
 
-const $annotationRenderer = Symbol('annotationRenderer');
 const $hotspotMap = Symbol('hotspotMap');
 const $mutationCallback = Symbol('mutationCallback');
 const $observer = Symbol('observer');
@@ -49,7 +47,6 @@ export declare interface AnnotationInterface {
 export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
     ModelViewerElement: T): Constructor<AnnotationInterface>&T => {
   class AnnotationModelViewerElement extends ModelViewerElement {
-    private[$annotationRenderer] = new CSS2DRenderer();
     private[$hotspotMap] = new Map<string, Hotspot>();
     private[$mutationCallback] = (mutations: Array<unknown>) => {
       mutations.forEach((mutation) => {
@@ -72,7 +69,7 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
     constructor(...args: Array<any>) {
       super(...args);
 
-      const {domElement} = this[$annotationRenderer];
+      const {domElement} = this[$scene].annotationRenderer;
       const {style} = domElement;
       style.display = 'none';
       style.pointerEvents = 'none';
@@ -159,23 +156,6 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       return {position: position, normal: normal};
     }
 
-    [$tick](time: number, delta: number) {
-      super[$tick](time, delta);
-      const scene = this[$scene];
-      const camera = scene.camera;
-
-      if (scene.isDirty) {
-        scene.updateHotspots(camera.position);
-        this[$annotationRenderer].domElement.style.display = '';
-        this[$annotationRenderer].render(scene, camera);
-      }
-    }
-
-    [$onResize](e: {width: number, height: number}) {
-      super[$onResize](e);
-      this[$annotationRenderer].setSize(e.width, e.height);
-    }
-
     private[$addHotspot](node: Node) {
       if (!(node instanceof HTMLElement &&
             node.slot.indexOf('hotspot') === 0)) {
@@ -197,7 +177,7 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
         // This happens automatically in render(), but we do it early so that
         // the slots appear in the shadow DOM and the elements get attached,
         // allowing us to dispatch events on them.
-        this[$annotationRenderer].domElement.appendChild(hotspot.element);
+        this[$scene].annotationRenderer.domElement.appendChild(hotspot.element);
       }
       this[$scene].isDirty = true;
     }

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -162,7 +162,7 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
     [$tick](time: number, delta: number) {
       super[$tick](time, delta);
       const scene = this[$scene];
-      const camera = scene.getCamera();
+      const camera = scene.camera;
 
       if (scene.isDirty) {
         scene.updateHotspots(camera.position);

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -143,7 +143,7 @@ suite('ModelViewerElementBase with AnnotationMixin', () => {
           const hotspotObject2D =
               scene.target.children[numSlots - 1] as Hotspot;
 
-          const camera = element[$scene].getCamera();
+          const camera = element[$scene].camera;
           camera.position.z = 2;
           camera.updateMatrixWorld();
           element[$needsRender]();
@@ -195,7 +195,7 @@ suite('ModelViewerElementBase with AnnotationMixin', () => {
       element.setAttribute('style', `width: ${width}px; height: ${height}px`);
       element.src = assetPath('models/cube.gltf');
 
-      const camera = element[$scene].getCamera();
+      const camera = element[$scene].camera;
       camera.position.z = 2;
       camera.updateMatrixWorld();
       await waitForEvent(element, 'load');

--- a/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
@@ -233,7 +233,7 @@ suite('ARRenderer', () => {
       });
 
       test('restores original camera', () => {
-        expect(modelScene.getCamera()).to.be.equal(modelScene.camera);
+        expect(modelScene.camera).to.be.equal(modelScene.camera);
       });
 
       test('restores scene size', () => {

--- a/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
@@ -249,12 +249,11 @@ suite('ARRenderer', () => {
       let yaw: number;
 
       setup(async () => {
-        await arRenderer.present(modelScene);
         arRenderer.onWebXRFrame(0, new MockXRFrame(arRenderer.currentSession!));
         yaw = modelScene.yaw;
       });
 
-      test('places the model oriented to the camera', () => {
+      test.only('places the model oriented to the camera', () => {
         const epsilon = 0.0001;
         const {target, position} = modelScene;
 

--- a/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
@@ -253,7 +253,7 @@ suite('ARRenderer', () => {
         yaw = modelScene.yaw;
       });
 
-      test.only('places the model oriented to the camera', () => {
+      test('places the model oriented to the camera', () => {
         const epsilon = 0.0001;
         const {target, position} = modelScene;
 

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -374,7 +374,12 @@ export class ARRenderer extends EventDispatcher {
     this.cameraPosition.set(viewMatrix[12], viewMatrix[13], viewMatrix[14]);
 
     if (!this.initialized) {
-      const {position, element} = scene;
+      const {position, element, camera} = scene;
+
+      camera.projectionMatrix.copy(
+          this.threeRenderer.xr.getCamera(camera).projectionMatrix);
+      camera.projectionMatrixInverse.copy(camera.projectionMatrix).invert();
+
       const {theta, radius} =
           (element as ModelViewerElementBase & ControlsInterface)
               .getCameraOrbit();
@@ -646,11 +651,6 @@ export class ARRenderer extends EventDispatcher {
       this.threeRenderer.clear();
       return;
     }
-
-    scene.camera.projectionMatrix.copy(
-        this.threeRenderer.xr.getCamera(scene.camera).projectionMatrix);
-    scene.camera.projectionMatrixInverse.copy(scene.camera.projectionMatrix)
-        .invert();
 
     // WebXR may return multiple views, i.e. for headset AR. This
     // isn't really supported at this point, but make a best-effort

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -647,6 +647,11 @@ export class ARRenderer extends EventDispatcher {
       return;
     }
 
+    scene.camera.projectionMatrix.copy(
+        this.threeRenderer.xr.getCamera(scene.camera).projectionMatrix);
+    scene.camera.projectionMatrixInverse.copy(scene.camera.projectionMatrix)
+        .invert();
+
     // WebXR may return multiple views, i.e. for headset AR. This
     // isn't really supported at this point, but make a best-effort
     // attempt to render other views also, using the first view

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -291,7 +291,6 @@ export class ARRenderer extends EventDispatcher {
     const scene = this.presentedScene;
     if (scene != null) {
       const {element} = scene;
-      scene.setCamera(scene.camera);
 
       scene.position.set(0, 0, 0);
       scene.scale.set(1, 1, 1);

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -111,10 +111,8 @@ export class ARRenderer extends EventDispatcher {
     this.threeRenderer.xr.enabled = true;
   }
 
-  async resolveARSession(scene: ModelScene): Promise<XRSession> {
+  async resolveARSession(): Promise<XRSession> {
     assertIsArCandidate();
-
-    this.overlay = scene.element.shadowRoot!.querySelector('div.default');
 
     const session: XRSession =
         await navigator.xr!.requestSession!('immersive-ar', {
@@ -169,8 +167,9 @@ export class ARRenderer extends EventDispatcher {
 
     // This sets isPresenting to true
     this._presentedScene = scene;
+    this.overlay = scene.element.shadowRoot!.querySelector('div.default');
 
-    const currentSession = await this.resolveARSession(scene);
+    const currentSession = await this.resolveARSession();
 
     currentSession.addEventListener('end', () => {
       this.postSessionCleanup();

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -381,9 +381,11 @@ export class ARRenderer extends EventDispatcher {
       const {width, height} = this.overlay!.getBoundingClientRect();
       scene.setSize(width, height);
 
-      this.projectionMatrix.copy(
-          this.threeRenderer.xr.getCamera(camera).projectionMatrix);
-      this.projectionMatrixInverse.copy(this.projectionMatrix).invert();
+      if (this.threeRenderer.xr.getSession() != null) {
+        this.projectionMatrix.copy(
+            this.threeRenderer.xr.getCamera(camera).projectionMatrix);
+        this.projectionMatrixInverse.copy(this.projectionMatrix).invert();
+      }
 
       const {theta, radius} =
           (element as ModelViewerElementBase & ControlsInterface)

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -14,6 +14,7 @@
  */
 
 import {AnimationAction, AnimationClip, AnimationMixer, Box3, Event as ThreeEvent, Matrix3, Object3D, PerspectiveCamera, Raycaster, Scene, Vector2, Vector3} from 'three';
+import {CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer';
 import {USE_OFFSCREEN_CANVAS} from '../constants.js';
 import ModelViewerElementBase, {$renderer} from '../model-viewer-base.js';
 import {Damper, SETTLING_TIME} from './Damper.js';
@@ -64,6 +65,7 @@ export class ModelScene extends Scene {
   public canvas: HTMLCanvasElement;
   public context: CanvasRenderingContext2D|ImageBitmapRenderingContext|null =
       null;
+  public annotationRenderer = new CSS2DRenderer();
   public width = 1;
   public height = 1;
   public aspect = 1;
@@ -273,6 +275,7 @@ export class ModelScene extends Scene {
     }
     this.width = Math.max(width, 1);
     this.height = Math.max(height, 1);
+    this.annotationRenderer.setSize(width, height);
 
     this.aspect = this.width / this.height;
     this.frameModel();
@@ -676,5 +679,15 @@ export class ModelScene extends Scene {
     this.forHotspots((hotspot) => {
       hotspot.visible = visible;
     });
+  }
+
+  postRender() {
+    const {camera} = this;
+
+    if (this.isDirty) {
+      this.updateHotspots(camera.position);
+      this.annotationRenderer.domElement.style.display = '';
+      this.annotationRenderer.render(this, camera);
+    }
   }
 }

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -127,6 +127,14 @@ export class ModelScene extends Scene {
 
     this.target.add(this.modelContainer);
     this.mixer = new AnimationMixer(this.modelContainer);
+
+    const {domElement} = this.annotationRenderer;
+    const {style} = domElement;
+    style.display = 'none';
+    style.pointerEvents = 'none';
+    style.position = 'absolute';
+    style.top = '0';
+    this.element.shadowRoot!.querySelector('.default')!.appendChild(domElement);
   }
 
   /**
@@ -623,6 +631,10 @@ export class ModelScene extends Scene {
    */
   addHotspot(hotspot: Hotspot) {
     this.target.add(hotspot);
+    // This happens automatically in render(), but we do it early so that
+    // the slots appear in the shadow DOM and the elements get attached,
+    // allowing us to dispatch events on them.
+    this.annotationRenderer.domElement.appendChild(hotspot.element);
   }
 
   removeHotspot(hotspot: Hotspot) {

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {AnimationAction, AnimationClip, AnimationMixer, Box3, Camera, Event as ThreeEvent, Matrix3, Object3D, PerspectiveCamera, Raycaster, Scene, Vector2, Vector3} from 'three';
+import {AnimationAction, AnimationClip, AnimationMixer, Box3, Event as ThreeEvent, Matrix3, Object3D, PerspectiveCamera, Raycaster, Scene, Vector2, Vector3} from 'three';
 import {USE_OFFSCREEN_CANVAS} from '../constants.js';
 import ModelViewerElementBase, {$renderer} from '../model-viewer-base.js';
 import {Damper, SETTLING_TIME} from './Damper.js';
@@ -70,7 +70,6 @@ export class ModelScene extends Scene {
   public isDirty = false;
   public renderCount = 0;
 
-  public activeCamera: Camera;
   // These default camera values are never used, as they are reset once the
   // model is loaded and framing is computed.
   public camera = new PerspectiveCamera(45, 1, 0.1, 100);
@@ -116,8 +115,6 @@ export class ModelScene extends Scene {
     // model is loaded and framing is computed.
     this.camera = new PerspectiveCamera(45, 1, 0.1, 100);
     this.camera.name = 'MainCamera';
-
-    this.activeCamera = this.camera;
 
     this.add(this.target);
 
@@ -349,20 +346,6 @@ export class ModelScene extends Scene {
    */
   getSize(): {width: number, height: number} {
     return {width: this.width, height: this.height};
-  }
-
-  /**
-   * Returns the current camera.
-   */
-  getCamera(): Camera {
-    return this.activeCamera;
-  }
-
-  /**
-   * Sets the passed in camera to be used for rendering.
-   */
-  setCamera(camera: Camera) {
-    this.activeCamera = camera;
   }
 
   /**
@@ -612,7 +595,7 @@ export class ModelScene extends Scene {
    */
   positionAndNormalFromPoint(pixelPosition: Vector2, object: Object3D = this):
       {position: Vector3, normal: Vector3}|null {
-    raycaster.setFromCamera(pixelPosition, this.getCamera());
+    raycaster.setFromCamera(pixelPosition, this.camera);
     const hits = raycaster.intersectObject(object, true);
 
     if (hits.length === 0) {

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -374,6 +374,7 @@ export class Renderer extends EventDispatcher {
   render(t: number, frame?: XRFrame) {
     if (frame != null) {
       this.arRenderer.onWebXRFrame(t, frame);
+      this.arRenderer.presentedScene!.postRender();
       return;
     }
 
@@ -401,7 +402,6 @@ export class Renderer extends EventDispatcher {
       if (!scene.isDirty) {
         continue;
       }
-      scene.isDirty = false;
       ++scene.renderCount;
 
       if (!scene.element.modelIsVisible && !this.multipleScenesVisible) {
@@ -428,6 +428,8 @@ export class Renderer extends EventDispatcher {
           0, Math.floor(this.height * dpr) - height, width, height);
       this.threeRenderer.render(scene, scene.camera);
 
+      scene.postRender();
+
       if (this.multipleScenesVisible) {
         if (scene.context == null) {
           scene.createContext();
@@ -444,6 +446,8 @@ export class Renderer extends EventDispatcher {
               this.canvas3D, 0, 0, width, height, 0, 0, width, height);
         }
       }
+
+      scene.isDirty = false;
     }
   }
 

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -426,7 +426,7 @@ export class Renderer extends EventDispatcher {
       this.threeRenderer.setRenderTarget(null);
       this.threeRenderer.setViewport(
           0, Math.floor(this.height * dpr) - height, width, height);
-      this.threeRenderer.render(scene, scene.getCamera());
+      this.threeRenderer.render(scene, scene.camera);
 
       if (this.multipleScenesVisible) {
         if (scene.context == null) {


### PR DESCRIPTION
It turns out #2279 broke both hotspot placement and raycast placement in WebXR, which is fixed here. It was broken somewhat subtly because of the way XRManager handles camera updates. Before our animation frame is called, WebXR updates the internal `cameraVR`, which is great. However, upon calling `threeRenderer.render(scene, camera)` the camera I pass in gets updated to the view matrix of cameraVR, but not the projection matrix. Since I'm using my camera for other activities that happen before render time (like raycasting and CSS2D rendering), this has the effect of making my camera delayed by a frame and also have the wrong projection matrix. I worked around this by moving my CSS2D rendering to after the 3D render call, but I still had to call `xr.getCamera()` once, which feels like a hack. @mrdoob I think we need to work on XRManager a bit.