### PR TITLE
fixed renderer-harness

### DIFF
--- a/packages/render-fidelity-tools/src/artifact-creator.ts
+++ b/packages/render-fidelity-tools/src/artifact-creator.ts
@@ -73,7 +73,8 @@ export class ArtifactCreator {
         join(outputDirectory, scenarioName, goldens[modelViewerIndex].file),
         modelViewerGolden);
 
-    const modelViewerGoldenImage = pngjs.PNG.sync.read(modelViewerGolden).data;
+    const modelViewerGoldenImage =
+        new Uint8ClampedArray(pngjs.PNG.sync.read(modelViewerGolden).data);
 
     for (const golden of goldens) {
       if (golden.name === 'model-viewer' ||
@@ -98,7 +99,8 @@ export class ArtifactCreator {
       await fs.writeFile(
           join(outputDirectory, scenarioName, golden.file), candidateGolden);
 
-      const candidateGoldenImage = pngjs.PNG.sync.read(candidateGolden).data;
+      const candidateGoldenImage =
+          new Uint8ClampedArray(pngjs.PNG.sync.read(candidateGolden).data);
       const analysisResult = await this.analyze(
           modelViewerGoldenImage, candidateGoldenImage, dimensions, false);
       analysisResults.push(analysisResult);
@@ -134,7 +136,8 @@ export class ArtifactCreator {
       throw new Error(`❌ Model-viewer's screenshot of ${
           scenarioName} is not captured correctly (value is null).`);
     }
-    const screenshotImage = pngjs.PNG.sync.read(screenshot as Buffer).data;
+    const screenshotImage =
+        new Uint8ClampedArray(pngjs.PNG.sync.read(screenshot as Buffer).data);
 
     const modelViewerIndex = 0;
     const modelViewerGoldenPath = join(
@@ -146,7 +149,8 @@ export class ArtifactCreator {
       throw new Error(`❌ Failed to read model-viewer's ${
           scenarioName} golden! Error message: ${error.message}`);
     }
-    const modelViewerGoldenImage = pngjs.PNG.sync.read(modelViewerGolden).data;
+    const modelViewerGoldenImage =
+        new Uint8ClampedArray(pngjs.PNG.sync.read(modelViewerGolden).data);
 
     const result =
         await this.analyze(screenshotImage, modelViewerGoldenImage, dimensions);
@@ -232,7 +236,8 @@ export class ArtifactCreator {
   }
 
   protected async analyze(
-      candidateImage: Buffer, goldenImage: Buffer, dimensions: Dimensions,
+      candidateImage: Uint8ClampedArray, goldenImage: Uint8ClampedArray,
+      dimensions: Dimensions,
       semiTransparentCheck: boolean = true): Promise<ImageComparisonAnalysis> {
     const imageDimensions = {
       width: dimensions.width * DEVICE_PIXEL_RATIO,

--- a/packages/render-fidelity-tools/src/artifact-creator.ts
+++ b/packages/render-fidelity-tools/src/artifact-creator.ts
@@ -152,8 +152,8 @@ export class ArtifactCreator {
     const modelViewerGoldenImage =
         new Uint8ClampedArray(pngjs.PNG.sync.read(modelViewerGolden).data);
 
-    const result =
-        await this.analyze(screenshotImage, modelViewerGoldenImage, dimensions);
+    const result = await this.analyze(
+        screenshotImage, modelViewerGoldenImage, dimensions, false);
 
     const rmsInDb = toDecibel(result.rmsDistanceRatio);
 

--- a/packages/render-fidelity-tools/src/common.ts
+++ b/packages/render-fidelity-tools/src/common.ts
@@ -28,7 +28,7 @@ export const DEVICE_PIXEL_RATIO: number = 2;
 
 // use this threshold to do automatic fidelity test for model-viewer. any
 // scenario whose rms value (in dB) is bigger than the threshold will fail.
-export const FIDELITY_TEST_THRESHOLD: number = -19;
+export const FIDELITY_TEST_THRESHOLD: number = -22;
 
 export interface FidelityRegressionResults {
   results: Array<ImageComparisonAnalysis>;

--- a/packages/render-fidelity-tools/src/common.ts
+++ b/packages/render-fidelity-tools/src/common.ts
@@ -30,9 +30,6 @@ export const DEVICE_PIXEL_RATIO: number = 2;
 // scenario whose rms value (in dB) is bigger than the threshold will fail.
 export const FIDELITY_TEST_THRESHOLD: number = -19;
 
-export const WARNING_MESSAGE: string =
-    'Candidate image is semi-transparent, probably the screenshot was taken before the poster faded away!';
-
 export interface FidelityRegressionResults {
   results: Array<ImageComparisonAnalysis>;
   warnings: Array<string>;
@@ -222,7 +219,7 @@ export class ImageComparator {
     };
   }
 
-  analyze(checkSemiTransparent: boolean = true): ImageComparisonResults {
+  analyze(): ImageComparisonResults {
     const {candidateImage, goldenImage} = this;
     const {width, height} = this.dimensions;
 
@@ -231,18 +228,6 @@ export class ImageComparator {
     if (candidateImage.length != goldenImage.length) {
       throw new Error(`Image sizes do not match (candidate: ${
           candidateImage.length}, golden: ${goldenImage.length})`);
-    }
-
-    // Sometimes the screenshot is taken when poster has not faded away, and
-    // when the golden image's background (use top left pixel to represent) is
-    // transparent while the candidate(mode-viewer) image is not, it's
-    // definitely that case
-    if (checkSemiTransparent) {
-      const candidateTopLeftAlpha = candidateImage[3];
-      const goldenTopLeftAlpha = goldenImage[3];
-      if (goldenTopLeftAlpha != candidateTopLeftAlpha) {
-        throw new Error(WARNING_MESSAGE);
-      }
     }
 
     let modelPixelCount = 0;

--- a/packages/render-fidelity-tools/src/common.ts
+++ b/packages/render-fidelity-tools/src/common.ts
@@ -126,11 +126,6 @@ export interface ImageComparisonConfig {
   scenarios: Array<ScenarioConfig>;
 }
 
-export interface ComparableImage {
-  [index: number]: number;
-  length: number;
-}
-
 export interface AnalysisOptions {
   generateVisuals: boolean;
 }
@@ -139,16 +134,17 @@ export class ImageComparator {
   protected imagePixels: number;
 
   constructor(
-      protected candidateImage: ComparableImage,
-      protected goldenImage: ComparableImage, readonly dimensions: Dimensions) {
+      protected candidateImage: Uint8ClampedArray,
+      protected goldenImage: Uint8ClampedArray,
+      readonly dimensions: Dimensions) {
     const {width, height} = dimensions;
 
     this.imagePixels = width * height;
   }
 
   protected drawPixel(
-      image: ComparableImage, position: number, r: number, g: number, b: number,
-      a: number = 255) {
+      image: Uint8ClampedArray, position: number, r: number, g: number,
+      b: number, a: number = 255) {
     image[position + 0] = r;
     image[position + 1] = g;
     image[position + 2] = b;

--- a/packages/render-fidelity-tools/src/components/renderer-harness.ts
+++ b/packages/render-fidelity-tools/src/components/renderer-harness.ts
@@ -63,17 +63,20 @@ export class RendererConfiguration extends LitElement {
     }
 
     if (changedProperties.has('scenarioName') ||
-        changedProperties.has('config')) {
+        changedProperties.has('configUrl')) {
       if (this.scenarioName == null || this.config == null) {
         this.scenario = null;
       } else {
         this.scenario =
             (new ConfigReader(this.config)).scenarioConfig(this.scenarioName);
-        this.dispatchEvent(new CustomEvent(
-            'scenario-change', {detail: {scenario: this.scenario}}));
       }
 
       const previousScenarioName = changedProperties.get('scenarioName');
+
+      if (previousScenarioName !== this.scenarioName) {
+        this.dispatchEvent(new CustomEvent(
+            'scenario-change', {detail: {scenario: this.scenario}}));
+      }
 
       if (previousScenarioName != null && this.scenarioName != null) {
         const url = new URL(window.location.toString());

--- a/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
+++ b/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
@@ -76,15 +76,18 @@ screenshotCreator.fidelityTest(scenarioWhitelist)
       const scenarioCount = fidelityRegressionPassedCount +
           fidelityRegressionErrorCount + fidelityRegressionWarningCount
 
-      console.log(`Fidelity regression test on ${
-          scenarioCount} scenarios finished. Model-Viewer passed ${
-          fidelityRegressionPassedCount} scenarios ✅, failed ${
-          fidelityRegressionErrorCount} scenarios ❌, ${
-          fidelityRegressionWarningCount} senarios passed with warings❗️. (Uses ${
+      console.log(`\nFidelity regression test on ${
+          scenarioCount} scenarios finished. (Uses ${
           FIDELITY_TEST_THRESHOLD} dB as threshold)`);
+      console.log(`Passed ${fidelityRegressionPassedCount} scenarios ✅`);
+      if (fidelityRegressionErrorCount > 0) {
+        console.log(`Failed ${fidelityRegressionErrorCount} scenarios ❌`);
+      }
 
       if (fidelityRegressionWarningCount > 0) {
-        console.log('🔍 Logging warning scenarios: ');
+        console.log(
+            `Warnings on ${fidelityRegressionWarningCount} senarios❗️`);
+        console.log('\n🔍 Logging warning scenarios: ');
         for (const warning of fidelityRegressionWarnings) {
           console.log(warning);
         }
@@ -94,7 +97,7 @@ screenshotCreator.fidelityTest(scenarioWhitelist)
       }
 
       if (fidelityRegressionErrorCount > 0) {
-        console.log('🔍 Logging failed scenarios: ');
+        console.log('\n🔍 Logging failed scenarios: ');
         for (const error of fidelityRegressionErrors) {
           console.log(error);
         }
@@ -106,12 +109,12 @@ screenshotCreator.fidelityTest(scenarioWhitelist)
       const compareRendererPassCount = comparedRenderResult.length;
       const compareRendererErrorCount = compareRendererErrors.length;
 
-      console.log(`Compare Renderers on ${scenarioCount} scenarios finished. ${
-          compareRendererPassCount} scenarios passed ✅, ${
-          compareRendererErrorCount} scenarios failed ❌`);
-
       if (compareRendererErrorCount > 0) {
-        console.log('🔍 Logging failed scenarios: ');
+        console.log(
+            `\nCompare Renderers on ${scenarioCount} scenarios finished. ${
+                compareRendererPassCount} scenarios passed ✅, ${
+                compareRendererErrorCount} scenarios failed ❌`);
+        console.log('\n🔍 Logging failed scenarios: ');
         for (const error of compareRendererErrors) {
           console.log(error);
         }

--- a/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
+++ b/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
@@ -23,7 +23,7 @@ const require = module.createRequire(import.meta.url);
 const core = require('@actions/core');
 
 import {ArtifactCreator} from '../artifact-creator.js';
-import {FIDELITY_TEST_THRESHOLD} from '../common.js';
+import {FIDELITY_TEST_THRESHOLD, toDecibel} from '../common.js';
 
 const configPath = resolve(process.argv[2]);
 const rootDirectory = resolve(dirname(configPath));
@@ -82,6 +82,12 @@ screenshotCreator.fidelityTest(scenarioWhitelist)
       console.log(`Passed ${fidelityRegressionPassedCount} scenarios ✅`);
       if (fidelityRegressionErrorCount > 0) {
         console.log(`Failed ${fidelityRegressionErrorCount} scenarios ❌`);
+      } else {
+        let maxError = -Infinity;
+        for (const result of fidelityRegressionResults) {
+          maxError = Math.max(maxError, toDecibel(result.rmsDistanceRatio));
+        }
+        console.log('Worst scenario RMS:', maxError, 'dB');
       }
 
       if (fidelityRegressionWarningCount > 0) {

--- a/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
+++ b/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
@@ -62,7 +62,7 @@
             })
           })
         });
-      });
+      }, {once: true});
       
       modelViewer.style.width = `${scenario.dimensions.width}px`;
       modelViewer.style.height = `${scenario.dimensions.height}px`;

--- a/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
+++ b/packages/render-fidelity-tools/test/renderers/model-viewer/index.html
@@ -26,7 +26,10 @@
 
   <style>
     body { margin: 0; }
-    model-viewer { --progress-bar-color: transparent; }
+    model-viewer { 
+      --progress-bar-color: transparent;
+      --poster-color: rgba(255,255,255,0);
+    }
   </style>
 </head>
 <body>
@@ -44,6 +47,8 @@
     customElements.get("model-viewer").minimumRenderScale = 1;
   </script>
   <script>
+    const harness = document.getElementById('harness');
+    const modelViewer = document.getElementById('modelViewer');
     harness.addEventListener('scenario-change', () => {
       const {scenario} = harness;
       modelViewer.addEventListener('poster-dismissed', () => {
@@ -57,9 +62,8 @@
             })
           })
         });
-      }, {once: true});
+      });
       
-      modelViewer.style = "--poster-color: rgba(255,255,255,0)";
       modelViewer.style.width = `${scenario.dimensions.width}px`;
       modelViewer.style.height = `${scenario.dimensions.height}px`;
 


### PR DESCRIPTION
We've had a lot of weird flakiness in our fidelity tests that we didn't understand, so we just turned the flake into a warning so we could ignore it. However, the fidelity tests actually catch quite a few nasty regressions, so I'd rather they were all functional. I found a few sketchy things that I've fixed here. I was only able to get a consistent repro on a single model locally, and this fixed that, but we'll see if the CI agrees.

And it looks like it does! Seems the catch for the poster issue must have been somehow wrong, but there's no poster problem now and once that check was removed everything seems to be working well.