### PR TITLE
Editor UX polish

### DIFF
--- a/packages/space-opera/src/components/camera_settings/camera_settings.ts
+++ b/packages/space-opera/src/components/camera_settings/camera_settings.ts
@@ -33,7 +33,7 @@ import {ModelViewerConfig, State} from '../../types.js';
 import {dispatchAutoRotate, dispatchCameraTarget, dispatchSaveCameraOrbit, getConfig} from '../config/reducer.js';
 import {Vector3D} from '../config/types.js';
 import {ConnectedLitElement} from '../connected_lit_element/connected_lit_element.js';
-import {getModel, getUpdatedModelViewer} from '../model_viewer_preview/reducer.js';
+import {getModel, getModelViewer, getUpdatedModelViewer} from '../model_viewer_preview/reducer.js';
 import {CheckboxElement} from '../shared/checkbox/checkbox.js';
 import {DraggableInput} from '../shared/draggable_input/draggable_input.js';
 import {styles as draggableInputRowStyles} from '../shared/draggable_input/draggable_input_row.css.js';
@@ -177,9 +177,10 @@ export class CameraSettings extends ConnectedLitElement {
     reduxStore.dispatch(dispatchSaveCameraOrbit(undefined));
   }
 
-  async onCameraOrbitEditorChange() {
+  onCameraOrbitEditorChange() {
     reduxStore.dispatch(
         dispatchSaveCameraOrbit(this.cameraOrbitEditor.currentOrbit));
+    getModelViewer().jumpCameraToGoal();
   }
 
   onCameraTargetChange(newValue: Vector3D) {

--- a/packages/space-opera/src/components/camera_settings/camera_settings.ts
+++ b/packages/space-opera/src/components/camera_settings/camera_settings.ts
@@ -107,6 +107,10 @@ export class CameraTargetInput extends ConnectedLitElement {
     this.change(target);
   }
 
+  resetTarget() {
+    reduxStore.dispatch(dispatchCameraTarget());
+  }
+
   render() {
     if (!this.target) {
       return html`<div class="note">Waiting for camera target...</div>`;
@@ -121,6 +125,9 @@ export class CameraTargetInput extends ConnectedLitElement {
         <me-draggable-input id="camera-target-z" value=${
         this.target.z} min=-9999 max=9999 dragStepSize=0.01 @change=${
         this.onInputChange} innerLabel="Z"></me-draggable-input>
+        <mwc-icon-button class="RevertButton" style="align-self: center; margin-top: -10px;" id="revert" icon="undo"
+        title="Reset target" @click=${this.resetTarget}>
+        </mwc-icon-button>
         `;
   }
 }
@@ -214,7 +221,7 @@ export class CameraSettings extends ConnectedLitElement {
               @click=${this.onSaveCameraOrbit}>
               Save current as initial
             </mwc-button>
-            <mwc-icon-button class="RevertButton" style="align-self: center; margin-top: 10px;" id="revert-metallic-roughness-texture" icon="undo"
+            <mwc-icon-button class="RevertButton" style="align-self: center; margin-top: 10px;" id="revert" icon="undo"
             title="Reset initial camera" @click=${this.resetInitialCamera}>
             </mwc-icon-button>
           </div>

--- a/packages/space-opera/src/components/camera_settings/components/zoom.ts
+++ b/packages/space-opera/src/components/camera_settings/components/zoom.ts
@@ -50,6 +50,12 @@ export class ZooomLimits extends ConnectedLitElement {
     reduxStore.dispatch(dispatchSetMinZoom(this.minFov, this.minRadius));
   }
 
+  dispatchResetMin() {
+    this.minRadius = undefined;
+    this.minFov = undefined;
+    reduxStore.dispatch(dispatchSetMinZoom());
+  }
+
   render() {
     return html`
     <me-checkbox
@@ -62,6 +68,8 @@ export class ZooomLimits extends ConnectedLitElement {
         this.enabled ? html`
       <mwc-button id="set-min-button" class="SetButton" unelevated 
       @click="${this.dispatchMin}">Set Min</mwc-button>
+      <mwc-button id="set-min-button" class="SetButton" unelevated icon="undo"
+      @click="${this.dispatchResetMin}">Reset Min</mwc-button>
     ` :
                        html``}
 `;

--- a/packages/space-opera/src/components/config/reducer.ts
+++ b/packages/space-opera/src/components/config/reducer.ts
@@ -194,9 +194,11 @@ export function configReducer(
       return {...state, autoRotate: action.payload};
     case SET_CAMERA_TARGET:
       const target = action.payload;
-      const cameraTarget = `${roundToDigits(target.x, DIGITS)}m ${
-          roundToDigits(
-              target.y, DIGITS)}m ${roundToDigits(target.z, DIGITS)}m`;
+      const cameraTarget = target == null ?
+          undefined :
+          `${roundToDigits(target.x, DIGITS)}m ${
+              roundToDigits(
+                  target.y, DIGITS)}m ${roundToDigits(target.z, DIGITS)}m`;
       return {...state, cameraTarget};
     case SAVE_CAMERA_ORBIT:
       const orbit = action.payload;

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -109,7 +109,8 @@ export class ModelViewerPreview extends ConnectedLitElement {
       ...this.config,
       src: this.gltfUrl,
       // Always enable camera controls for preview
-      cameraControls: true
+      cameraControls: true,
+      interactionPrompt: 'none'
     };
 
     const hasModel = !!editedConfig.src;

--- a/packages/space-opera/src/components/utils/render_model_viewer.ts
+++ b/packages/space-opera/src/components/utils/render_model_viewer.ts
@@ -108,7 +108,7 @@ export function renderModelViewer(
         exposure=${ifDefined(config.exposure)}
         poster=${ifDefined(config.poster)}
         reveal=${ifDefined(config.reveal)}
-        interaction-prompt="none"
+        interaction-prompt=${ifDefined(config.interactionPrompt)}
         shadow-intensity=${ifDefined(config.shadowIntensity)}
         shadow-softness=${ifDefined(config.shadowSoftness)}
         camera-target=${ifDefined(config.cameraTarget)}

--- a/packages/space-opera/src/components/utils/render_model_viewer.ts
+++ b/packages/space-opera/src/components/utils/render_model_viewer.ts
@@ -108,6 +108,7 @@ export function renderModelViewer(
         exposure=${ifDefined(config.exposure)}
         poster=${ifDefined(config.poster)}
         reveal=${ifDefined(config.reveal)}
+        interaction-prompt="none"
         shadow-intensity=${ifDefined(config.shadowIntensity)}
         shadow-softness=${ifDefined(config.shadowSoftness)}
         camera-target=${ifDefined(config.cameraTarget)}

--- a/packages/space-opera/src/types.ts
+++ b/packages/space-opera/src/types.ts
@@ -36,6 +36,7 @@ export interface ModelViewerConfig {
   exposure?: number;  // Environment for hdr environment, used as ibl intensity
   poster?: string;    // Display an image before model finished loading
   reveal?: string;    // Controls when the model should be revealed
+  interactionPrompt?: string;
   shadowIntensity?: number;
   shadowSoftness?: number;
   maxCameraOrbit?: string;


### PR DESCRIPTION
This fixes several small bugs: the yaw/pitch inputs weren't  updating properly, the reset min zoom button  was accidentally removed, the config values were left on auto instead of undefined, and  the  target didn't  have a revert button. I also turned off the  interaction prompt, since I  find that very annoying when  using the editor. 
