### PR TITLE
Remove checks about event nature in onPointerMove

### DIFF
--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -497,7 +497,7 @@ export class SmoothControls extends EventDispatcher {
     return (event: E) => {
       fn(event);
 
-      if (event.cancelable) {
+      if (this.touchMode !== null && event.cancelable) {
         event.preventDefault();
       }
     };

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -196,7 +196,7 @@ export class SmoothControls extends EventDispatcher {
       }
       element.removeEventListener('keydown', this.onKeyDown);
       element.removeEventListener('touchstart', this.onTouchStart);
-      element.removeEventListener('touchmove', this.onTouchMove);
+      element.removeEventListener('touchmove', this._onTouchMove);
 
       self.removeEventListener('mouseup', this.onMouseUp);
       self.removeEventListener('touchend', this.onTouchEnd);
@@ -549,8 +549,8 @@ export class SmoothControls extends EventDispatcher {
   private set touchMode(touchMode: TouchMode) {
     this._touchMode = touchMode;
     const {element} = this;
-    element.removeEventListener('touchmove', this.onTouchMove);
-    if (touchMode) {
+    element.removeEventListener('touchmove', this._onTouchMove);
+    if (touchMode !== null) {
       this._onTouchMove = (event) => {
         touchMode(event);
 
@@ -558,14 +558,11 @@ export class SmoothControls extends EventDispatcher {
           event.preventDefault();
         }
       };
-      element.addEventListener('touchmove', this.onTouchMove, {passive: false});
+      element.addEventListener(
+          'touchmove', this._onTouchMove, {passive: false});
     } else {
       self.removeEventListener('touchend', this.onTouchEnd);
     }
-  }
-
-  private get onTouchMove() {
-    return this._onTouchMove;
   }
 
   private handleSinglePointerMove(pointer: Pointer) {
@@ -662,7 +659,7 @@ export class SmoothControls extends EventDispatcher {
         const {touches} = event;
         if (touches.length === 0) {
           const {element} = this;
-          element.removeEventListener('touchmove', this.onTouchMove);
+          element.removeEventListener('touchmove', this._onTouchMove);
           self.removeEventListener('touchend', this.onTouchEnd);
         } else {
           this.onTouchChange(event);

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -658,9 +658,7 @@ export class SmoothControls extends EventDispatcher {
       (event: TouchEvent) => {
         const {touches} = event;
         if (touches.length === 0) {
-          const {element} = this;
-          element.removeEventListener('touchmove', this._onTouchMove);
-          self.removeEventListener('touchend', this.onTouchEnd);
+          this.touchMode = null;
         } else {
           this.onTouchChange(event);
         }

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -146,6 +146,7 @@ export class SmoothControls extends EventDispatcher {
   };
   private lastTouches!: TouchList;
   private touchDecided = false;
+  private touchMoveFixed = false;
 
   constructor(
       readonly camera: PerspectiveCamera, readonly element: HTMLElement) {
@@ -164,6 +165,12 @@ export class SmoothControls extends EventDispatcher {
 
   enableInteraction() {
     if (this._interactionEnabled === false) {
+      // https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
+      if (!this.touchMoveFixed) {
+        this.touchMoveFixed = true;
+        self.addEventListener('touchmove', function() {}, {passive: false});
+      }
+
       const {element} = this;
       element.addEventListener('mousedown', this.onMouseDown);
       if (!this._disableZoom) {


### PR DESCRIPTION
As discussed in #2687, I refactored the mouse/touch handling in SmoothControls to get rid of the checks on `event.type` and `touchMode` in `onPointerMove`. Instead, the correct switch case is determined in `touchstart` and `mousedown` and assigned directly as a move handler.

I remained faithful to the old behavior with two exceptions described below, which I consider welcome consequences of a more elegant approach.

1.  After zooming with 2 touches, lifting one touch will resume rotation. I consider this a significant UX improvement as the old behavior was a big nuisance for me personally.
2. Zooming during a scroll is now disallowed. Previously, it was allowed to initiate a zoom interaction with two touches even when the first touch interaction was determined to be a scroll. 
On Android Chrome, this resulted in both the page and the model itself zooming simultaneously. To reproduce this, pan upwards on a model and then zoom on the model using two fingers.

So far I have tested the [Disable Zoom](https://modelviewer.dev/examples/stagingandcameras/#disableZoom), [Panning ](https://modelviewer.dev/examples/stagingandcameras/#panning)and [Turn Skybox](https://modelviewer.dev/examples/stagingandcameras/#turnSkybox) examples on Win10 Chrome, Win10 Firefox and Android Chrome and all behave as expected.

This PR also serves as a partial fix to #2684 because instead of being added when controls are enabled and persisting indefinitely, the `mouseup` and `touchend` listeners on window only last for the duration of the interaction.

