### PR TITLE
r129

### DIFF
--- a/packages/editing-adapter/package-lock.json
+++ b/packages/editing-adapter/package-lock.json
@@ -6110,8 +6110,8 @@
           }
         },
         "three": {
-          "version": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
-          "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA=="
+          "version": "https://registry.npmjs.org/three/-/three-0.129.0.tgz",
+          "integrity": "sha512-wiWio1yVRg2Oj6WEWsTHQo5eSzYpEwSBtPSi3OofNpvFbf26HFfb9kw4FZJNjII4qxzp0b1xLB11+tKkBGB1ZA=="
         },
         "through": {
           "version": "2.3.8",

--- a/packages/model-viewer/package-lock.json
+++ b/packages/model-viewer/package-lock.json
@@ -1520,9 +1520,9 @@
       }
     },
     "@types/three": {
-      "version": "0.127.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.127.1.tgz",
-      "integrity": "sha512-e90iYq3zde3axANg7BPZY0fKrez1AzveamIIFk23PMh9WtCx91geokDy+yEAIymdIldgUpvezAP6+zCV3oekXw==",
+      "version": "0.129.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.129.1.tgz",
+      "integrity": "sha512-31VTcjAQNggIrCH9NVotTYsr5Ws/QMGGTaMK6RP3EgyzW2WEuZdm25TNidd6PJ3e4a6/hbswNacnTsjwc7ksbw==",
       "dev": true
     },
     "@types/whatwg-url": {

--- a/packages/model-viewer/package-lock.json
+++ b/packages/model-viewer/package-lock.json
@@ -5771,9 +5771,9 @@
       }
     },
     "three": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
-      "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA==",
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.129.0.tgz",
+      "integrity": "sha512-wiWio1yVRg2Oj6WEWsTHQo5eSzYpEwSBtPSi3OofNpvFbf26HFfb9kw4FZJNjII4qxzp0b1xLB11+tKkBGB1ZA==",
       "dev": true
     },
     "through": {

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -102,7 +102,7 @@
     "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-polyfill": "^3.0.0",
     "rollup-plugin-terser": "^7.0.0",
-    "three": "^0.128.0",
+    "three": "^0.129.0",
     "typescript": "4.0.3"
   },
   "publishConfig": {

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -78,7 +78,7 @@
     "@types/mocha": "^8.0.3",
     "@types/pngjs": "^3.4.0",
     "@types/resize-observer-browser": "^0.1.2",
-    "@types/three": "^0.127.1",
+    "@types/three": "^0.129.1",
     "@ungap/event-target": "^0.2.2",
     "@webcomponents/webcomponentsjs": "~2.1.3",
     "chai": "^4.2.0",

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -16,7 +16,7 @@
 
 import {Matrix3, Matrix4, Vector2} from 'three';
 
-import ModelViewerElementBase, {$needsRender, $scene, toVector3D, Vector3D} from '../model-viewer-base.js';
+import ModelViewerElementBase, {$needsRender, $scene, $tick, toVector3D, Vector3D} from '../model-viewer-base.js';
 import {Hotspot, HotspotConfiguration} from '../three-components/Hotspot.js';
 import {Constructor} from '../utilities.js';
 
@@ -92,6 +92,18 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
         this[$observer].disconnect();
       } else {
         ShadyDOM.unobserveChildren(this[$observer]);
+      }
+    }
+
+    [$tick](time: number, delta: number) {
+      super[$tick](time, delta);
+      const scene = this[$scene];
+      const {camera, annotationRenderer} = scene;
+
+      if (scene.isDirty) {
+        scene.updateHotspots(camera.position);
+        annotationRenderer.domElement.style.display = '';
+        annotationRenderer.render(scene, camera);
       }
     }
 

--- a/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
@@ -14,8 +14,8 @@
  */
 
 import {Matrix4, PerspectiveCamera, Vector2, Vector3} from 'three';
-import {ControlsInterface, ControlsMixin} from '../../features/controls.js';
 
+import {ControlsInterface, ControlsMixin} from '../../features/controls.js';
 import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
 import {ARRenderer} from '../../three-components/ARRenderer.js';
 import {SETTLING_TIME} from '../../three-components/Damper.js';
@@ -255,9 +255,9 @@ suite('ARRenderer', () => {
 
       test('places the model oriented to the camera', () => {
         const epsilon = 0.0001;
-        const {target, position} = modelScene;
+        const {target, position, camera} = modelScene;
 
-        const {cameraPosition} = arRenderer;
+        const cameraPosition = camera.position;
         const cameraToHit = new Vector2(
             position.x - cameraPosition.x, position.z - cameraPosition.z);
         const forward = target.getWorldDirection(new Vector3());

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -80,7 +80,6 @@ export class ARRenderer extends EventDispatcher {
   public threeRenderer: WebGLRenderer;
   public currentSession: XRSession|null = null;
   public placeOnWall = false;
-  public cameraPosition = new Vector3();
 
   private placementBox: PlacementBox|null = null;
   private lastTick: number|null = null;
@@ -396,8 +395,6 @@ export class ARRenderer extends EventDispatcher {
     this.presentedScene!.orientHotspots(
         Math.atan2(viewMatrix[1], viewMatrix[5]));
 
-    this.cameraPosition.set(viewMatrix[12], viewMatrix[13], viewMatrix[14]);
-
     if (!this.initialized) {
       const {position, element} = scene;
 
@@ -420,7 +417,7 @@ export class ARRenderer extends EventDispatcher {
       scene.yaw = Math.atan2(cameraDirection.x, cameraDirection.z) - theta;
       this.goalYaw = scene.yaw;
 
-      position.copy(this.cameraPosition)
+      position.copy(scene.camera.position)
           .add(cameraDirection.multiplyScalar(-1 * radius));
       this.goalPosition.copy(position);
 
@@ -639,7 +636,7 @@ export class ARRenderer extends EventDispatcher {
             this.placementBox!.offsetHeight = offset / scale;
             this.presentedScene!.setShadowScaleAndOffset(scale, offset);
             // Interpolate hit ray up to drag plane
-            const cameraPosition = vector3.copy(this.cameraPosition);
+            const cameraPosition = vector3.copy(scene.camera.position);
             const alpha = -offset / (cameraPosition.y - hit.y);
             cameraPosition.multiplyScalar(alpha);
             hit.multiplyScalar(1 - alpha).add(cameraPosition);

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -140,6 +140,8 @@ export class ARRenderer extends EventDispatcher {
 
     await this.threeRenderer.xr.setSession(session as any);
 
+    (this.threeRenderer.xr as any).cameraAutoUpdate = false;
+
     return session;
   }
 
@@ -389,6 +391,8 @@ export class ARRenderer extends EventDispatcher {
     camera.near = 0.1;
     camera.far = 100;
 
+    (this.threeRenderer.xr as any).updateCamera(camera);
+
     this.presentedScene!.orientHotspots(
         Math.atan2(viewMatrix[1], viewMatrix[5]));
 
@@ -402,7 +406,8 @@ export class ARRenderer extends EventDispatcher {
 
       if (this.threeRenderer.xr.getSession() != null) {
         this.projectionMatrix.copy(
-            this.threeRenderer.xr.getCamera(camera).projectionMatrix);
+            //@ts-ignore
+            this.threeRenderer.xr.getCamera().projectionMatrix);
         this.projectionMatrixInverse.copy(this.projectionMatrix).invert();
       }
 

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -15,9 +15,11 @@
 
 import {AnimationAction, AnimationClip, AnimationMixer, Box3, Event as ThreeEvent, Matrix3, Object3D, PerspectiveCamera, Raycaster, Scene, Vector2, Vector3} from 'three';
 import {CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer';
+
 import {USE_OFFSCREEN_CANVAS} from '../constants.js';
 import ModelViewerElementBase, {$renderer, RendererInterface} from '../model-viewer-base.js';
 import {resolveDpr} from '../utilities.js';
+
 import {Damper, SETTLING_TIME} from './Damper.js';
 import {ModelViewerGLTFInstance} from './gltf-instance/ModelViewerGLTFInstance.js';
 import {Hotspot} from './Hotspot.js';
@@ -708,15 +710,5 @@ export class ModelScene extends Scene {
     this.forHotspots((hotspot) => {
       hotspot.visible = visible;
     });
-  }
-
-  postRender() {
-    const {camera} = this;
-
-    if (this.isDirty) {
-      this.updateHotspots(camera.position);
-      this.annotationRenderer.domElement.style.display = '';
-      this.annotationRenderer.render(this, camera);
-    }
   }
 }

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {ACESFilmicToneMapping, Event, EventDispatcher, GammaEncoding, PCFSoftShadowMap, WebGL1Renderer} from 'three';
+import {ACESFilmicToneMapping, Event, EventDispatcher, GammaEncoding, PCFSoftShadowMap, WebGLRenderer} from 'three';
 import {RoughnessMipmapper} from 'three/examples/jsm/utils/RoughnessMipmapper';
 
 import {USE_OFFSCREEN_CANVAS} from '../constants.js';
@@ -67,7 +67,7 @@ export class Renderer extends EventDispatcher {
     this._singleton = new Renderer({debug: isDebugMode()});
   }
 
-  public threeRenderer!: WebGL1Renderer;
+  public threeRenderer!: WebGLRenderer;
   public canvasElement: HTMLCanvasElement;
   public canvas3D: HTMLCanvasElement|OffscreenCanvas;
   public textureUtils: TextureUtils|null;
@@ -121,7 +121,7 @@ export class Renderer extends EventDispatcher {
     this.canvas3D.addEventListener('webglcontextlost', this.onWebGLContextLost);
 
     try {
-      this.threeRenderer = new WebGL1Renderer({
+      this.threeRenderer = new WebGLRenderer({
         canvas: this.canvas3D,
         alpha: true,
         antialias: true,

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -379,7 +379,6 @@ export class Renderer extends EventDispatcher {
   render(t: number, frame?: XRFrame) {
     if (frame != null) {
       this.arRenderer.onWebXRFrame(t, frame);
-      this.arRenderer.presentedScene!.postRender();
       return;
     }
 
@@ -452,8 +451,6 @@ export class Renderer extends EventDispatcher {
       this.threeRenderer.setViewport(
           0, Math.floor(this.height * dpr) - height, width, height);
       this.threeRenderer.render(scene, scene.camera);
-
-      scene.postRender();
 
       if (this.multipleScenesVisible) {
         if (scene.context == null) {

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -13,8 +13,10 @@
  */
 
 import {Euler, Event as ThreeEvent, EventDispatcher, PerspectiveCamera, Spherical} from 'three';
+
 import {TouchAction} from '../features/controls.js';
 import {clamp} from '../utilities.js';
+
 import {Damper, SETTLING_TIME} from './Damper.js';
 
 

--- a/packages/modelviewer.dev/package-lock.json
+++ b/packages/modelviewer.dev/package-lock.json
@@ -5092,8 +5092,8 @@
           }
         },
         "three": {
-          "version": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
-          "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA=="
+          "version": "https://registry.npmjs.org/three/-/three-0.129.0.tgz",
+          "integrity": "sha512-wiWio1yVRg2Oj6WEWsTHQo5eSzYpEwSBtPSi3OofNpvFbf26HFfb9kw4FZJNjII4qxzp0b1xLB11+tKkBGB1ZA=="
         },
         "through": {
           "version": "2.3.8",

--- a/packages/render-fidelity-tools/package-lock.json
+++ b/packages/render-fidelity-tools/package-lock.json
@@ -8557,8 +8557,8 @@
           }
         },
         "three": {
-          "version": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
-          "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA=="
+          "version": "https://registry.npmjs.org/three/-/three-0.129.0.tgz",
+          "integrity": "sha512-wiWio1yVRg2Oj6WEWsTHQo5eSzYpEwSBtPSi3OofNpvFbf26HFfb9kw4FZJNjII4qxzp0b1xLB11+tKkBGB1ZA=="
         },
         "through": {
           "version": "2.3.8",

--- a/packages/space-opera/package-lock.json
+++ b/packages/space-opera/package-lock.json
@@ -21665,9 +21665,9 @@
       }
     },
     "three": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
-      "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA==",
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.129.0.tgz",
+      "integrity": "sha512-wiWio1yVRg2Oj6WEWsTHQo5eSzYpEwSBtPSi3OofNpvFbf26HFfb9kw4FZJNjII4qxzp0b1xLB11+tKkBGB1ZA==",
       "dev": true
     },
     "through": {

--- a/packages/space-opera/package-lock.json
+++ b/packages/space-opera/package-lock.json
@@ -6135,8 +6135,8 @@
           }
         },
         "three": {
-          "version": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
-          "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA=="
+          "version": "https://registry.npmjs.org/three/-/three-0.129.0.tgz",
+          "integrity": "sha512-wiWio1yVRg2Oj6WEWsTHQo5eSzYpEwSBtPSi3OofNpvFbf26HFfb9kw4FZJNjII4qxzp0b1xLB11+tKkBGB1ZA=="
         },
         "through": {
           "version": "2.3.8",
@@ -11911,8 +11911,8 @@
               }
             },
             "three": {
-              "version": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
-              "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA=="
+              "version": "https://registry.npmjs.org/three/-/three-0.129.0.tgz",
+              "integrity": "sha512-wiWio1yVRg2Oj6WEWsTHQo5eSzYpEwSBtPSi3OofNpvFbf26HFfb9kw4FZJNjII4qxzp0b1xLB11+tKkBGB1ZA=="
             },
             "through": {
               "version": "2.3.8",

--- a/packages/space-opera/package.json
+++ b/packages/space-opera/package.json
@@ -70,7 +70,7 @@
     "remote-redux-devtools": "^0.5.16",
     "@types/remote-redux-devtools": "^0.5.4",
     "rollup": "^2.26.6",
-    "three": "^0.128.0",
+    "three": "^0.129.0",
     "ts-closure-library": "^2019.11.1-1.10",
     "typescript": "4.0.3",
     "qrious": "^4.0.2",


### PR DESCRIPTION
This updates three.js to r129 and our renderer to use WebGL2 where available. With the new `updateCamera()` method, I was able to revert the `postRender()` workaround for updating the hotspots. Thanks @mrdoob!