### PR TITLE
remove ios13 testing while BrowserStack's test runner is down

### DIFF
--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -142,17 +142,17 @@ module.exports = function(config) {
         // instances, causing them to time out:
         url: 'http://127.0.0.1:9876'
       },
-      'iOS Safari (iOS 13)': {
-        base: 'BrowserStack',
-        os: 'iOS',
-        os_version: '13',
-        device: 'iPhone 8',
-        browser: 'iPhone',
-        real_mobile: 'true',
-        // BrowserStack seems to drop the port when redirecting to this special
-        // domain so we go there directly instead:
-        url: 'http://bs-local.com:9876'
-      },
+      // 'iOS Safari (iOS 13)': {
+      //   base: 'BrowserStack',
+      //   os: 'iOS',
+      //   os_version: '13',
+      //   device: 'iPhone 8',
+      //   browser: 'iPhone',
+      //   real_mobile: 'true',
+      //   // BrowserStack seems to drop the port when redirecting to this special
+      //   // domain so we go there directly instead:
+      //   url: 'http://bs-local.com:9876'
+      // },
       'iOS Safari (iOS 14)': {
         base: 'BrowserStack',
         os: 'iOS',


### PR DESCRIPTION
BrowserStack is investigating why iOS13 has gone from flaky to not working at all. Meanwhile, I'd like our automated tests to pass.