### PR TITLE
* Resolves extraneous materials being created.

### DIFF
--- a/packages/model-viewer/src/test/three-components/gltf-instance/correlated-scene-graph-spec.ts
+++ b/packages/model-viewer/src/test/three-components/gltf-instance/correlated-scene-graph-spec.ts
@@ -21,6 +21,8 @@ import {CorrelatedSceneGraph} from '../../../three-components/gltf-instance/corr
 import {Material, PBRMetallicRoughness, Texture, TextureInfo} from '../../../three-components/gltf-instance/gltf-2.0.js';
 import {assetPath, loadThreeGLTF} from '../../helpers.js';
 
+
+
 const expect = chai.expect;
 
 const HORSE_GLB_PATH = assetPath('models/Horse.glb');
@@ -115,6 +117,23 @@ suite('correlated-scene-graph', () => {
               }
             });
         expect(name).to.be.eq('Default');
+      });
+
+      test('Only one default material after cloning', async () => {
+        const threeGLTF = await loadThreeGLTF(KHRONOS_TRIANGLE_GLB_PATH);
+        const correlatedSceneGraph = CorrelatedSceneGraph.from(threeGLTF);
+
+        const scene = SkeletonUtils.clone(threeGLTF.scene) as Group;
+        const scenes: Group[] = [scene];
+
+        const cloneThreeGLTF: GLTF = {...threeGLTF, scene, scenes};
+
+        const cloneCorrelatedSceneGraph =
+            CorrelatedSceneGraph.from(cloneThreeGLTF, correlatedSceneGraph);
+
+        expect(cloneCorrelatedSceneGraph.gltf.materials!.length).to.be.eq(1);
+        expect(cloneCorrelatedSceneGraph.gltf.materials![0].name)
+            .to.be.eq('Default');
       });
     });
   });

--- a/packages/model-viewer/src/three-components/gltf-instance/correlated-scene-graph.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/correlated-scene-graph.ts
@@ -135,7 +135,7 @@ export class CorrelatedSceneGraph {
             if (((object as Mesh).isMesh || (object as Material).isMaterial) &&
                 elementReference == null) {
               // Checks if default material was allready addded to the gltf.
-              if (cloneGLTF.materials) {
+              if (cloneGLTF.materials && cloneGLTF.materials.length) {
                 const material =
                     cloneGLTF.materials[cloneGLTF.materials.length - 1];
                 if (material.name === 'Default') {
@@ -151,9 +151,10 @@ export class CorrelatedSceneGraph {
                 defaultReference.index = cloneGLTF.materials.length;
                 cloneGLTF.materials.push(defaultMaterial);
               }
+
+              elementReference = defaultReference;
             }
 
-            elementReference = defaultReference;
 
             if (elementReference == null) {
               return;

--- a/packages/model-viewer/src/three-components/gltf-instance/correlated-scene-graph.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/correlated-scene-graph.ts
@@ -123,19 +123,37 @@ export class CorrelatedSceneGraph {
 
     const defaultMaterial = {name: 'Default'} as Material;
     const defaultReference = {type: 'materials', index: -1} as GLTFReference;
-    if (cloneGLTF.materials == null) {
-      cloneGLTF.materials = [];
-    }
-    defaultReference.index = cloneGLTF.materials.length;
-    cloneGLTF.materials.push(defaultMaterial);
 
     for (let i = 0; i < originalThreeGLTF.scenes.length; i++) {
       this[$parallelTraverseThreeScene](
           originalThreeGLTF.scenes[i],
           cloneThreeGLTF.scenes[i],
           (object: ThreeSceneObject, cloneObject: ThreeSceneObject) => {
-            const elementReference =
+            let elementReference =
                 upstreamCorrelatedSceneGraph.threeObjectMap.get(object);
+
+            if (((object as Mesh).isMesh || (object as Material).isMaterial) &&
+                elementReference == null) {
+              // Checks if default material was allready addded to the gltf.
+              if (cloneGLTF.materials) {
+                const material =
+                    cloneGLTF.materials[cloneGLTF.materials.length - 1];
+                if (material.name === 'Default') {
+                  defaultReference.index = cloneGLTF.materials.length - 1;
+                }
+              }
+
+              // Adds the defaul material if the default material was not added.
+              if (defaultReference.index < 0) {
+                if (cloneGLTF.materials == null) {
+                  cloneGLTF.materials = [];
+                }
+                defaultReference.index = cloneGLTF.materials.length;
+                cloneGLTF.materials.push(defaultMaterial);
+              }
+            }
+
+            elementReference = defaultReference;
 
             if (elementReference == null) {
               return;


### PR DESCRIPTION
Default material was being created even in cases where an object node did have a material (such as a group node)

This is a follow up to #2419 - tested with the same asset to verify that this PR does not cause a regression with the case where the glTF only has the default material.

<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
<!-- Example: Fixes #1234 -->
