### PR TITLE
simplified progress bar CSS for easier styling

### DIFF
--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -171,30 +171,16 @@ canvas.show {
   left: 0;
   width: 100%;
   height: var(--progress-bar-height, 5px);
+  background-color: var(--progress-bar-color, rgba(0, 0, 0, 0.4));
   transition: transform 0.09s;
   transform-origin: top left;
   transform: scaleX(0);
   overflow: hidden;
 }
 
-#default-progress-bar > .bar:before {
-  content: '';
-  display: block;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-
-  background-color: var(--progress-bar-color, rgba(0, 0, 0, 0.4));
-
-  transition: none;
-  transform-origin: top left;
-  transform: translateY(0);
-}
-
-#default-progress-bar > .bar.hide:before {
-  transition: transform 0.3s 1s;
-  transform: translateY(-100%);
+#default-progress-bar > .bar.hide {
+  transition: opacity 0.3s 1s;
+  opacity: 0;
 }
 
 .slot.interaction-prompt {


### PR DESCRIPTION
Fixes #2393 

The simplifies the progress bar CSS so that it is more ergonomic to style using `part`. It is slightly different than it used to be, fading out instead of sliding up, but given its small default height, I'd say most people will be unlikely to notice the difference. @maciekglowka does this look like a reasonable change?  I verified that your initial CSS works as expected now.