### PR TITLE
simplified USDZ and added docs

### DIFF
--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -72,6 +72,12 @@
               SceneViewer or QuickLook, as these are native apps. Only through WebXR, now our default AR mode, can this be
               achieved, as the AR session is still inside of the browser. This also removes the need to redownload the model.
             </p>
+            <p>
+              Note that by specifically including <code>quick-look</code> in
+              <code>ar-modes</code>, but not specifying an <code>ios-src</code>,
+              the USDZ will instead be auto-generated when the user clicks the
+              AR button on iOS to launch Quick Look. 
+            </p>
           </div>
           <example-snippet stamp-to="webXR" highlight-as="html">
             <template>
@@ -269,7 +275,7 @@
             <h4>This demonstrates several augmented reality modes, including
             <code>webxr</code>, <code>scene-viewer</code>,
             <code>quick-look</code> &amp; the accompanying attributes,
-            <code>ar</code>, <code>ar-modes</code>, <code>ar-scale</code>,
+            <code>ar</code>, <code>ar-scale</code>,
             <code>ios-src</code>.</h4>
             <p>
               Note that WebXR mode requires the page be served on HTTPS and if
@@ -277,10 +283,18 @@
               <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/xr-spatial-tracking">
                 <code>xr-spatial-tracking</code></a> policy.
             </p>
+            <p>
+              In this example an <code>ios-src</code> attribute is specified,
+              which enables Quick Look on iOS even if it is not specified in
+              <code>ar-modes</code>. This requires an extra download, but can be
+              useful if the auto-generated USDZ is not adequate (for instance it
+              does not support animations yet). Also, this source can be either
+              a .usdz or a .reality file.
+            </p>
           </div>
           <example-snippet stamp-to="ar" highlight-as="html">
             <template>
-<model-viewer src="../../shared-assets/models/Astronaut.glb" ar ar-scale="fixed" ar-modes="webxr scene-viewer quick-look" camera-controls alt="A 3D model of an astronaut" skybox-image="../../shared-assets/environments/aircraft_workshop_01_1k.hdr" ios-src="../../shared-assets/models/Astronaut.usdz"></model-viewer>
+<model-viewer src="../../shared-assets/models/Astronaut.glb" ar ar-scale="fixed" camera-controls alt="A 3D model of an astronaut" skybox-image="../../shared-assets/environments/aircraft_workshop_01_1k.hdr" ios-src="../../shared-assets/models/Astronaut.usdz"></model-viewer>
             </template>
           </example-snippet>
 

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -121,6 +121,13 @@ select.addEventListener('input', (event) => {
             called. Also, the <code>bounds</code> attribute is set to
             <code>"tight"</code> to keep the transformed model from floating
             over its shadow.</p>
+            <p>Note that these changes can be made in AR as well, but only in
+            WebXR mode, as this is the only mode that remains in the browser.
+            Changes you made ahead of time will not be reflected in Scene
+            Viewer, since this app downloads the original model again from its
+            URL. iOS Quick Look will reflect your changes as long as
+            <code>ios-src</code> is not specified, since in this case a USDZ
+            will be generated on the fly from the current state.</p>
           </div>
           <example-snippet stamp-to="transforms" highlight-as="html">
             <template>
@@ -191,7 +198,11 @@ z.addEventListener('input', () => {
           <h4 id="intro"><span class="font-medium">Directly manipulate the scene graph</h4>
           <div class="heading">
             <h2 class="demo-title">Change Material Base Color</h2>
-            <p>This is an experimental feature, and the API is considered highly unstable. Please try it out, but be prepared for it to change!</p>
+            <p>This is an experimental feature, and the API is considered highly
+            unstable. Please try it out, but be prepared for it to change!</p>
+            <p>As above, you can change these values in AR, but only in WebXR
+            mode. iOS Quick Look does not reflect these color changes as USDZ
+            does not appear to support colors multiplied onto textures.</p>
           </div>
           <example-snippet stamp-to="changeColor" highlight-as="html">
             <template>
@@ -233,6 +244,9 @@ document.querySelector('#color-controls').addEventListener('click', (event) => {
         <div class="wrapper">
           <div class="heading">
             <h2 class="demo-title">Change Material Metalness and Roughness Factors</h2>
+            <p>As above, you can change these values in AR, but only in WebXR
+            mode. iOS Quick Look does reflect these property changes since they
+            are not also textured.</p>
           </div>
           <example-snippet stamp-to="changeMaterial" highlight-as="html">
             <template>
@@ -287,6 +301,9 @@ modelViewerParameters.addEventListener("load", (ev) => {
         <div class="wrapper">
           <div class="heading">
             <h2 class="demo-title">Swap textures - Diffuse/MetallicRoughness</h2>
+            <p>As above, you can change these values in AR, but only in WebXR
+            mode. iOS Quick Look reflects these texture changes so long as the
+            USDZ is auto-generated.</p>
           </div>
           <example-snippet stamp-to="swapTextures" highlight-as="html">
             <template>
@@ -343,6 +360,9 @@ modelViewerTexture.addEventListener("load", (ev) => {
         <div class="wrapper">
           <div class="heading">
             <h2 class="demo-title">Swap textures - Normals/Occlusion/Emission</h2>
+            <p>As above, you can change these values in AR, but only in WebXR
+              mode. iOS Quick Look reflects these texture changes so long as the
+              USDZ is auto-generated.</p>
           </div>
           <example-snippet stamp-to="swapTextures2" highlight-as="html">
             <template>


### PR DESCRIPTION
@kolodi A slight simplification of #2374 in order to release the USDZ memory earlier. Also added info about `ios-src` and how auto-generation interacts with the scene-graph API. 