### PR TITLE
Adds a warning for deprecated extension KHR_materials_pbrSpecularGlos…

### DIFF
--- a/packages/model-viewer/src/features/scene-graph/material.ts
+++ b/packages/model-viewer/src/features/scene-graph/material.ts
@@ -55,6 +55,14 @@ export class Material extends ThreeDOMElement implements MaterialInterface {
       return;
     }
 
+    if (gltfMaterial.extensions &&
+        gltfMaterial.extensions['KHR_materials_pbrSpecularGlossiness']) {
+      console.warn(`Material ${gltfMaterial.name} uses a deprecated extension
+          "KHR_materials_pbrSpecularGlossiness", please use
+          "pbrMetallicRoughness" instead.`);
+    }
+
+
     if (gltfMaterial.pbrMetallicRoughness == null) {
       gltfMaterial.pbrMetallicRoughness = {};
     }

--- a/packages/model-viewer/src/features/scene-graph/material.ts
+++ b/packages/model-viewer/src/features/scene-graph/material.ts
@@ -59,7 +59,9 @@ export class Material extends ThreeDOMElement implements MaterialInterface {
         gltfMaterial.extensions['KHR_materials_pbrSpecularGlossiness']) {
       console.warn(`Material ${gltfMaterial.name} uses a deprecated extension
           "KHR_materials_pbrSpecularGlossiness", please use
-          "pbrMetallicRoughness" instead.`);
+          "pbrMetallicRoughness" instead. Specular Glossiness materials are
+          currently supported for rendering, but not for our scene-graph API,
+          nor for auto-generation of USDZ for Quick Look.`);
     }
 
 


### PR DESCRIPTION
…siness

<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
Address issue with #2626
This should have been more obvious, apparently USDZ exporter does not support KHR_materials_pbrSpecularGlossiness
