### PR TITLE
fixed default material in scene-graph

### DIFF
--- a/packages/model-viewer/src/test/features/scene-graph/model-spec.ts
+++ b/packages/model-viewer/src/test/features/scene-graph/model-spec.ts
@@ -24,9 +24,19 @@ import {assetPath, loadThreeGLTF} from '../../helpers.js';
 const expect = chai.expect;
 
 const ASTRONAUT_GLB_PATH = assetPath('models/Astronaut.glb');
+const KHRONOS_TRIANGLE_GLB_PATH =
+    assetPath('models/glTF-Sample-Models/2.0/Triangle/glTF/Triangle.gltf');
 
 suite('scene-graph/model', () => {
   suite('Model', () => {
+    test('creates a "default" material, when none is specified', async () => {
+      const threeGLTF = await loadThreeGLTF(KHRONOS_TRIANGLE_GLB_PATH);
+      const model = new Model(CorrelatedSceneGraph.from(threeGLTF));
+
+      expect(model.materials.length).to.be.eq(1);
+      expect(model.materials[0].name).to.be.eq('Default');
+    });
+
     test.skip('exposes a list of materials in the scene', async () => {
       // TODO: This test is skipped because [$correlatedObjects] can contain
       // unused materials, because it can contain a base material and the

--- a/packages/model-viewer/src/test/three-components/gltf-instance/correlated-scene-graph-spec.ts
+++ b/packages/model-viewer/src/test/three-components/gltf-instance/correlated-scene-graph-spec.ts
@@ -93,7 +93,7 @@ suite('correlated-scene-graph', () => {
     });
 
     suite('when correlating a cloned glTF', () => {
-      test('ignores the GLTFLoader "default" material', async () => {
+      test('creates a GLTFLoader "default" material', async () => {
         const threeGLTF = await loadThreeGLTF(KHRONOS_TRIANGLE_GLB_PATH);
         const correlatedSceneGraph = CorrelatedSceneGraph.from(threeGLTF);
 
@@ -105,11 +105,16 @@ suite('correlated-scene-graph', () => {
         const cloneCorrelatedSceneGraph =
             CorrelatedSceneGraph.from(cloneThreeGLTF, correlatedSceneGraph);
 
+        let name;
         cloneCorrelatedSceneGraph.threeObjectMap.forEach(
-            (_reference, threeObject) => {
-              expect((threeObject as MeshStandardMaterial).isMaterial)
-                  .to.be.undefined;
+            (reference, threeObject) => {
+              if ((threeObject as MeshStandardMaterial).isMaterial) {
+                name =
+                    cloneCorrelatedSceneGraph.gltf.materials![reference.index]
+                        .name;
+              }
             });
+        expect(name).to.be.eq('Default');
       });
     });
   });

--- a/packages/model-viewer/src/three-components/gltf-instance/correlated-scene-graph.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/correlated-scene-graph.ts
@@ -119,26 +119,38 @@ export class CorrelatedSceneGraph {
     const cloneThreeObjectMap: ThreeObjectToGLTFElementHandleMap = new Map();
     const cloneGLTFELementMap: GLTFElementToThreeObjectMap = new Map();
 
+    const defaultMaterial = {name: 'Default'} as Material;
+    const defaultReference = {type: 'materials', index: -1} as GLTFReference;
+
     for (let i = 0; i < originalThreeGLTF.scenes.length; i++) {
       this[$parallelTraverseThreeScene](
           originalThreeGLTF.scenes[i],
           cloneThreeGLTF.scenes[i],
           (object: ThreeSceneObject, cloneObject: ThreeSceneObject) => {
-            const elementReference =
+            let elementReference =
                 upstreamCorrelatedSceneGraph.threeObjectMap.get(object);
 
-            if (elementReference != null) {
-              const {type, index} = elementReference;
-              const cloneElement = cloneGLTF[type]![index];
-
-              cloneThreeObjectMap.set(cloneObject, {type, index});
-
-              const cloneObjects: Set<typeof cloneObject> =
-                  cloneGLTFELementMap.get(cloneElement) || new Set();
-              cloneObjects.add(cloneObject);
-
-              cloneGLTFELementMap.set(cloneElement, cloneObjects);
+            if (elementReference == null) {
+              if (defaultReference.index < 0) {
+                if (cloneGLTF.materials == null) {
+                  cloneGLTF.materials = [];
+                }
+                defaultReference.index = cloneGLTF.materials.length;
+                cloneGLTF.materials.push(defaultMaterial);
+              }
+              elementReference = defaultReference;
             }
+
+            const {type, index} = elementReference;
+            const cloneElement = cloneGLTF[type]![index];
+
+            cloneThreeObjectMap.set(cloneObject, {type, index});
+
+            const cloneObjects: Set<typeof cloneObject> =
+                cloneGLTFELementMap.get(cloneElement) || new Set();
+            cloneObjects.add(cloneObject);
+
+            cloneGLTFELementMap.set(cloneElement, cloneObjects);
           });
     }
 


### PR DESCRIPTION
Fixes #2419 

We created a default material in the correlated scene graph, but failed to clone it.