### PR TITLE
removed two-finger rotation for wall placement

### DIFF
--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -587,7 +587,9 @@ export class ARRenderer extends EventDispatcher {
         this.isTwoFingering = false;
       } else {
         const {separation, deltaYaw} = this.fingerPolar(fingers);
-        this.goalYaw += deltaYaw;
+        if (this.placeOnWall === false) {
+          this.goalYaw += deltaYaw;
+        }
         if (scene.canScale) {
           const scale = separation / this.firstRatio;
           this.goalScale =


### PR DESCRIPTION
Fixes #2402 

Rotation was never meant to be enabled for wall placement.