### PR TITLE
fixed transform duplication issue

### DIFF
--- a/packages/model-viewer/src/test/three-components/gltf-instance/ModelViewerGLTFInstance-spec.ts
+++ b/packages/model-viewer/src/test/three-components/gltf-instance/ModelViewerGLTFInstance-spec.ts
@@ -83,9 +83,8 @@ suite('ModelViewerGLTFInstance', () => {
 
   suite('preparing the GLTF', () => {
     test('duplicates a transparent, double-sided mesh', () => {
-      const meshThree = preparedGLTF.scene.children[2] as Mesh;
-      expect(meshThree.children[0]).to.be.ok;
-      expect((meshThree.children[0] as Mesh).isMesh).to.be.ok;
+      expect(preparedGLTF.scene.children.length).to.be.eq(4);
+      expect((preparedGLTF.scene.children[3] as Mesh).isMesh).to.be.ok;
     });
 
     test('sets meshes to cast shadows', () => {

--- a/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
@@ -115,7 +115,7 @@ export class ModelViewerGLTFInstance extends GLTFInstance {
       const meshBack = mesh.clone() as Mesh;
       meshBack.material = duplicateMaterial;
       meshBack.renderOrder = -1;
-      mesh.add(meshBack);
+      mesh.parent!.add(meshBack);
     }
 
     return prepared;


### PR DESCRIPTION
Fixes #2386 

The transform was being applied twice since the duplicate was made a child rather than a sibling. 