### PR TITLE
Move before place

### DIFF
--- a/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
@@ -18,7 +18,6 @@ import {Matrix4, PerspectiveCamera, Vector2, Vector3} from 'three';
 import {ControlsInterface, ControlsMixin} from '../../features/controls.js';
 import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
 import {ARRenderer} from '../../three-components/ARRenderer.js';
-import {SETTLING_TIME} from '../../three-components/Damper.js';
 import {ModelScene} from '../../three-components/ModelScene.js';
 import {Renderer} from '../../three-components/Renderer.js';
 import {waitForEvent} from '../../utilities.js';
@@ -266,22 +265,7 @@ suite('ARRenderer', () => {
         expect(forward.y).to.be.equal(0);
         expect(cameraToHit.cross(forwardProjection)).to.be.closeTo(0, epsilon);
         expect(cameraToHit.dot(forwardProjection)).to.be.lessThan(0);
-      });
-
-      suite('after hit placement', () => {
-        let hitPosition: Vector3;
-
-        setup(async () => {
-          hitPosition = new Vector3(5, -1, 1);
-          await arRenderer.placeModel(hitPosition);
-          // Long enough time to settle at new position.
-          arRenderer.onWebXRFrame(
-              SETTLING_TIME, new MockXRFrame(arRenderer.currentSession!));
-        });
-
-        test('scene has the same orientation', () => {
-          expect(modelScene.yaw).to.be.equal(yaw);
-        });
+        expect(modelScene.yaw).to.be.equal(yaw);
       });
     });
   });

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -103,6 +103,7 @@ export class ARRenderer extends EventDispatcher {
   private frames = 0;
   private initialized = false;
   private oldTarget = new Vector3();
+  private oldFramedFieldOfView = 45;
   private placementComplete = false;
   private isTranslating = false;
   private isRotating = false;
@@ -238,6 +239,7 @@ export class ARRenderer extends EventDispatcher {
     scene.setShadowIntensity(0);
 
     this.oldTarget.copy(scene.getTarget());
+    this.oldFramedFieldOfView = scene.framedFieldOfView;
 
     scene.addEventListener('model-load', this.onUpdateScene);
 
@@ -357,6 +359,7 @@ export class ARRenderer extends EventDispatcher {
       }
       const point = this.oldTarget;
       scene.setTarget(point.x, point.y, point.z);
+      scene.framedFieldOfView = this.oldFramedFieldOfView;
       scene.xrCamera = null;
 
       scene.removeEventListener('model-load', this.onUpdateScene);
@@ -412,17 +415,11 @@ export class ARRenderer extends EventDispatcher {
 
   private updateView(view: XRView) {
     const scene = this.presentedScene!;
+    const xr = this.threeRenderer.xr as any;
 
-    (this.threeRenderer.xr as any).updateCamera(camera);
-    //@ts-ignore
-    const xrCamera = this.threeRenderer.xr.getCamera();
-    scene.xrCamera = xrCamera;
-
-    xrCamera.position.copy(camera.position);
-    xrCamera.quaternion.copy(camera.quaternion);
-    xrCamera.scale.copy(camera.scale);
-
-    const {elements} = xrCamera.matrixWorld;
+    xr.updateCamera(camera);
+    scene.xrCamera = xr.getCamera();
+    const {elements} = scene.getCamera().matrixWorld;
     scene.orientHotspots(Math.atan2(elements[1], elements[5]));
 
     if (!this.initialized) {

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -484,7 +484,7 @@ export class ARRenderer extends EventDispatcher {
     if (location != null) {
       vector3.copy(location).sub(this.presentedScene!.getCamera().position);
       if (vector3.length() > MAX_DISTANCE)
-        location = null;
+        return null;
     }
     return location;
   }
@@ -656,16 +656,11 @@ export class ARRenderer extends EventDispatcher {
           return;
         }
 
-        let hit = null;
-        if (finger.results.length >= 1) {
-          hit = this.getHitPoint(finger.results[0]);
-        }
-
+        const hit = finger.results.length > 0 ?
+            this.getHitPoint(finger.results[0]) :
+            this.getTouchLocation();
         if (hit == null) {
-          hit = this.getTouchLocation();
-          if (hit == null) {
-            return;
-          }
+          return;
         }
 
         this.goalPosition.sub(this.lastDragPosition);

--- a/packages/model-viewer/src/three-components/PlacementBox.ts
+++ b/packages/model-viewer/src/three-components/PlacementBox.ts
@@ -132,6 +132,14 @@ export class PlacementBox extends Mesh {
     return hitResult == null ? null : hitResult.position;
   }
 
+  getExpandedHit(scene: ModelScene, screenX: number, screenY: number): Vector3
+      |null {
+    this.hitPlane.scale.set(1000, 1000, 1000);
+    const hitResult = this.getHit(scene, screenX, screenY);
+    this.hitPlane.scale.set(1, 1, 1);
+    return hitResult;
+  }
+
   /**
    * Offset the height of the box relative to the bottom of the scene. Positive
    * is up, so generally only negative values are used.

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -370,10 +370,10 @@ export class SmoothControls extends EventDispatcher {
 
     const deltaRatio = deltaZoom === 0 ?
         0 :
-        deltaZoom > 0 ? (maximumRadius! - radius) /
-                (Math.log(maximumFieldOfView!) - this.goalLogFov) :
-                        (radius - minimumRadius!) /
-                (this.goalLogFov - Math.log(minimumFieldOfView!));
+        ((deltaZoom > 0 ? maximumRadius! : minimumRadius!) - radius) /
+            (Math.log(
+                 deltaZoom > 0 ? maximumFieldOfView! : minimumFieldOfView!) -
+             this.goalLogFov);
 
     const goalRadius = radius +
         deltaZoom *


### PR DESCRIPTION
Addressing what I hope is the biggest part of #2413, this changes the WebXR UX to allow user interactions all the time, instead of blocking them until the model is placed on the floor/wall. I think this improves the experience quite a bit and makes it less annoying/visible to the user when ARCore is struggling. However, there is not much we can do about ARCore's failures to find especially walls. We could potentially implement something like Scene Viewer's UI here, but that's pretty complicated and has it's own user education issues. We'll go with simple for now, but please add your thoughts to the above-linked discussion. 

Also fixes an existing bug where the zoom was sometimes not where you left it when returning from a WebXR session.