### PR TITLE
Update controls-related examples

### DIFF
--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -269,15 +269,15 @@
   }, true);
 
   modelViewer.addEventListener('touchstart', (event) => {
-    startX = event.touches[0].clientX;
-    startY = event.touches[0].clientY;
-    panning = event.touches.length === 2;
+    startX = event.targetTouches[0].clientX;
+    startY = event.targetTouches[0].clientY;
+    panning = event.targetTouches.length === 2;
     if (!panning)
       return;
 
-    const {touches} = event;
-    lastX = 0.5 * (touches[0].clientX + touches[1].clientX);
-    lastY = 0.5 * (touches[0].clientY + touches[1].clientY);
+    const {targetTouches} = event;
+    lastX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
+    lastY = 0.5 * (targetTouches[0].clientY + targetTouches[1].clientY);
     startPan();
   }, true);
 
@@ -290,12 +290,12 @@
   }, true);
 
   modelViewer.addEventListener('touchmove', (event) => {
-    if (!panning || event.touches.length !== 2)
+    if (!panning || event.targetTouches.length !== 2)
       return;
 
-    const {touches} = event;
-    const thisX = 0.5 * (touches[0].clientX + touches[1].clientX);
-    const thisY = 0.5 * (touches[0].clientY + touches[1].clientY);
+    const {targetTouches} = event;
+    const thisX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
+    const thisY = 0.5 * (targetTouches[0].clientY + targetTouches[1].clientY);
     movePan(thisX, thisY);
   }, true);
 
@@ -304,7 +304,7 @@
   }, true);
   
   self.addEventListener('touchend', (event) => {
-    if (event.touches.length === 0) {
+    if (event.targetTouches.length === 0) {
       recenter(event.changedTouches[0]);
     }
   }, true);
@@ -369,12 +369,12 @@
   }, true);
 
   modelViewer.addEventListener('touchstart', (event) => {
-    panning = event.touches.length === 2;
+    panning = event.targetTouches.length === 2;
     if (!panning)
       return;
 
-    const {touches} = event;
-    lastX = 0.5 * (touches[0].clientX + touches[1].clientX);
+    const {targetTouches} = event;
+    lastX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
     startPan();
   }, true);
 
@@ -387,11 +387,11 @@
   }, true);
 
   modelViewer.addEventListener('touchmove', (event) => {
-    if (!panning || event.touches.length !== 2)
+    if (!panning || event.targetTouches.length !== 2)
       return;
 
-    const {touches} = event;
-    const thisX = 0.5 * (touches[0].clientX + touches[1].clientX);
+    const {targetTouches} = event;
+    const thisX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
     updatePan(thisX);
   }, true);
 

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -269,13 +269,13 @@
   }, true);
 
   modelViewer.addEventListener('touchstart', (event) => {
-    startX = event.targetTouches[0].clientX;
-    startY = event.targetTouches[0].clientY;
-    panning = event.targetTouches.length === 2;
+    const {targetTouches, touches} = event;
+    startX = targetTouches[0].clientX;
+    startY = targetTouches[0].clientY;
+    panning = targetTouches.length === 2 && targetTouches.length === touches.length;
     if (!panning)
       return;
 
-    const {targetTouches} = event;
     lastX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
     lastY = 0.5 * (targetTouches[0].clientY + targetTouches[1].clientY);
     startPan();
@@ -369,11 +369,11 @@
   }, true);
 
   modelViewer.addEventListener('touchstart', (event) => {
-    panning = event.targetTouches.length === 2;
+    const {targetTouches, touches} = event;
+    panning = targetTouches.length === 2 && targetTouches.length === touches.length;
     if (!panning)
       return;
 
-    const {targetTouches} = event;
     lastX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
     startPan();
   }, true);

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -247,8 +247,8 @@
         Math.abs(pointer.clientY - startY) > tapDistance)
       return;
     const rect = modelViewer.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
+    const x = pointer.clientX - rect.left;
+    const y = pointer.clientY - rect.top;
     const hit = modelViewer.positionAndNormalFromPoint(x, y);
     modelViewer.cameraTarget =
         hit == null ? 'auto auto auto' : hit.position.toString();
@@ -306,6 +306,10 @@
   modelViewer.addEventListener('touchend', (event) => {
     if (event.targetTouches.length === 0) {
       recenter(event.changedTouches[0]);
+
+      if (event.cancelable) {
+        event.preventDefault();
+      }
     }
   }, true);
 })();

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -303,7 +303,7 @@
     recenter(event);
   }, true);
   
-  self.addEventListener('touchend', (event) => {
+  modelViewer.addEventListener('touchend', (event) => {
     if (event.targetTouches.length === 0) {
       recenter(event.changedTouches[0]);
     }
@@ -399,7 +399,7 @@
     panning = false;
   }, true);
   
-  self.addEventListener('touchend', (event) => {
+  modelViewer.addEventListener('touchend', (event) => {
     panning = false;
   }, true);
 </script>


### PR DESCRIPTION
Updates relevant examples to be in line with the changes to SmoothControls.
Favors simplicity over completeness.
For example: after swiping vertically on the [panning example](http://localhost:8080/packages/modelviewer.dev/examples/stagingandcameras/#panning) to scroll, it is possible to add a second touch and pan while scrolling. SmoothControls has guards against zoom while scrolling but an unsavory amount of redundancy is necessary to port them to the examples.
To avoid this, we should consider adding an API to allow for user-defined `touchModes`.