### PR TITLE
Fix iOS zoom

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -494,7 +494,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       if (changedProperties.has('touchAction')) {
         const touchAction = this.touchAction;
         controls.applyOptions({touchAction});
-        controls.setTouchActionStyle();
+        controls.updateTouchActionStyle();
       }
 
       if (changedProperties.has('orbitSensitivity')) {

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -176,7 +176,7 @@ export class SmoothControls extends EventDispatcher {
       this.element.style.cursor = 'grab';
       this._interactionEnabled = true;
 
-      this.setTouchActionStyle();
+      this.updateTouchActionStyle();
     }
   }
 
@@ -200,7 +200,7 @@ export class SmoothControls extends EventDispatcher {
       this.touchMode = null;
       this._interactionEnabled = false;
 
-      this.setTouchActionStyle();
+      this.updateTouchActionStyle();
     }
   }
 
@@ -220,7 +220,7 @@ export class SmoothControls extends EventDispatcher {
         this.element.addEventListener('wheel', this.onWheel);
       }
 
-      this.setTouchActionStyle();
+      this.updateTouchActionStyle();
     }
   }
 
@@ -432,7 +432,7 @@ export class SmoothControls extends EventDispatcher {
     this.moveCamera();
   }
 
-  setTouchActionStyle() {
+  updateTouchActionStyle() {
     const {style} = this.element;
 
     if (this._interactionEnabled) {

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -440,7 +440,7 @@ export class SmoothControls extends EventDispatcher {
     if (this._interactionEnabled) {
       const {touchAction} = this._options;
       if (this._disableZoom && touchAction !== 'none') {
-        style.touchAction = `${touchAction} pinch-zoom`;
+        style.touchAction = 'manipulation';
       } else {
         style.touchAction = touchAction!;
       }


### PR DESCRIPTION
Based on the [logs (or lack thereof) produced on iOS](https://github.com/google/model-viewer/issues/2729#issuecomment-907334260) on branch `lucadalli:debug-ios-zoom`, it seems that if two touches happen at the same time, iOS only fires one `touchstart` event 😵🤯

The previous implementation was banking on the fact that each touch fires a `touchstart` event.
These changes should hopefully fix the issue.