### PR TITLE
glTF KHR_materials_variants extension export support

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -214,8 +214,7 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
         }
 
         const exporter =
-            new GLTFExporter()
-                // @ts-ignore
+            (new GLTFExporter() as any)
                 .register(
                     (writer: any) =>
                         new GLTFExporterMaterialsVariantsExtension(writer));

--- a/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
+++ b/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
@@ -21,6 +21,7 @@ import {KTX2Loader} from 'three/examples/jsm/loaders/KTX2Loader';
 import ModelViewerElementBase from '../model-viewer-base.js';
 import {CacheEvictionPolicy} from '../utilities/cache-eviction-policy.js';
 
+import GLTFMaterialsVariantsExtension from './gltf-instance/VariantMaterialLoaderPlugin';
 import {GLTFInstance, GLTFInstanceConstructor} from './GLTFInstance.js';
 
 export type ProgressCallback = (progress: number) => void;
@@ -136,7 +137,8 @@ export class CachingGLTFLoader<T extends GLTFInstanceConstructor =
     this[$loader].setKTX2Loader(ktx2Loader);
   }
 
-  protected[$loader]: GLTFLoader = new GLTFLoader();
+  protected[$loader]: GLTFLoader = new GLTFLoader().register(
+      parser => new GLTFMaterialsVariantsExtension(parser));
   protected[$GLTFInstance]: T;
 
   protected get[$evictionPolicy](): CacheEvictionPolicy {

--- a/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialExporterPlugin.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialExporterPlugin.ts
@@ -69,7 +69,7 @@ export default class GLTFExporterMaterialsVariantsExtension {
 
   beforeParse(objects: Object3D[]) {
     // Find all variant names and store them to the table
-    const variantNameTable = new Map<string, boolean>();
+    const variantNameSet = new Set<string>();
     for (const object of objects) {
       object.traverse(o => {
         if (!compatibleObject(o)) {
@@ -80,15 +80,13 @@ export default class GLTFExporterMaterialsVariantsExtension {
           const variantMaterial = variantMaterials.get(variantName);
           // Ignore unloaded variant materials
           if (compatibleMaterial(variantMaterial.material)) {
-            variantNameTable.set(variantName, true);
+            variantNameSet.add(variantName);
           }
         }
       });
     }
     // We may want to sort?
-    for (const name of variantNameTable.keys()) {
-      this.variantNames.push(name);
-    }
+    variantNameSet.forEach(name => this.variantNames.push(name));
   }
 
   writeMesh(mesh: Mesh, meshDef: any) {

--- a/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialExporterPlugin.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialExporterPlugin.ts
@@ -1,0 +1,132 @@
+/**
+ * Materials variants extension
+ *
+ * Specification:
+ * https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_variants
+ */
+
+import {Material, Mesh, Object3D} from 'three';
+
+/**
+ * @param object {THREE.Object3D}
+ * @return {boolean}
+ */
+const compatibleObject = (object: Object3D) => {
+  // @TODO: Need properer variantMaterials format validation?
+  return (object as Mesh).material !==
+      undefined &&        // easier than (!object.isMesh && !object.isLine &&
+                          // !object.isPoints)
+      object.userData &&  // just in case
+      object.userData.variantMaterials &&
+      // Is this line costly?
+      !!Object
+            .values(object.userData.variantMaterials　as {material: Material}[])
+            .filter(m => compatibleMaterial(m.material));
+};
+
+/**
+ * @param material {THREE.Material}
+ * @return {boolean}
+ */
+const compatibleMaterial = (material: Material) => {
+  // @TODO: support multi materials?
+  return material && material.isMaterial && !Array.isArray(material);
+};
+
+export default class GLTFExporterMaterialsVariantsExtension {
+  writer: any;  // @TODO: Replace with GLTFWriter when GLTFExporter plugin TS
+                // declartion is ready
+  name: string;
+  variantNames: string[];
+
+  constructor(writer: any) {
+    this.writer = writer;
+    this.name = 'KHR_materials_variants';
+    this.variantNames = [];
+  }
+
+  beforeParse(objects: Object3D[]) {
+    // Find all variant names and store them to the table
+    const variantNameTable: {[key: string]: boolean} = {};
+    for (const object of objects) {
+      object.traverse(o => {
+        if (!compatibleObject(o)) {
+          return;
+        }
+        const variantMaterials = o.userData.variantMaterials;
+        for (const variantName in variantMaterials) {
+          const variantMaterial = variantMaterials[variantName];
+          // Ignore unloaded variant materials
+          if (compatibleMaterial(variantMaterial.material)) {
+            variantNameTable[variantName] = true;
+          }
+        }
+      });
+    }
+    // We may want to sort?
+    Object.keys(variantNameTable).forEach(name => this.variantNames.push(name));
+  }
+
+  writeMesh(mesh: Mesh, meshDef: any) {
+    if (!compatibleObject(mesh)) {
+      return;
+    }
+
+    const userData = mesh.userData;
+    const variantMaterials = userData.variantMaterials;
+    const mappingTable:
+        {[key: string]: {material: number, variants: number[]}} = {};
+    for (const variantName in variantMaterials) {
+      const variantMaterialInstance = variantMaterials[variantName].material;
+      if (!compatibleMaterial(variantMaterialInstance)) {
+        continue;
+      }
+      const variantIndex =
+          this.variantNames.indexOf(variantName);  // Shouldn't be -1
+      const materialIndex =
+          this.writer.processMaterial(variantMaterialInstance);
+      if (!mappingTable[materialIndex]) {
+        mappingTable[materialIndex] = {material: materialIndex, variants: []};
+      }
+      mappingTable[materialIndex].variants.push(variantIndex);
+    }
+
+    const mappingsDef =
+        Object.values(mappingTable)
+            .map((m => {return m.variants.sort((a, b) => a - b) && m}))
+            .sort((a, b) => a.material - b.material);
+
+    if (mappingsDef.length === 0) {
+      return;
+    }
+
+    const originalMaterialIndex =
+        compatibleMaterial(userData.originalMaterial) ?
+        this.writer.processMaterial(userData.originalMaterial) :
+        -1;
+
+    for (const primitiveDef of meshDef.primitives) {
+      // Override primitiveDef.material with original material.
+      if (originalMaterialIndex >= 0) {
+        primitiveDef.material = originalMaterialIndex;
+      }
+      primitiveDef.extensions = primitiveDef.extensions || {};
+      primitiveDef.extensions[this.name] = {mappings: mappingsDef};
+    }
+  }
+
+  afterParse() {
+    if (this.variantNames.length === 0) {
+      return;
+    }
+
+    const root = this.writer.json;
+    root.extensions = root.extensions || {};
+
+    const variantsDef = this.variantNames.map(n => {
+      return {name: n};
+    });
+    root.extensions[this.name] = {variants: variantsDef};
+    this.writer.extensionsUsed[this.name] = true;
+  }
+}

--- a/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialLoaderPlugin.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialLoaderPlugin.ts
@@ -40,7 +40,7 @@ import {GLTF, GLTFLoaderPlugin, GLTFParser} from 'three/examples/jsm/loaders/GLT
  */
 const ensureUniqueNames = (variantNames: string[]) => {
   const uniqueNames = [];
-  const knownNames = new Map<string, boolean>();
+  const knownNames = new Set<string>();
 
   for (const name of variantNames) {
     let uniqueName = name;
@@ -51,7 +51,7 @@ const ensureUniqueNames = (variantNames: string[]) => {
     while (knownNames.has(uniqueName)) {
       uniqueName = name + '.' + (++suffix);
     }
-    knownNames.set(uniqueName, true);
+    knownNames.add(uniqueName);
     uniqueNames.push(uniqueName);
   }
 

--- a/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialLoaderPlugin.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialLoaderPlugin.ts
@@ -1,0 +1,275 @@
+/**
+ * Materials variants extension
+ *
+ * Specification:
+ * https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_variants
+ */
+
+import {Material, Mesh, Object3D} from 'three';
+import {GLTF, GLTFLoaderPlugin, GLTFParser} from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+/**
+ * KHR_materials_variants specification allows duplicated variant names
+ * but it makes handling the extension complex.
+ * We ensure tha names and make it easier.
+ * If you want to export the extension with the original names
+ * you are recommended to write GLTFExporter plugin to restore the names.
+ *
+ * @param variantNames {Array<string>}
+ * @return {Array<string>}
+ */
+const ensureUniqueNames = (variantNames: string[]) => {
+  const uniqueNames = [];
+  const knownNames: {[key: string]: boolean} = {};
+
+  for (const name of variantNames) {
+    let uniqueName = name;
+    let suffix = 0;
+    // @TODO: An easy solution.
+    //        O(N^2) in the worst scenario where N is variantNames.length.
+    //        Fix me if needed.
+    while (knownNames[uniqueName] !== undefined) {
+      uniqueName = name + '.' + (++suffix);
+    }
+    knownNames[uniqueName] = true;
+    uniqueNames.push(uniqueName);
+  }
+
+  return uniqueNames;
+};
+
+/**
+ * Convert mappings array to table object to make handling the extension easier.
+ *
+ * @param
+ *     extensionDef {glTF.meshes[n].primitive.extensions.KHR_materials_variants}
+ * @param variantNames {Array<string>} Required to be unique names
+ * @return {Object}
+ */
+const mappingsArrayToTable = (extensionDef: any, variantNames: string[]) => {
+  const table:
+      {[key: string]:
+           {material: Material|null, gltfMaterialIndex: number}} = {};
+  for (const mapping of extensionDef.mappings) {
+    for (const variant of mapping.variants) {
+      table[variantNames[variant]] = {
+        material: null,
+        gltfMaterialIndex: mapping.material
+      };
+    }
+  }
+  return table;
+};
+
+/**
+ * @param object {THREE.Object3D}
+ * @return {boolean}
+ */
+const compatibleObject = (object: Object3D) => {
+  return 'material' in object &&  // easier than (!object.isMesh &&
+                                  // !object.isLine && !object.isPoints)
+      object!.userData &&         // just in case
+      object!.userData.variantMaterials;
+};
+
+export default class GLTFMaterialsVariantsExtension implements
+    GLTFLoaderPlugin {
+  parser: GLTFParser;
+  name: string;
+
+  constructor(parser: GLTFParser) {
+    this.parser = parser;
+    this.name = 'KHR_materials_variants';
+  }
+
+  // Note that the following properties will be overridden even if they are
+  // pre-defined
+  // - gltf.userData.variants
+  // - mesh.userData.variantMaterials
+  afterRoot(gltf: GLTF) {
+    const parser = this.parser;
+    const json = parser.json;
+
+    if (!json.extensions || !json.extensions[this.name]) {
+      return null;
+    }
+
+    const extensionDef = json.extensions[this.name];
+    const variantsDef = extensionDef.variants || [];
+    const variants =
+        ensureUniqueNames(variantsDef.map((v: {name: string}) => v.name));
+
+    for (const scene of gltf.scenes) {
+      // Save the variants data under associated mesh.userData
+      scene.traverse(object => {
+        // The following code can be simplified if parser.associations directly
+        // supports meshes.
+        const association = parser.associations.get(object);
+
+        if (!association || association.type !== 'nodes') {
+          return;
+        }
+
+        const nodeDef = json.nodes[association.index];
+        const meshIndex = nodeDef.mesh;
+
+        if (meshIndex === undefined) {
+          return;
+        }
+
+        // Two limitations:
+        // 1. The nodeDef shouldn't have any objects (camera, light, or
+        // nodeDef.extensions object)
+        //    other than nodeDef.mesh
+        // 2. Other plugins shouldn't change any scene graph hierarchy
+        // The following code can cause error if hitting the either or both
+        // limitations If parser.associations will directly supports meshes
+        // these limitations can be removed
+
+        const meshDef = json.meshes[meshIndex];
+        const primitivesDef = meshDef.primitives;
+        const meshes = 'isMesh' in object ? [object] : object.children;
+
+        for (let i = 0; i < primitivesDef.length; i++) {
+          const primitiveDef = primitivesDef[i];
+          const extensionsDef = primitiveDef.extensions;
+          if (!extensionsDef || !extensionsDef[this.name]) {
+            continue;
+          }
+          meshes[i].userData.variantMaterials =
+              mappingsArrayToTable(extensionsDef[this.name], variants);
+        }
+      });
+    }
+
+    gltf.userData.variants = variants;
+
+    // @TODO: Adding functions to userData might be problematic
+    //        for example when serializing?
+    gltf.userData.functions = gltf.userData.functions || {};
+
+    /**
+     * @param object {THREE.Mesh}
+     * @param variantName {string|null}
+     * @return {Promise}
+     * @TODO: Support multi materials?
+     */
+    const switchMaterial = async (
+        object: Mesh,
+        variantName: string|null,
+        onUpdate:
+            ((object: Mesh,
+              oldMaterial: Material,
+              gltfMaterialIndex: number|null) => void)|null) => {
+      if (!object.userData.originalMaterial) {
+        object.userData.originalMaterial = object.material;
+      }
+
+      const oldMaterial = object.material;
+      let gltfMaterialIndex = null;
+
+      if (variantName === null ||
+          !object.userData.variantMaterials[variantName]) {
+        object.material = object.userData.originalMaterial;
+        if (parser.associations.has(object.material as Material)) {
+          gltfMaterialIndex =
+              parser.associations.get(object.material as Material)!.index;
+        }
+      } else {
+        const variantMaterialParam =
+            object.userData.variantMaterials[variantName];
+
+        if (variantMaterialParam.material) {
+          object.material = variantMaterialParam.material;
+          if ('gltfMaterialIndex' in variantMaterialParam) {
+            gltfMaterialIndex = variantMaterialParam.gltfMaterialIndex;
+          }
+        } else {
+          gltfMaterialIndex = variantMaterialParam.gltfMaterialIndex;
+          object.material =
+              await parser.getDependency('material', gltfMaterialIndex);
+          parser.assignFinalMaterial(object);
+          variantMaterialParam.material = object.material;
+        }
+      }
+
+      if (onUpdate !== null) {
+        onUpdate(object, oldMaterial as Material, gltfMaterialIndex);
+      }
+    };
+
+    /**
+     * @param object {THREE.Mesh}
+     * @return {Promise}
+     */
+    const ensureLoadVariants = (object: Mesh) => {
+      const currentMaterial = object.material;
+      const variantMaterials = object.userData.variantMaterials;
+      const pending = [];
+      for (const variantName in variantMaterials) {
+        const variantMaterial = variantMaterials[variantName];
+        if (variantMaterial.material) {
+          continue;
+        }
+        const materialIndex = variantMaterial.gltfMaterialIndex;
+        pending.push(parser.getDependency('material', materialIndex)
+                         .then((material: Material) => {
+                           object.material = material;
+                           parser.assignFinalMaterial(object);
+                           variantMaterials[variantName].material =
+                               object.material;
+                         }));
+      }
+      return Promise.all(pending).then(() => {
+        object.material = currentMaterial;
+      });
+    };
+
+    /**
+     * @param object {THREE.Object3D}
+     * @param variantName {string|null}
+     * @param doTraverse {boolean} Default is true
+     * @param onUpdate {function}
+     * @return {Promise}
+     */
+    gltf.userData.functions.selectVariant =
+        (object: Object3D,
+         variantName: string|null,
+         doTraverse = true,
+         onUpdate = null) => {
+          const pending = [];
+          if (doTraverse) {
+            object.traverse(
+                (o: Object3D) => compatibleObject(o) &&
+                    pending.push(
+                        switchMaterial(o as Mesh, variantName, onUpdate)));
+          } else {
+            compatibleObject(object) &&
+                pending.push(
+                    switchMaterial(object as Mesh, variantName, onUpdate));
+          }
+          return Promise.all(pending);
+        };
+
+    /**
+     * @param object {THREE.Object3D}
+     * @param doTraverse {boolean} Default is true
+     * @return {Promise}
+     */
+    gltf.userData.functions.ensureLoadVariants =
+        (object: Object3D, doTraverse = true) => {
+          const pending = [];
+          if (doTraverse) {
+            object.traverse(
+                (o: Object3D) => compatibleObject(o) &&
+                    pending.push(ensureLoadVariants(o as Mesh)));
+          } else {
+            compatibleObject(object) &&
+                pending.push(ensureLoadVariants(object as Mesh));
+          }
+          return Promise.all(pending);
+        };
+
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
This PR adds glTF `KHR_materials_variants` extension export support based on my Three.js glTF loader/exporter plugins

* [Three.js glTF loader KHR_materials_variants extension plugin](https://github.com/takahirox/three-gltf-extensions/tree/main/loaders/KHR_materials_variants)
* [Three.js glTF exporter KHR_materials_variants extension plugin](https://github.com/takahirox/three-gltf-extensions/tree/main/exporters/KHR_materials_variants)

**Changes**

* Copy the plugin source codes into &lt;model-viewer&gt; repository, rather than importing them, for easier maintenance
* Rewrite them to TypeScript from JavaScript
* Register the plugins to `GLTFLoader` and `GLTFExporter`
* Some minor internal API change. See my review comments.

**Notes**

* I replaced [our `KHR_materials_variants` handlers for the loader in `loadVariant()`](https://github.com/google/model-viewer/blob/v1.7.2/packages/model-viewer/src/three-components/gltf-instance/correlated-scene-graph.ts#L247-L285) with the loader plugin because the exporter `KHR_materials_variants` plugin API is expected to be used with the loader `KHR_materials_variants` plugin API.
* The loader plugin loads variant materials on demand and [stores them under `mesh.userData.variantMaterials`](https://github.com/takahirox/three-gltf-extensions/tree/main/loaders/KHR_materials_variants#api). The exporter plugin exports variant materials [from `mesh.userData.variantMaterials`](https://github.com/takahirox/three-gltf-extensions/tree/main/exporters/KHR_materials_variants#api). If for example editor wants to add, remove, or update variant materials, it should edit `mesh.userData.variantMaterials`.
* I didn't test well yet, I would be happy if you folks test on your ends, too

/cc @elalish 