### PR TITLE
Add workaround for the karma test on WSL

### DIFF
--- a/packages/editing-adapter/karma.conf.js
+++ b/packages/editing-adapter/karma.conf.js
@@ -43,7 +43,14 @@ module.exports = function(config) {
 
     // Note setting --browsers on the command-line always overrides this list.
     browsers: [
-      'ChromeHeadless',
+      'ChromeHeadlessNoSandbox',
     ],
+
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox'],
+      }
+    }
   });
 };

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -70,8 +70,15 @@ module.exports = function(config) {
 
     // Note setting --browsers on the command-line always overrides this list.
     browsers: [
-      'ChromeHeadless',
+      'ChromeHeadlessNoSandbox',
     ],
+
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox'],
+      }
+    },
   });
 
 

--- a/packages/space-opera/karma.conf.js
+++ b/packages/space-opera/karma.conf.js
@@ -58,7 +58,14 @@ module.exports = function(config) {
 
     // Note setting --browsers on the command-line always overrides this list.
     browsers: [
-      'ChromeHeadless',
+      'ChromeHeadlessNoSandbox',
     ],
+
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox'],
+      }
+    }
   });
 };


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue

Related discussion: #2194

### The problem this PR fixes

It doesn't seem that `$ num run test:ci` runs on WSL2.

```
$ npm run test:ci

> test:ci
> ./node_modules/.bin/lerna run test:ci --stream

lerna notice cli v3.22.1
lerna info versioning independent
lerna info Executing command in 4 packages: "npm run test:ci"
@google/model-viewer: > @google/model-viewer@1.7.1 test:ci
@google/model-viewer: > npm run test
@google/model-viewer: > @google/model-viewer@1.7.1 test
@google/model-viewer: > karma start --single-run
@google/model-viewer: (node:13498) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./dist/" in the "exports" field module resolution of the package at /mnt/c/Users/Takahiro/Documents/model-viewer/packages/model-viewer/node_modules/systemjs/package.json.
@google/model-viewer: Update this package.json to use a subpath pattern like "./dist/*".
@google/model-viewer: (Use `node --trace-deprecation ...` to show where the warning was created)
@google/model-viewer: START:
@google/model-viewer: 01 06 2021 18:12:18.813:INFO [karma-server]: Karma v5.2.3 server started at http://localhost:9876/
@google/model-viewer: 01 06 2021 18:12:18.864:INFO [launcher]: Launching browsers ChromeHeadless with concurrency 10
@google/model-viewer: 01 06 2021 18:12:19.160:INFO [launcher]: Starting browser ChromeHeadless
@google/model-viewer: 01 06 2021 18:19:19.262:WARN [launcher]: ChromeHeadless have not captured in 420000 ms, killing.
@google/model-viewer: 01 06 2021 18:19:19.284:INFO [launcher]: Trying to start ChromeHeadless again (1/2).
@google/model-viewer: 01 06 2021 18:26:19.386:WARN [launcher]: ChromeHeadless have not captured in 420000 ms, killing.
@google/model-viewer: 01 06 2021 18:26:19.389:INFO [launcher]: Trying to start ChromeHeadless again (2/2).
@google/model-viewer: 01 06 2021 18:33:19.489:WARN [launcher]: ChromeHeadless have not captured in 420000 ms, killing.
@google/model-viewer: 01 06 2021 18:33:19.493:ERROR [launcher]: ChromeHeadless failed 2 times (timeout). Giving up.
@google/model-viewer: Finished in 0 secs / 0 secs @ 18:33:19 GMT-0700 (Pacific Daylight Time)
lerna ERR! npm run test:ci exited 1 in '@google/model-viewer'
```

Platform: Windows10 + WSL2 + Ubuntu 18.04 LTS

It doesn't seem that Headless Chrome boots up correctly.

### Solution

This PR fixes the problem by setting the following as workaround in `karma.conf.js`

```
    browsers: ['ChromeHeadlessNoSandbox'],
    customLaunchers: {
      ChromeHeadlessNoSandbox: {
        base: 'ChromeHeadless',
        flags: ['--no-sandbox']
      }
    },
```

The solution is from https://github.com/karma-runner/karma-chrome-launcher/issues/158#issuecomment-339265457

With this change `$ npm run test:ci` runs on my WSL2.

### Request

If this change looks ok, just in case would you please check that this change doesn't break the tests on other platforms if you work on Mac, Linux, or others, before you merge this PR?