### PR TITLE
improved examples CSS

### DIFF
--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -366,7 +366,7 @@
             </div>
             <example-snippet stamp-to="transparentBackground" highlight-as="html">
               <template>
-<div class="background-demo" style="background: linear-gradient(#ffffff, #ada996); overflow-x: hidden;">
+<div class="demo" style="background: linear-gradient(#ffffff, #ada996); overflow-x: hidden;">
   <span style="position: absolute; text-align: center; font-size: 100px; top:50%;">Background</span>
   <model-viewer camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/AlphaBlendModeTest/glTF-Binary/AlphaBlendModeTest.glb" alt="A 3D transparency test" style="background-color: unset;"></model-viewer>
 </div>

--- a/packages/modelviewer.dev/styles/examples.css
+++ b/packages/modelviewer.dev/styles/examples.css
@@ -371,18 +371,6 @@ model-viewer:focus {
   box-sizing: border-box;
 }
 
-.background-demo {
-  grid-area: demo;
-  position: sticky;
-  top: 0;
-  height: 90vh;
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  border: 0px solid #555;
-  box-sizing: border-box;
-}
-
 .examples-container > .sample > .demo {
   height: 100vh;
 }
@@ -760,18 +748,6 @@ paper-button {
     margin-left: 0;
     visibility: visible;
   }
-
-  .background-demo {
-    grid-area: demo;
-    position: sticky;
-    top: 0;
-    height: 100vh;
-    flex: 1;
-    display: flex;
-    justify-content: center;
-    border: 0px solid #555;
-    box-sizing: border-box;
-  }
   
   .examples-container > .sample > #demo-container-1 {
     margin-top: 75px;
@@ -780,7 +756,7 @@ paper-button {
   
   .examples-container > .sample > .demo {
     top: 0;
-    height: 90vh;
+    height: 150vw;
   }
 
   body {
@@ -847,7 +823,6 @@ paper-button {
   }
   .demo {
     position: relative;
-    height: 76vh;
     flex-direction: column-reverse;
     background-color: #455A64;
   }


### PR DESCRIPTION
Fixes #1830 

I believe the problem was a bunch of rapid element resizing due to the element's size being dependent on vh, which changes as the URL bar scrolls in and out of sight. At fixed aspect ratio, it seems to be much happier. I also found a small error in the background example which was solved by simplifying the CSS.