### PR TITLE
add ar-tracking attribute

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -118,6 +118,8 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
             new CustomEvent<ARStatusDetails>('ar-status', {detail: {status}}));
         if (status === ARStatus.NOT_PRESENTING) {
           this.removeAttribute('ar-tracking');
+        } else if (status === ARStatus.SESSION_STARTED) {
+          this.setAttribute('ar-tracking', ARTracking.TRACKING);
         }
       }
     };

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -330,6 +330,18 @@
         "links": [
           "<a href=\"../examples/augmentedreality/#webXR\"><span class='attribute'>ar-status</span> example</a>"
         ]
+      },
+      {
+        "name": "ar-tracking",
+        "htmlName": "arTracking",
+        "description": "This read-only attribute enables DOM content to be styled based on the state of the WebXR AR tracking. For instance, a failure message can be shown by scoping a CSS rule to model-viewer[ar-tracking=\"not-tracking\"]. Setting this attribute has no effect. Most AR tracking failures are due to the camera being covered or seeing little discernable texture",
+        "default": {
+          "default": "N/A",
+          "options": "tracking, not-tracking"
+        },
+        "links": [
+          "<a href=\"../examples/augmentedreality/#webXR\"><span class='attribute'>ar-tracking</span> example</a>"
+        ]
       }
     ],
     "Methods": [
@@ -346,6 +358,14 @@
         "description": "Fired when the <span class='attribute'>ar-status</span> attribute above changes. The event.detail.status property will be set to the same value as the <span class='attribute'>ar-status</span> attribute, either 'not-presenting', 'session-started', 'object-placed', or 'failed'. This event is only enabled for WebXR AR sessions, with the exception of 'failed', which will be fired any time AR was initiated but failed to start all of the given modes.",
         "links": [
           "<a href=\"../examples/augmentedreality/#sceneViewer\"><span class='attribute'>ar-status</span> example</a>"
+        ]
+      },
+      {
+        "name": "ar-tracking",
+        "htmlName": "arTracking",
+        "description": "Fired when the <span class='attribute'>ar-tracking</span> attribute above changes. The event.detail.status property will be set to the same value as the <span class='attribute'>ar-tracking</span> attribute, either 'tracking', or 'not-tracking'. This event is only enabled for WebXR AR sessions.",
+        "links": [
+          "<a href=\"../examples/augmentedreality/#sceneViewer\"><span class='attribute'>ar-tracking</span> example</a>"
         ]
       },
       {

--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -85,6 +85,10 @@
     <img src="../../assets/hand.png">
   </div>
 
+  <button id="ar-failure">
+    AR is not tracking!
+  </button>
+
   <div class="slider">
     <div class="slides">
       <button class="slide selected" onclick="switchSrc(this, 'Chair')"
@@ -192,6 +196,18 @@
 
   model-viewer > #ar-prompt > img {
     animation: circle 4s linear infinite;
+  }
+
+  model-viewer > #ar-failure {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 175px;
+    display: none;
+  }
+
+  model-viewer[ar-tracking="not-tracking"] > #ar-failure {
+    display: block;
   }
 
   .slider {


### PR DESCRIPTION
Fixes #2340 

Description in the docs. Also fixes the bug where session-started was happening later than the start of the session. Not-tracking is only posted if it's true after the first 30 XR frames have passed (about 1 second), to give ARCore a chance.