### PR TITLE
fixed USDZ generation with reveal=interaction

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -64,6 +64,7 @@ const $onARStatus = Symbol('onARStatus');
 const $onARTracking = Symbol('onARTracking');
 const $onARTap = Symbol('onARTap');
 const $selectARMode = Symbol('selectARMode');
+const $triggerLoad = Symbol('triggerLoad');
 
 export declare interface ARInterface {
   ar: boolean;
@@ -260,12 +261,7 @@ configuration or device capabilities');
     protected async[$enterARWithWebXR]() {
       console.log('Attempting to present in AR with WebXR...');
 
-      if (!this.loaded) {
-        this[$preload] = true;
-        this[$updateSource]();
-        await waitForEvent(this, 'load');
-        this[$preload] = false;
-      }
+      await this[$triggerLoad]();
 
       try {
         this[$arButtonContainer].removeEventListener(
@@ -283,6 +279,15 @@ configuration or device capabilities');
         this.activateAR();
       } finally {
         this[$selectARMode]();
+      }
+    }
+
+    async[$triggerLoad]() {
+      if (!this.loaded) {
+        this[$preload] = true;
+        this[$updateSource]();
+        await waitForEvent(this, 'load');
+        this[$preload] = false;
       }
     }
 
@@ -391,6 +396,8 @@ configuration or device capabilities');
 
     async prepareUSDZ(): Promise<string> {
       const updateSourceProgress = this[$progressTracker].beginActivity();
+
+      await this[$triggerLoad]();
 
       const scene = this[$scene];
 

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -56,7 +56,7 @@
 <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.js"></script>
 
 <!-- Use it like any other HTML element -->
-<model-viewer src="shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut" auto-rotate camera-controls></model-viewer>
+<model-viewer src="shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut" ar ar-modes="webxr scene-viewer quick-look" environment-image="neutral" auto-rotate camera-controls></model-viewer>
                 </template>
               </example-snippet>
             </div>

--- a/packages/modelviewer.dev/styles/examples.css
+++ b/packages/modelviewer.dev/styles/examples.css
@@ -371,7 +371,7 @@ model-viewer:focus {
   box-sizing: border-box;
 }
 
-.examples-container > .sample > .demo {
+.sample > .demo {
   height: 100vh;
 }
 
@@ -754,7 +754,7 @@ paper-button {
     padding-top: 0px;
   }
   
-  .examples-container > .sample > .demo {
+  .sample > .demo {
     top: 0;
     height: 150vw;
   }


### PR DESCRIPTION
Fixes #2397 

Now if the user clicks the AR button on iOS with reveal="interaction" (no loaded model yet) and no ios-src, we will trigger the model load in order to have something to convert to USDZ. Also added AR to the front page and made its CSS consistent with the other examples.