### PR TITLE
removed bad example path

### DIFF
--- a/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
@@ -187,12 +187,12 @@ export class ModelViewerGLTFInstance extends GLTFInstance {
 
     // Clones the roughnessMap if it exists.
     let roughnessMap: Texture|null = null;
-    if (material.roughnessMap) {
+    if (material.roughnessMap != null) {
       roughnessMap = material.roughnessMap.clone();
     }
 
     // Assigns the roughnessMap to the cloned material and generates mipmaps.
-    if (roughnessMap) {
+    if (roughnessMap != null) {
       roughnessMap.needsUpdate = true;
       clone.roughnessMap = roughnessMap;
 

--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -378,7 +378,7 @@
           </div>
           <example-snippet stamp-to="customButton" highlight-as="html">
             <template>
-<model-viewer ar camera-controls ios-src="assets/Astronaut.usdz" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
+<model-viewer ar ar-modes="webxr scene-viewer quick-look" camera-controls src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
   <button slot="ar-button" style="background-color: white; border-radius: 4px; border: none; position: absolute; top: 16px; right: 16px; ">
       👋 Activate AR
   </button>


### PR DESCRIPTION
Fixes the AR Custom Button example on iOS. Apparently "needs a newer version of iOS" also means "couldn't find that URL". 