### PR TITLE
added two-finger rotation for WebXR

### DIFF
--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -509,7 +509,7 @@ export class ARRenderer extends EventDispatcher {
         this.lastDragPosition.copy(hitPosition);
       } else if (this.placeOnWall === false) {
         this.isRotating = true;
-        this.lastAngle = axes[0];
+        this.lastAngle = axes[0] * ROTATION_RATE;
       }
     } else if (fingers.length === 2) {
       box.show = true;
@@ -590,9 +590,9 @@ export class ARRenderer extends EventDispatcher {
     }
 
     if (this.isRotating) {
-      const thisDragX = this.inputSource!.gamepad.axes[0];
-      this.goalYaw += (thisDragX - this.lastAngle) * ROTATION_RATE;
-      this.lastAngle = thisDragX;
+      const angle = this.inputSource!.gamepad.axes[0] * ROTATION_RATE;
+      this.goalYaw += angle - this.lastAngle;
+      this.lastAngle = angle;
     } else if (this.isTranslating) {
       fingers.forEach(finger => {
         if (finger.inputSource !== this.inputSource ||

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -91,9 +91,10 @@ export class ARRenderer extends EventDispatcher {
   private placementComplete = false;
   private isTranslating = false;
   private isRotating = false;
-  private isScaling = false;
+  private isTwoFingering = false;
   private lastDragPosition = new Vector3();
-  private lastScalar = 0;
+  private firstRatio = 0;
+  private lastAngle = 0;
   private goalPosition = new Vector3();
   private goalYaw = 0;
   private goalScale = 1;
@@ -508,31 +509,44 @@ export class ARRenderer extends EventDispatcher {
         this.lastDragPosition.copy(hitPosition);
       } else if (this.placeOnWall === false) {
         this.isRotating = true;
-        this.lastScalar = axes[0];
+        this.lastAngle = axes[0];
       }
-    } else if (fingers.length === 2 && scene.canScale) {
+    } else if (fingers.length === 2) {
       box.show = true;
-      this.isScaling = true;
-      this.lastScalar = this.fingerSeparation(fingers) / scene.scale.x;
+      this.isTwoFingering = true;
+      const {separation} = this.fingerPolar(fingers);
+      this.firstRatio = separation / scene.scale.x;
     }
   };
 
   private onSelectEnd = () => {
     this.isTranslating = false;
     this.isRotating = false;
-    this.isScaling = false;
+    this.isTwoFingering = false;
     this.inputSource = null;
     this.goalPosition.y +=
         this.placementBox!.offsetHeight * this.presentedScene!.scale.x;
     this.placementBox!.show = false
   };
 
-  private fingerSeparation(fingers: XRTransientInputHitTestResult[]): number {
+  private fingerPolar(fingers: XRTransientInputHitTestResult[]):
+      {separation: number, deltaYaw: number} {
     const fingerOne = fingers[0].inputSource.gamepad.axes;
     const fingerTwo = fingers[1].inputSource.gamepad.axes;
     const deltaX = fingerTwo[0] - fingerOne[0];
     const deltaY = fingerTwo[1] - fingerOne[1];
-    return Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+    const angle = Math.atan2(deltaY, deltaX);
+    let deltaYaw = this.lastAngle - angle;
+    if (deltaYaw > Math.PI) {
+      deltaYaw -= 2 * Math.PI;
+    } else if (deltaYaw < -Math.PI) {
+      deltaYaw += 2 * Math.PI;
+    }
+    this.lastAngle = angle;
+    return {
+      separation: Math.sqrt(deltaX * deltaX + deltaY * deltaY),
+      deltaYaw: deltaYaw
+    };
   }
 
   private processInput(frame: XRFrame) {
@@ -540,7 +554,7 @@ export class ARRenderer extends EventDispatcher {
     if (hitSource == null) {
       return;
     }
-    if (!this.isTranslating && !this.isScaling && !this.isRotating) {
+    if (!this.isTranslating && !this.isTwoFingering && !this.isRotating) {
       return;
     }
     const fingers = frame.getHitTestResultsForTransientInput(hitSource);
@@ -549,32 +563,36 @@ export class ARRenderer extends EventDispatcher {
 
     // Rotating, translating and scaling are mutually exclusive operations; only
     // one can happen at a time, but we can switch during a gesture.
-    if (this.isScaling) {
+    if (this.isTwoFingering) {
       if (fingers.length < 2) {
         // If we lose the second finger, stop scaling (in fact, stop processing
         // input altogether until a new gesture starts).
-        this.isScaling = false;
+        this.isTwoFingering = false;
       } else {
-        const separation = this.fingerSeparation(fingers);
-        const scale = separation / this.lastScalar;
-        this.goalScale =
-            (scale < SCALE_SNAP_HIGH && scale > SCALE_SNAP_LOW) ? 1 : scale;
+        const {separation, deltaYaw} = this.fingerPolar(fingers);
+        this.goalYaw += deltaYaw;
+        if (scene.canScale) {
+          const scale = separation / this.firstRatio;
+          this.goalScale =
+              (scale < SCALE_SNAP_HIGH && scale > SCALE_SNAP_LOW) ? 1 : scale;
+        }
       }
       return;
-    } else if (fingers.length === 2 && scene.canScale) {
+    } else if (fingers.length === 2) {
       // If we were rotating or translating and we get a second finger, switch
       // to scaling instead.
       this.isTranslating = false;
       this.isRotating = false;
-      this.isScaling = true;
-      this.lastScalar = this.fingerSeparation(fingers) / scale;
+      this.isTwoFingering = true;
+      const {separation} = this.fingerPolar(fingers);
+      this.firstRatio = separation / scale;
       return;
     }
 
     if (this.isRotating) {
       const thisDragX = this.inputSource!.gamepad.axes[0];
-      this.goalYaw += (thisDragX - this.lastScalar) * ROTATION_RATE;
-      this.lastScalar = thisDragX;
+      this.goalYaw += (thisDragX - this.lastAngle) * ROTATION_RATE;
+      this.lastAngle = thisDragX;
     } else if (this.isTranslating) {
       fingers.forEach(finger => {
         if (finger.inputSource !== this.inputSource ||

--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -254,7 +254,7 @@
           </div>
           <example-snippet stamp-to="ar" highlight-as="html">
             <template>
-<model-viewer src="../../shared-assets/models/Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" ar-scale="auto" camera-controls alt="A 3D model of an astronaut" skybox-image="../../shared-assets/environments/aircraft_workshop_01_1k.hdr" ios-src="../../shared-assets/models/Astronaut.usdz"></model-viewer>
+<model-viewer src="../../shared-assets/models/Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" camera-controls alt="A 3D model of an astronaut" skybox-image="../../shared-assets/environments/aircraft_workshop_01_1k.hdr" ios-src="../../shared-assets/models/Astronaut.usdz"></model-viewer>
             </template>
           </example-snippet>
 
@@ -272,7 +272,7 @@
           </div>
           <example-snippet stamp-to="sceneViewer" highlight-as="html">
             <template>
-<model-viewer id="model-viewer" src="../../shared-assets/models/Astronaut.glb" ar ar-modes="scene-viewer webxr" ar-scale="auto" camera-controls alt="A 3D model of an astronaut" skybox-image="../../shared-assets/environments/aircraft_workshop_01_1k.hdr">
+<model-viewer id="model-viewer" src="../../shared-assets/models/Astronaut.glb" ar ar-modes="scene-viewer webxr" camera-controls alt="A 3D model of an astronaut" skybox-image="../../shared-assets/environments/aircraft_workshop_01_1k.hdr">
   <div id="error" class="hide">AR is not supported on this device</div>
 </model-viewer>
 <script>


### PR DESCRIPTION
Fixes #2180 
Fixes #1270 (sort of; that issue has multiple things and some have to be external HTML)

This should help especially for large models or models you're inside of. Now that AR mode starts from the same camera position as 3D mode, if you've set the user up inside of the model, that will work in AR too, and rotation will be possible with two fingers (since you can't find a one-finger spot outside of the bounding box).