### PR TITLE
Export JPGs in GLB

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -130,8 +130,7 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       // decide if it should save as JPEG vs PNG. However, TextureLoader sets
       // format based on if the url ends in .jpg, which does not work for an
       // ObjectURL like we're passing here. So, to keep from inflating all JPEGs
-      // to PNGs, we do this hack, and since I don't have a separate three.js
-      // dep in here, I'm setting RGBFormat by number instead of name.
+      // to PNGs, we allow the user of the API to specify the type.
       if (type === 'image/jpeg') {
         texture.format = RGBFormat;
       }

--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -14,7 +14,7 @@
  */
 
 import {property} from 'lit-element';
-import {Euler, MeshStandardMaterial, RepeatWrapping, sRGBEncoding, Texture, TextureLoader} from 'three';
+import {Euler, MeshStandardMaterial, RepeatWrapping, RGBFormat, sRGBEncoding, Texture, TextureLoader} from 'three';
 import {GLTFExporter, GLTFExporterOptions} from 'three/examples/jsm/exporters/GLTFExporter';
 
 import ModelViewerElementBase, {$needsRender, $onModelLoad, $renderer, $scene} from '../model-viewer-base.js';
@@ -53,7 +53,7 @@ export interface SceneGraphInterface {
   scale: string;
   readonly originalGltfJson: GLTF|null;
   exportScene(options?: SceneExportOptions): Promise<Blob>;
-  createTexture(uri: string): Promise<ModelViewerTexture|null>;
+  createTexture(uri: string, type?: string): Promise<ModelViewerTexture|null>;
 }
 
 /**
@@ -113,7 +113,8 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       };
     }
 
-    async createTexture(uri: string): Promise<ModelViewerTexture|null> {
+    async createTexture(uri: string, type: string = 'image/png'):
+        Promise<ModelViewerTexture|null> {
       const currentGLTF = this[$currentGLTF];
       const texture: Texture = await new Promise<Texture>(
           (resolve) => this[$textureLoader].load(uri, resolve));
@@ -125,6 +126,15 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       texture.wrapS = RepeatWrapping;
       texture.wrapT = RepeatWrapping;
       texture.flipY = false;
+      // This hack is because GLTFExporter checks if format is RGB vs RGBA to
+      // decide if it should save as JPEG vs PNG. However, TextureLoader sets
+      // format based on if the url ends in .jpg, which does not work for an
+      // ObjectURL like we're passing here. So, to keep from inflating all JPEGs
+      // to PNGs, we do this hack, and since I don't have a separate three.js
+      // dep in here, I'm setting RGBFormat by number instead of name.
+      if (type === 'image/jpeg') {
+        texture.format = RGBFormat;
+      }
 
       return new ModelViewerTexture(this[$getOnUpdateMethod](), texture);
     }

--- a/packages/space-opera/src/components/materials_panel/materials_panel.ts
+++ b/packages/space-opera/src/components/materials_panel/materials_panel.ts
@@ -31,6 +31,7 @@ import {RGB, RGBA} from '@google/model-viewer/lib/model-viewer';
 import {customElement, html, internalProperty, query} from 'lit-element';
 import * as color from 'ts-closure-library/lib/color/color';  // from //third_party/javascript/closure/color
 
+import {$threeTexture} from '../../../../model-viewer/lib/features/scene-graph/image.js';
 import {TextureInfo} from '../../../../model-viewer/lib/features/scene-graph/texture-info.js';
 import {AlphaMode} from '../../../../model-viewer/lib/three-components/gltf-instance/gltf-2.0.js';
 import {GLTF, TextureInfo as GLTFTextureInfo} from '../../../../model-viewer/lib/three-components/gltf-instance/gltf-defaulted';
@@ -393,15 +394,26 @@ export class MaterialPanel extends ConnectedLitElement {
     }
   }
 
-  async onTextureUpload(uri: string, textureInfo: TextureInfo) {
-    if (this.thumbnailsById.has(uri)) {
+  async onTextureUpload(detail, textureInfo: TextureInfo) {
+    const {url, type} = detail;
+    if (this.thumbnailsById.has(url)) {
       console.log('URL collision! Texture not updated.');
       return;
     }
-    const texture = await getModelViewer()?.createTexture(uri);
+    const texture = await getModelViewer()?.createTexture(url);
     if (texture == null) {
       return;
     }
+    // This hack is because GLTFExporter checks if format is RGB vs RGBA to
+    // decide if it should save as JPEG vs PNG. However, TextureLoader sets
+    // format based on if the url ends in .jpg, which does not work for an
+    // ObjectURL like we're passing here. So, to keep from inflating all JPEGs
+    // to PNGs, we do this hack, and since I don't have a separate three.js dep
+    // in here, I'm setting RGBFormat by number instead of name.
+    if (type === 'image/jpeg') {
+      texture.source[$threeTexture].format = 1022;  // RGBFormat
+    }
+
     textureInfo.setTexture(texture);
     const id = await pushThumbnail(this.thumbnailsById, textureInfo);
     // Trigger async panel update / render

--- a/packages/space-opera/src/components/materials_panel/materials_panel.ts
+++ b/packages/space-opera/src/components/materials_panel/materials_panel.ts
@@ -31,7 +31,6 @@ import {RGB, RGBA} from '@google/model-viewer/lib/model-viewer';
 import {customElement, html, internalProperty, query} from 'lit-element';
 import * as color from 'ts-closure-library/lib/color/color';  // from //third_party/javascript/closure/color
 
-import {$threeTexture} from '../../../../model-viewer/lib/features/scene-graph/image.js';
 import {TextureInfo} from '../../../../model-viewer/lib/features/scene-graph/texture-info.js';
 import {AlphaMode} from '../../../../model-viewer/lib/three-components/gltf-instance/gltf-2.0.js';
 import {GLTF, TextureInfo as GLTFTextureInfo} from '../../../../model-viewer/lib/three-components/gltf-instance/gltf-defaulted';
@@ -401,18 +400,9 @@ export class MaterialPanel extends ConnectedLitElement {
       console.log('URL collision! Texture not updated.');
       return;
     }
-    const texture = await getModelViewer()?.createTexture(url);
+    const texture = await getModelViewer()?.createTexture(url, type);
     if (texture == null) {
       return;
-    }
-    // This hack is because GLTFExporter checks if format is RGB vs RGBA to
-    // decide if it should save as JPEG vs PNG. However, TextureLoader sets
-    // format based on if the url ends in .jpg, which does not work for an
-    // ObjectURL like we're passing here. So, to keep from inflating all JPEGs
-    // to PNGs, we do this hack, and since I don't have a separate three.js dep
-    // in here, I'm setting RGBFormat by number instead of name.
-    if (type === 'image/jpeg') {
-      texture.source[$threeTexture].format = 1022;  // RGBFormat
     }
 
     textureInfo.setTexture(texture);

--- a/packages/space-opera/src/components/materials_panel/materials_panel.ts
+++ b/packages/space-opera/src/components/materials_panel/materials_panel.ts
@@ -43,7 +43,7 @@ import {CheckboxElement} from '../shared/checkbox/checkbox.js';
 import {ColorPicker} from '../shared/color_picker/color_picker.js';
 import {Dropdown} from '../shared/dropdown/dropdown.js';
 import {SliderWithInputElement} from '../shared/slider_with_input/slider_with_input.js';
-import {TexturePicker} from '../shared/texture_picker/texture_picker.js';
+import {FileDetails, TexturePicker} from '../shared/texture_picker/texture_picker.js';
 import {ALPHA_BLEND_MODES} from '../utils/gltf_constants.js';
 import {checkFinite} from '../utils/reducer_utils.js';
 
@@ -394,7 +394,8 @@ export class MaterialPanel extends ConnectedLitElement {
   }
 
   async onTextureUpload(
-      detail, texturePicker: TexturePicker, textureInfo: TextureInfo) {
+      detail: FileDetails, texturePicker: TexturePicker,
+      textureInfo: TextureInfo) {
     const {url, type} = detail;
     if (this.thumbnailsById.has(url)) {
       console.log('URL collision! Texture not updated.');
@@ -426,7 +427,7 @@ export class MaterialPanel extends ConnectedLitElement {
         this.getMaterial().pbrMetallicRoughness.baseColorTexture);
   }
 
-  onBaseColorTextureUpload(event: CustomEvent) {
+  onBaseColorTextureUpload(event: CustomEvent<FileDetails>) {
     this.onTextureUpload(
         event.detail,
         this.baseColorTexturePicker,
@@ -439,7 +440,7 @@ export class MaterialPanel extends ConnectedLitElement {
         this.getMaterial().pbrMetallicRoughness.metallicRoughnessTexture);
   }
 
-  onMetallicRoughnessTextureUpload(event: CustomEvent) {
+  onMetallicRoughnessTextureUpload(event: CustomEvent<FileDetails>) {
     this.onTextureUpload(
         event.detail,
         this.metallicRoughnessTexturePicker,
@@ -451,7 +452,7 @@ export class MaterialPanel extends ConnectedLitElement {
         this.selectedNormalTextureId, this.getMaterial().normalTexture);
   }
 
-  onNormalTextureUpload(event: CustomEvent) {
+  onNormalTextureUpload(event: CustomEvent<FileDetails>) {
     this.onTextureUpload(
         event.detail,
         this.normalTexturePicker,
@@ -463,7 +464,7 @@ export class MaterialPanel extends ConnectedLitElement {
         this.selectedEmissiveTextureId, this.getMaterial().emissiveTexture);
   }
 
-  onEmissiveTextureUpload(event: CustomEvent) {
+  onEmissiveTextureUpload(event: CustomEvent<FileDetails>) {
     this.onTextureUpload(
         event.detail,
         this.emissiveTexturePicker,
@@ -480,7 +481,7 @@ export class MaterialPanel extends ConnectedLitElement {
         this.selectedOcclusionTextureId, this.getMaterial().occlusionTexture);
   }
 
-  onOcclusionTextureUpload(event: CustomEvent) {
+  onOcclusionTextureUpload(event: CustomEvent<FileDetails>) {
     this.onTextureUpload(
         event.detail,
         this.occlusionTexturePicker,

--- a/packages/space-opera/src/components/materials_panel/materials_panel.ts
+++ b/packages/space-opera/src/components/materials_panel/materials_panel.ts
@@ -394,7 +394,8 @@ export class MaterialPanel extends ConnectedLitElement {
     }
   }
 
-  async onTextureUpload(detail, textureInfo: TextureInfo) {
+  async onTextureUpload(
+      detail, texturePicker: TexturePicker, textureInfo: TextureInfo) {
     const {url, type} = detail;
     if (this.thumbnailsById.has(url)) {
       console.log('URL collision! Texture not updated.');
@@ -423,6 +424,7 @@ export class MaterialPanel extends ConnectedLitElement {
       // Trigger async texture_picker update / render
       this.thumbnailUrls = [...this.thumbnailUrls];
       this.thumbnailUrls.push(this.thumbnailsById.get(id)!.objectUrl);
+      texturePicker.selectedIndex = this.thumbnailIds.indexOf(id);
     }
     reduxStore.dispatch(dispatchModelDirty());
     this.dispatchEvent(new CustomEvent('texture-upload-complete'));
@@ -436,7 +438,9 @@ export class MaterialPanel extends ConnectedLitElement {
 
   onBaseColorTextureUpload(event: CustomEvent) {
     this.onTextureUpload(
-        event.detail, this.getMaterial().pbrMetallicRoughness.baseColorTexture);
+        event.detail,
+        this.baseColorTexturePicker,
+        this.getMaterial().pbrMetallicRoughness.baseColorTexture);
   }
 
   onMetallicRoughnessTextureChange() {
@@ -448,6 +452,7 @@ export class MaterialPanel extends ConnectedLitElement {
   onMetallicRoughnessTextureUpload(event: CustomEvent) {
     this.onTextureUpload(
         event.detail,
+        this.metallicRoughnessTexturePicker,
         this.getMaterial().pbrMetallicRoughness.metallicRoughnessTexture);
   }
 
@@ -457,7 +462,10 @@ export class MaterialPanel extends ConnectedLitElement {
   }
 
   onNormalTextureUpload(event: CustomEvent) {
-    this.onTextureUpload(event.detail, this.getMaterial().normalTexture);
+    this.onTextureUpload(
+        event.detail,
+        this.normalTexturePicker,
+        this.getMaterial().normalTexture);
   }
 
   onEmissiveTextureChange() {
@@ -466,7 +474,10 @@ export class MaterialPanel extends ConnectedLitElement {
   }
 
   onEmissiveTextureUpload(event: CustomEvent) {
-    this.onTextureUpload(event.detail, this.getMaterial().emissiveTexture);
+    this.onTextureUpload(
+        event.detail,
+        this.emissiveTexturePicker,
+        this.getMaterial().emissiveTexture);
   }
 
   onEmissiveFactorChanged() {
@@ -480,7 +491,10 @@ export class MaterialPanel extends ConnectedLitElement {
   }
 
   onOcclusionTextureUpload(event: CustomEvent) {
-    this.onTextureUpload(event.detail, this.getMaterial().occlusionTexture);
+    this.onTextureUpload(
+        event.detail,
+        this.occlusionTexturePicker,
+        this.getMaterial().occlusionTexture);
   }
 
   onAlphaModeSelect() {

--- a/packages/space-opera/src/components/shared/texture_picker/texture_picker.ts
+++ b/packages/space-opera/src/components/shared/texture_picker/texture_picker.ts
@@ -30,6 +30,11 @@ import {styles} from './texture_picker.css.js';
 
 const ACCEPT_IMAGE_TYPE = IMAGE_MIME_TYPES.join(',');
 
+export interface FileDetails {
+  url: string;
+  type: string;
+}
+
 /**
  * LitElement for a texture picker which allows user to select one of the
  * texture images presented
@@ -130,7 +135,7 @@ export class TexturePicker extends LitElement {
     }
 
     const url = createSafeObjectURL(files[0]).unsafeUrl;
-    this.dispatchEvent(new CustomEvent(
+    this.dispatchEvent(new CustomEvent<FileDetails>(
         'texture-uploaded', {detail: {url, type: files[0].type}}));
   }
 }

--- a/packages/space-opera/src/components/shared/texture_picker/texture_picker.ts
+++ b/packages/space-opera/src/components/shared/texture_picker/texture_picker.ts
@@ -130,7 +130,8 @@ export class TexturePicker extends LitElement {
     }
 
     const url = createSafeObjectURL(files[0]).unsafeUrl;
-    this.dispatchEvent(new CustomEvent('texture-uploaded', {detail: url}));
+    this.dispatchEvent(new CustomEvent(
+        'texture-uploaded', {detail: {url, type: files[0].type}}));
   }
 }
 

--- a/packages/space-opera/src/test/materials_panel/materials_panel_test.ts
+++ b/packages/space-opera/src/test/materials_panel/materials_panel_test.ts
@@ -36,8 +36,8 @@ async function checkUpload(
 
   expect(imageList.children.length).toEqual(listLength + 1);
 
-  texturePicker.dispatchEvent(
-      new CustomEvent('texture-uploaded', {detail: TEXTURE_PATH}));
+  texturePicker.dispatchEvent(new CustomEvent(
+      'texture-uploaded', {detail: {url: TEXTURE_PATH, type: 'image/png'}}));
   await waitForEvent(panel, 'texture-upload-complete');
   await panel.updateComplete;
 

--- a/packages/space-opera/src/test/shared/texture_picker/texture_picker_test.ts
+++ b/packages/space-opera/src/test/shared/texture_picker/texture_picker_test.ts
@@ -81,7 +81,9 @@ describe('texture picker test', () => {
     expect(eventListenerSpy).toHaveBeenCalledTimes(1);
     const eventListenerArguments = eventListenerSpy.calls.first().args;
     expect(eventListenerArguments.length).toBe(1);
-    expect(eventListenerArguments[0].detail).toBeInstanceOf(String);
+    const {url, type} = eventListenerArguments[0].detail;
+    expect(url).toBeInstanceOf(String);
+    expect(type).toEqual('image/jpeg');
   });
 
   it('dispatches an event with undefined selectedIndex on null texture click',

--- a/packages/space-opera/src/test/shared/texture_picker/texture_picker_test.ts
+++ b/packages/space-opera/src/test/shared/texture_picker/texture_picker_test.ts
@@ -21,7 +21,7 @@ import '../../../components/shared/texture_picker/texture_picker.js';
 import {IconButton} from '@material/mwc-icon-button';
 
 import {FileModalElement} from '../../../components/file_modal/file_modal.js';
-import {TexturePicker} from '../../../components/shared/texture_picker/texture_picker.js';
+import {FileDetails, TexturePicker} from '../../../components/shared/texture_picker/texture_picker.js';
 import {createSafeObjectURL} from '../../../components/utils/create_object_url.js';
 import {generatePngBlob} from '../../utils/test_utils.js';
 
@@ -81,7 +81,7 @@ describe('texture picker test', () => {
     expect(eventListenerSpy).toHaveBeenCalledTimes(1);
     const eventListenerArguments = eventListenerSpy.calls.first().args;
     expect(eventListenerArguments.length).toBe(1);
-    const {url, type} = eventListenerArguments[0].detail;
+    const {url, type} = eventListenerArguments[0].detail as FileDetails;
     expect(url).toBeInstanceOf(String);
     expect(type).toEqual('image/jpeg');
   });


### PR DESCRIPTION
Fixes #2668 

Turns out this was properly exporting GLBs with the same output format as input format (for JPG and PNG), but would convert any separately uploaded texture from JPG to PNG. I also fixed a small bug where uploaded textures were not updating the editor's UX properly.