### PR TITLE
Set touch-action style

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -494,6 +494,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       if (changedProperties.has('touchAction')) {
         const touchAction = this.touchAction;
         controls.applyOptions({touchAction});
+        controls.setTouchActionStyle();
       }
 
       if (changedProperties.has('orbitSensitivity')) {

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -432,7 +432,7 @@ export class SmoothControls extends EventDispatcher {
     this.moveCamera();
   }
 
-  private setTouchActionStyle() {
+  setTouchActionStyle() {
     const {style} = this.element;
 
     if (this._interactionEnabled) {


### PR DESCRIPTION
As per discussion #2726, sets the `touch-action` CSS property based on the model-viewer's `touch-action`, `disable-zoom` and `camera-controls` properties.
