### PR TITLE
Restore initial material

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -149,8 +149,7 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
           return;
         }
 
-        await this[$model]![$switchVariant](
-            variantName == 'null' ? null : variantName!);
+        await this[$model]![$switchVariant](variantName!);
         this[$needsRender]();
         this.dispatchEvent(new CustomEvent('variant-applied'));
       }

--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -47,7 +47,7 @@ interface SceneExportOptions {
 
 export interface SceneGraphInterface {
   readonly model?: Model;
-  variantName: string|undefined;
+  variantName: string|null|undefined;
   readonly availableVariants: Array<string>;
   orientation: string;
   scale: string;
@@ -149,8 +149,10 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
           return;
         }
 
-        await this[$model]![$switchVariant](variantName!);
+        await this[$model]![$switchVariant](
+            variantName! == 'null' ? null : variantName!);
         this[$needsRender]();
+        this.dispatchEvent(new CustomEvent('variant-applied'));
       }
 
       if (changedProperties.has('orientation') ||

--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -47,7 +47,7 @@ interface SceneExportOptions {
 
 export interface SceneGraphInterface {
   readonly model?: Model;
-  variantName: string|null|undefined;
+  variantName: string|null;
   readonly availableVariants: Array<string>;
   orientation: string;
   scale: string;
@@ -70,7 +70,7 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
     private[$originalGltfJson]: GLTF|null = null;
 
     @property({type: String, attribute: 'variant-name'})
-    variantName: string|undefined = undefined;
+    variantName: string|null = null;
 
     @property({type: String, attribute: 'orientation'})
     orientation: string = '0 0 0';
@@ -150,7 +150,7 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
         }
 
         await this[$model]![$switchVariant](
-            variantName! == 'null' ? null : variantName!);
+            variantName == 'null' ? null : variantName!);
         this[$needsRender]();
         this.dispatchEvent(new CustomEvent('variant-applied'));
       }

--- a/packages/model-viewer/src/features/scene-graph/model.ts
+++ b/packages/model-viewer/src/features/scene-graph/model.ts
@@ -161,7 +161,7 @@ export class Model implements ModelInterface {
    * Switches model variant to the variant name provided, or switches to
    * default/initial materials if 'null' is provided.
    */
-  async[$switchVariant](variantName: string) {
+  async[$switchVariant](variantName: string|null) {
     const promises = new Array<Promise<ThreeMaterial|ThreeMaterial[]|null>>();
     for (const primitive of this[$primitives]) {
       promises.push(primitive.enableVariant(variantName));

--- a/packages/model-viewer/src/features/scene-graph/model.ts
+++ b/packages/model-viewer/src/features/scene-graph/model.ts
@@ -161,7 +161,7 @@ export class Model implements ModelInterface {
    * Switches model variant to the variant name provided, or switches to
    * default/initial materials if 'null' is provided.
    */
-  async[$switchVariant](variantName: string|null) {
+  async[$switchVariant](variantName: string) {
     const promises = new Array<Promise<ThreeMaterial|ThreeMaterial[]|null>>();
     for (const primitive of this[$primitives]) {
       promises.push(primitive.enableVariant(variantName));

--- a/packages/model-viewer/src/features/scene-graph/model.ts
+++ b/packages/model-viewer/src/features/scene-graph/model.ts
@@ -157,7 +157,11 @@ export class Model implements ModelInterface {
     return this[$materials];
   }
 
-  async[$switchVariant](variantName: string) {
+  /**
+   * Switches model variant to the variant name provided, or switches to
+   * default/initial materials if 'null' is provided.
+   */
+  async[$switchVariant](variantName: string|null) {
     const promises = new Array<Promise<ThreeMaterial|ThreeMaterial[]|null>>();
     for (const primitive of this[$primitives]) {
       promises.push(primitive.enableVariant(variantName));

--- a/packages/model-viewer/src/features/scene-graph/nodes/primitive-node.ts
+++ b/packages/model-viewer/src/features/scene-graph/nodes/primitive-node.ts
@@ -154,9 +154,9 @@ export class PrimitiveNode extends Node {
     return this.mesh.material;
   }
 
-  async enableVariant(name: string):
-      Promise<ThreeMaterial|ThreeMaterial[]|null> {
-    if (name === 'null') {
+  async enableVariant(name: string|
+                      null): Promise<ThreeMaterial|ThreeMaterial[]|null> {
+    if (name == null) {
       return await this.setActiveMaterial(this[$defaultMaterialIdx]);
     }
     if (this[$variantInfo] != null) {

--- a/packages/model-viewer/src/features/scene-graph/nodes/primitive-node.ts
+++ b/packages/model-viewer/src/features/scene-graph/nodes/primitive-node.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Material as ThreeMaterial, Mesh, SkinnedMesh} from 'three';
+import {Material as ThreeMaterial, Mesh, MeshStandardMaterial, SkinnedMesh} from 'three';
 import {GLTFReference} from 'three/examples/jsm/loaders/GLTFLoader';
 
 import {CorrelatedSceneGraph} from '../../../three-components/gltf-instance/correlated-scene-graph.js';
@@ -30,6 +30,7 @@ export const $correlatedSceneGraph = Symbol('correlatedSceneGraph');
 export const $prepareVariantsForExport = Symbol('prepareVariantsForExport');
 export const $switchVariant = Symbol('switchVariant');
 export const $children = Symbol('children');
+export const $defaultMaterialIdx = Symbol('defaultMaterialIdx');
 
 // Defines the base level node methods and data.
 export class Node {
@@ -47,13 +48,23 @@ export class PrimitiveNode extends Node {
   private[$materials] = new Map<number, Material>();
   // Maps variant name to material index.
   private[$variantInfo]: Map<string, {material: Material, index: number}>;
-  // List of child nodes.
+  private[$defaultMaterialIdx]: number;
+
   constructor(
       mesh: Mesh, mvMaterials: Material[],
       correlatedSceneGraph: CorrelatedSceneGraph) {
     super(mesh.name);
     this[$mesh] = mesh;
     const {gltf, threeGLTF} = correlatedSceneGraph;
+    // Captures the primitive's default material.
+    const materialRef = correlatedSceneGraph.threeObjectMap.get(
+        mesh.material as MeshStandardMaterial);
+    if (materialRef != null) {
+      this[$defaultMaterialIdx] = materialRef.index;
+    } else {
+      console.error(
+          `Primitive (${mesh.name}) missing default material reference.`);
+    }
 
     // TODO: Remove the associationKey 'work arounds' after fixing Three.js
     // associations. This is needed for now because Three.js does not create
@@ -143,8 +154,11 @@ export class PrimitiveNode extends Node {
     return this.mesh.material;
   }
 
-  async enableVariant(name: string):
-      Promise<ThreeMaterial|ThreeMaterial[]|null> {
+  async enableVariant(name: string|
+                      null): Promise<ThreeMaterial|ThreeMaterial[]|null> {
+    if (name == null) {
+      return await this.setActiveMaterial(this[$defaultMaterialIdx]);
+    }
     if (this[$variantInfo] != null) {
       const material = this[$variantInfo].get(name);
       if (material != null) {

--- a/packages/model-viewer/src/features/scene-graph/nodes/primitive-node.ts
+++ b/packages/model-viewer/src/features/scene-graph/nodes/primitive-node.ts
@@ -154,9 +154,9 @@ export class PrimitiveNode extends Node {
     return this.mesh.material;
   }
 
-  async enableVariant(name: string|
-                      null): Promise<ThreeMaterial|ThreeMaterial[]|null> {
-    if (name == null) {
+  async enableVariant(name: string):
+      Promise<ThreeMaterial|ThreeMaterial[]|null> {
+    if (name === 'null') {
       return await this.setActiveMaterial(this[$defaultMaterialIdx]);
     }
     if (this[$variantInfo] != null) {

--- a/packages/model-viewer/src/features/scene-graph/nodes/primitive-node.ts
+++ b/packages/model-viewer/src/features/scene-graph/nodes/primitive-node.ts
@@ -56,7 +56,7 @@ export class PrimitiveNode extends Node {
     super(mesh.name);
     this[$mesh] = mesh;
     const {gltf, threeGLTF} = correlatedSceneGraph;
-    // Captures the primitive's default material.
+    // Captures the primitive's initial material.
     const materialRef = correlatedSceneGraph.threeObjectMap.get(
         mesh.material as MeshStandardMaterial);
     if (materialRef != null) {

--- a/packages/model-viewer/src/test/features/scene-graph-spec.ts
+++ b/packages/model-viewer/src/test/features/scene-graph-spec.ts
@@ -93,7 +93,6 @@ suite('ModelViewerElementBase with SceneGraphMixin', () => {
           `Setting varianName to null results in primitive
            reverting to default/initial material`,
           async () => {
-            // let defaultIndex = 0;
             let primitiveNode: PrimitiveNode|null = null
             // Finds the first primitive with material 0 assigned.
             for (const primitive of element.model![$primitives]) {

--- a/packages/model-viewer/src/test/features/scene-graph/nodes/primitive-node-spec.ts
+++ b/packages/model-viewer/src/test/features/scene-graph/nodes/primitive-node-spec.ts
@@ -97,7 +97,8 @@ suite('scene-graph/model/mesh-primitives', () => {
       const materials = new Array<MeshStandardMaterial>();
       for (const primitive of primitives) {
         materials.push(
-            primitive.enableVariant('Yellow Yellow') as MeshStandardMaterial);
+            await primitive.enableVariant('Yellow Yellow') as
+            MeshStandardMaterial);
       }
       expect(materials).to.not.be.empty;
       expect(materials.find((material: MeshStandardMaterial) => {
@@ -110,7 +111,8 @@ suite('scene-graph/model/mesh-primitives', () => {
       let materials = new Array<MeshStandardMaterial>();
       for (const primitive of primitives) {
         materials.push(
-            primitive.enableVariant('Yellow Yellow') as MeshStandardMaterial);
+            await primitive.enableVariant('Yellow Yellow') as
+            MeshStandardMaterial);
       }
       expect(materials.find((material: MeshStandardMaterial) => {
         return material.name === 'yellow';
@@ -119,11 +121,25 @@ suite('scene-graph/model/mesh-primitives', () => {
       materials = new Array<MeshStandardMaterial>();
       for (const primitive of primitives) {
         materials.push(
-            primitive.enableVariant('Purple Yellow') as MeshStandardMaterial);
+            await primitive.enableVariant('Purple Yellow') as
+            MeshStandardMaterial);
       }
       expect(materials.find((material: MeshStandardMaterial) => {
         return material.name === 'purple';
       })).to.not.be.null;
+    });
+
+    test('Primitive switches to default material', async () => {
+      const primitive = findPrimitivesWithVariant(model, 'Purple Yellow')![0];
+
+      // Gets current material.
+      const initialMaterial = await primitive.enableVariant('Purple Yellow');
+      // Switches to variant.
+      const variantMaterial = await primitive.enableVariant('Yellow Red');
+      expect(initialMaterial).to.not.equal(variantMaterial)
+      // Switches to default material.
+      const resetMaterial = await primitive.enableVariant(null);
+      expect(resetMaterial).to.equal(initialMaterial);
     });
   });
 

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -867,8 +867,8 @@
     "Attributes": [
       {
         "name": "variant-name",
-        "htmlName": "variant-name",
-        "description": "Selects a model variant by name. Note selecting for variant name 'null' reverts to the initial material.",
+        "htmlName": "variantName",
+        "description": "Selects a model variant by name, valid variant names include all names defined in the glTF file, plus the name 'null'. Note selecting for variant name 'null' reverts to the initial/default material.",
         "links": [
           "<a href=\"../examples/scenegraph/#variants\">Related examples</a>"
         ]
@@ -905,14 +905,6 @@
         "description": "This property reports an array of strings, corresponding to variants in the loaded model that can be selected with <span class='attribute'>variant-name</span>.",
         "links": [
           "<a href=\"../examples/scenegraph/#variants\">Related examples</a>"
-        ]
-      },
-      {
-        "name": "variantName",
-        "htmlName": "variantName",
-        "description": "Corresponding property of the attribute <code>variant-name</code>.",
-        "links": [
-          "<a href=\"../docs/index.html#entrydocs-scenegraph-attributes-variant-name\">See <code>variant-name</code></a>"
         ]
       },
       {

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -868,7 +868,7 @@
       {
         "name": "variant-name",
         "htmlName": "variantName",
-        "description": "Selects a model variant by name, valid variant names include all names defined in the glTF file, plus the name 'null'. Note selecting for variant name 'null' reverts to the initial/default material.",
+        "description": "Selects a model variant by name.",
         "links": [
           "<a href=\"../examples/scenegraph/#variants\">Related examples</a>"
         ]

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -867,8 +867,8 @@
     "Attributes": [
       {
         "name": "variant-name",
-        "htmlName": "variantName",
-        "description": "Selects a model variant by name.",
+        "htmlName": "variant-name",
+        "description": "Selects a model variant by name. Note selecting for variant name 'null' reverts to the initial material.",
         "links": [
           "<a href=\"../examples/scenegraph/#variants\">Related examples</a>"
         ]
@@ -905,6 +905,14 @@
         "description": "This property reports an array of strings, corresponding to variants in the loaded model that can be selected with <span class='attribute'>variant-name</span>.",
         "links": [
           "<a href=\"../examples/scenegraph/#variants\">Related examples</a>"
+        ]
+      },
+      {
+        "name": "variantName",
+        "htmlName": "variantName",
+        "description": "Corresponding property of the attribute <code>variant-name</code>.",
+        "links": [
+          "<a href=\"../docs/index.html#entrydocs-scenegraph-attributes-variant-name\">See <code>variant-name</code></a>"
         ]
       },
       {

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -95,15 +95,15 @@ modelViewerVariants.addEventListener('load', () => {
     option.textContent = name;
     select.appendChild(option);
   }
-
+  // Adds a default option.
   const option = document.createElement('option');
-    option.value = 'null';
-    option.textContent = 'reset';
+    option.value = 'default';
+    option.textContent = 'Default';
     select.appendChild(option);
 });
 
 select.addEventListener('input', (event) => {
-  modelViewerVariants.variantName = event.target.value;
+  modelViewerVariants.variantName = event.target.value === 'default' ? null : event.target.value;
 });
 </script>
             </template>

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -54,10 +54,10 @@ button {
   </style>
 </head>
 <body>
-<div class="examples-page">  
+<div class="examples-page">
   <div class="sidebar" id="sidenav"></div>
   <div id="toggle"></div>
-  
+
   <div class="examples-container">
     <div class="sample">
       <div id="variants" class="demo"></div>
@@ -73,7 +73,8 @@ button {
             one using the <code>variantName</code> attribute. This is similar
             functionality to the lower-level scene-graph API below, but in that
             case it is up to you to choose the right texture URL, rather than
-            having that information stored in the GLB. </p>
+            having that information stored in the GLB. <i>Note: setting <code>variantName</code>
+            to <code>null</code> reverts to the initial material.</i></p>
           </div>
           <example-snippet stamp-to="variants" highlight-as="html">
             <template>
@@ -94,6 +95,11 @@ modelViewerVariants.addEventListener('load', () => {
     option.textContent = name;
     select.appendChild(option);
   }
+
+  const option = document.createElement('option');
+    option.value = 'null';
+    option.textContent = 'reset';
+    select.appendChild(option);
 });
 
 select.addEventListener('input', (event) => {
@@ -137,8 +143,8 @@ select.addEventListener('input', (event) => {
     <div>Pitch: <input id="pitch" value="0" size="3" class="number"> degrees</div>
     <div>Yaw: <input id="yaw" value="0" size="3" class="number"> degrees</div>
     <div>
-      Scale: X: <input id="x" value="1" size="3" class="number">, 
-      Y: <input id="y" value="1" size="3" class="number">, 
+      Scale: X: <input id="x" value="1" size="3" class="number">,
+      Y: <input id="y" value="1" size="3" class="number">,
       Z: <input id="z" value="1" size="3" class="number">
     </div>
     <button id="frame">Update Framing</button>
@@ -282,7 +288,7 @@ modelViewerParameters.addEventListener("load", (ev) => {
     material.pbrMetallicRoughness.setMetallicFactor(event.target.value);
     metalnessDisplay.textContent = event.target.value;
   });
-  
+
   document.querySelector('#roughness').addEventListener('input', (event) => {
     material.pbrMetallicRoughness.setRoughnessFactor(event.target.value);
     roughnessDisplay.textContent = event.target.value;
@@ -341,7 +347,7 @@ modelViewerTexture.addEventListener("load", (ev) => {
   document.querySelector('#diffuse').addEventListener('input', (event) => {
     applyPBRTexture('baseColorTexture', event);
   });
-  
+
   document.querySelector('#metallicRoughness').addEventListener('input', (event) => {
     applyPBRTexture('metallicRoughnessTexture', event);
   });
@@ -408,11 +414,11 @@ modelViewerTexture.addEventListener("load", () => {
   document.querySelector('#normals').addEventListener('input', (event) => {
     createAndApplyTexture('normalTexture', event);
   });
-  
+
   document.querySelector('#occlusion').addEventListener('input', (event) => {
     createAndApplyTexture('occlusionTexture', event);
   });
-  
+
   document.querySelector('#emission').addEventListener('input', (event) => {
     createAndApplyTexture('emissiveTexture', event);
   });
@@ -467,7 +473,7 @@ modelViewerTexture.addEventListener("load", () => {
       let texture = await modelViewerTexture.createTexture(event.target.value);
       // Applies the new texture to the specified channel.
       material[channel].setTexture(texture);
-    } 
+    }
   }
 
   document.querySelector('#normals2').addEventListener('input', (event) => {


### PR DESCRIPTION
Allows passing 'null' to enableVariant() API in order to switch the material back its initial setting.
