### PR TITLE
fixed context restoration

### DIFF
--- a/packages/model-viewer/src/features/environment.ts
+++ b/packages/model-viewer/src/features/environment.ts
@@ -28,7 +28,7 @@ const DEFAULT_EXPOSURE = 1.0;
 
 const $currentEnvironmentMap = Symbol('currentEnvironmentMap');
 const $applyEnvironmentMap = Symbol('applyEnvironmentMap');
-const $updateEnvironment = Symbol('updateEnvironment');
+export const $updateEnvironment = Symbol('updateEnvironment');
 const $cancelEnvironmentUpdate = Symbol('cancelEnvironmentUpdate');
 const $onPreload = Symbol('onPreload');
 

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -471,6 +471,10 @@ export class Renderer extends EventDispatcher {
       this.textureUtils.dispose();
     }
 
+    if (this.roughnessMipmapper != null) {
+      this.roughnessMipmapper.dispose();
+    }
+
     if (this.threeRenderer != null) {
       this.threeRenderer.dispose();
     }
@@ -494,8 +498,10 @@ export class Renderer extends EventDispatcher {
   onWebGLContextRestored = () => {
     this.textureUtils?.dispose();
     this.textureUtils = new TextureUtils(this.threeRenderer);
+    this.roughnessMipmapper = new RoughnessMipmapper(this.threeRenderer);
     for (const scene of this.scenes) {
       (scene.element as any)[$updateEnvironment]();
     }
+    this.threeRenderer.shadowMap.needsUpdate = true;
   };
 }

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -16,6 +16,7 @@
 import {ACESFilmicToneMapping, Event, EventDispatcher, GammaEncoding, PCFSoftShadowMap, WebGLRenderer} from 'three';
 import {RoughnessMipmapper} from 'three/examples/jsm/utils/RoughnessMipmapper';
 
+import {$updateEnvironment} from '../features/environment.js';
 import {$canvas, $tick, $updateSize} from '../model-viewer-base.js';
 import {clamp, isDebugMode, resolveDpr} from '../utilities.js';
 
@@ -111,7 +112,6 @@ export class Renderer extends EventDispatcher {
 
     this.canvas3D = document.createElement('canvas');
     this.canvas3D.id = 'webgl-canvas';
-    this.canvas3D.addEventListener('webglcontextlost', this.onWebGLContextLost);
 
     try {
       this.threeRenderer = new WebGLRenderer({
@@ -145,6 +145,10 @@ export class Renderer extends EventDispatcher {
         this.canRender ? new TextureUtils(this.threeRenderer) : null;
     this.roughnessMipmapper = new RoughnessMipmapper(this.threeRenderer);
     CachingGLTFLoader.initializeKTX2Loader(this.threeRenderer);
+
+    this.canvas3D.addEventListener('webglcontextlost', this.onWebGLContextLost);
+    this.canvas3D.addEventListener(
+        'webglcontextrestored', this.onWebGLContextRestored);
 
     this.updateRendererSize();
     this.lastTick = performance.now();
@@ -478,10 +482,20 @@ export class Renderer extends EventDispatcher {
 
     this.canvas3D.removeEventListener(
         'webglcontextlost', this.onWebGLContextLost);
+    this.canvas3D.removeEventListener(
+        'webglcontextrestored', this.onWebGLContextRestored);
   }
 
   onWebGLContextLost = (event: Event) => {
     this.dispatchEvent(
         {type: 'contextlost', sourceEvent: event} as ContextLostEvent);
+  };
+
+  onWebGLContextRestored = () => {
+    this.textureUtils?.dispose();
+    this.textureUtils = new TextureUtils(this.threeRenderer);
+    for (const scene of this.scenes) {
+      (scene.element as any)[$updateEnvironment]();
+    }
   };
 }

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -59,7 +59,6 @@ export class ModelViewerPreview extends ConnectedLitElement {
   @internalProperty() camera: Camera = INITIAL_CAMERA;
   @internalProperty() addHotspotMode = false;
   @internalProperty() gltfUrl?: string;
-  @internalProperty() gltfError: string = '';
   @internalProperty() extraAttributes: any = {};
   @internalProperty() refreshButtonIsReady: boolean = false;
   @internalProperty() bestPractices?: BestPracticesState;
@@ -131,10 +130,7 @@ export class ModelViewerPreview extends ConnectedLitElement {
 
     // Add additional elements, editor specific.
     childElements.push(refreshMobileButton);
-    if (this.gltfError) {
-      childElements.push(html`<div class="ErrorText">Error loading glTF:<br/>${
-          this.gltfError}</div>`);
-    } else if (!hasModel) {
+    if (!hasModel) {
       childElements.push(
           html
           `<div class="HelpText">Drag a glTF or GLB here!<br/><small>And HDRs for lighting</small></div>`);
@@ -154,16 +150,10 @@ export class ModelViewerPreview extends ConnectedLitElement {
               cameraChange: () => {
                 this.onCameraChange();
               },
-              modelVisibility: () => {
-                this.onModelVisible();
-              },
               click: (event: MouseEvent) => {
                 if (this.addHotspotMode) {
                   this.addHotspot(event);
                 }
-              },
-              error: (error: CustomEvent) => {
-                this.gltfError = error.detail;
               }
             },
             childElements)}`;
@@ -182,12 +172,6 @@ export class ModelViewerPreview extends ConnectedLitElement {
     this.resolveLoad();
   }
 
-  private onModelVisible() {
-    if (!this.modelViewer.loaded) {
-      throw new Error('onModelVisible called before mv was loaded');
-    }
-  }
-
   private onCameraChange() {
     reduxStore.dispatch(dispatchCameraIsDirty());
   }
@@ -198,7 +182,8 @@ export class ModelViewerPreview extends ConnectedLitElement {
     const y = event.clientY - rect.top;
     const positionAndNormal = this.modelViewer.positionAndNormalFromPoint(x, y);
     if (!positionAndNormal) {
-      throw new Error('invalid click position');
+      console.log('Click was not on model, no hotspot added.');
+      return;
     }
     reduxStore.dispatch(dispatchAddHotspot({
       name: generateUniqueHotspotName(),


### PR DESCRIPTION
Fixes #782 

This is tricky to test; you have to put a break point in the render loop, then set `window.renderer = this.threeRenderer` to keep a handle. Then you remove the break point and continue and in the console put `window.renderer.forceContextLoss()` and verify the render is gone. Then put `window.renderer.forceContextRestore()` and verify the render is working again (the bug was that the object would show up black instead of lit because our lighting was not getting properly restored). I tried to make an automated test out of this, but for some reason it is not behaving properly.