### PR TITLE
Fix editor export

### DIFF
--- a/packages/space-opera/editor/index.html
+++ b/packages/space-opera/editor/index.html
@@ -148,7 +148,6 @@
         </me-tabbed-panel>
         <me-tabbed-panel icon="create">
           <me-export-panel header="true"></me-export-panel>
-          <me-transformation-controls></me-transformation-controls>
           <me-ibl-selector></me-ibl-selector>
           <me-animation-controls></me-animation-controls>
           <me-hotspot-panel></me-hotspot-panel>

--- a/packages/space-opera/editor/index.html
+++ b/packages/space-opera/editor/index.html
@@ -147,13 +147,13 @@
           </div>
         </me-tabbed-panel>
         <me-tabbed-panel icon="create">
-          <me-export-panel header="true"></me-export-panel>
+          <me-export-panel header></me-export-panel>
           <me-ibl-selector></me-ibl-selector>
           <me-animation-controls></me-animation-controls>
           <me-hotspot-panel></me-hotspot-panel>
         </me-tabbed-panel>
         <me-tabbed-panel icon="photo_camera">
-          <me-export-panel header="true"></me-export-panel>
+          <me-export-panel header></me-export-panel>
           <me-camera-settings></me-camera-settings>
         </me-tabbed-panel>
         <me-tabbed-panel icon="color_lens">

--- a/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
@@ -320,7 +320,6 @@ export class ImportCard extends LitElement {
         value="${DEFAULT_POSTER_HEIGHT}">
       </me-slider-with-input>
     </me-section-row>
-    <me-export-zip-button id="export-zip" style="display: block; margin-top: 10px;"></me-export-zip-button>
     `;
   }
 }

--- a/packages/space-opera/src/components/model_viewer_snippet/model_viewer_snippet.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/model_viewer_snippet.ts
@@ -116,6 +116,7 @@ export class ExportPanel extends ConnectedLitElement {
 <me-expandable-tab tabName="File Manager" .open=${true}>
   <div slot="content">
     <me-import-card></me-import-card>
+    <me-export-zip-button id="export-zip" style="display: block; margin-top: 10px;"></me-export-zip-button>
   </div>
 </me-expandable-tab>
 <me-expandable-tab tabName="Mobile View" .open=${true}>

--- a/packages/space-opera/src/components/model_viewer_snippet/model_viewer_snippet.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/model_viewer_snippet.ts
@@ -45,7 +45,7 @@ import {applyRelativeFilePaths, getExtraAttributes} from './reducer.js';
  */
 @customElement('me-export-panel')
 export class ExportPanel extends ConnectedLitElement {
-  @property({type: String}) header = '';
+  @property({type: Boolean}) header = false;
 
   @internalProperty() config: ModelViewerConfig = {};
   @internalProperty() arConfig: ArConfigState = {};
@@ -88,7 +88,7 @@ export class ExportPanel extends ConnectedLitElement {
     const snippet = renderModelViewer(
         editedConfig, editedArConfig, this.extraAttributes, {}, childElements);
 
-    if (this.header === 'true') {
+    if (this.header === true) {
       return html`
 <me-expandable-tab tabName="&lt;model-viewer&gt; snippet" 
   .open=${true} .sticky=${false} 

--- a/packages/space-opera/src/components/model_viewer_snippet/model_viewer_snippet.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/model_viewer_snippet.ts
@@ -91,7 +91,7 @@ export class ExportPanel extends ConnectedLitElement {
     if (this.header === 'true') {
       return html`
 <me-expandable-tab tabName="&lt;model-viewer&gt; snippet" 
-  .open=${true} .sticky=${true} 
+  .open=${true} .sticky=${false} 
   .copyFunction=${this.snippetCopyToClipboard.bind(this)}>
   <div slot="content">
     <snippet-viewer id="snippet-header" .renderedSnippet=${snippet}>
@@ -103,7 +103,7 @@ export class ExportPanel extends ConnectedLitElement {
     // on import/export tab
     return html`
 <me-expandable-tab tabName="&lt;model-viewer&gt; snippet" 
-  .open=${true} .sticky=${true} 
+  .open=${true} .sticky=${false} 
   .copyFunction=${this.snippetCopyToClipboard.bind(this)}>
   <div slot="content">
     <snippet-viewer id="snippet-header" .renderedSnippet=${snippet}>

--- a/packages/space-opera/src/components/shared/expandable_content/expandable_section.css.ts
+++ b/packages/space-opera/src/components/shared/expandable_content/expandable_section.css.ts
@@ -37,5 +37,6 @@ export const styles: CSSResult = css`
 
 .sticky[open] {
   background-color: #202124;  /* GOOGLE_GREY_900 */
+  padding: 0 20px;
 }
 `;


### PR DESCRIPTION
Fixes #2768 / #2767

I must have moved an element when I was refactoring  that I shouldn't have. I also made the snippet non-sticky, which makes the editor much more usable on mobile.

I was  surprised to find there was no test  for this, but I  tried adding one and now  I think I know why. When adding a  test for the snippet, the download button is part of  that, which imports `JSZip`, a commonJS module with a default export. It all works with rollup, but Karma chokes on it  with a  pretty baffling error message. I  tried a bunch of things, but could not get  it to resolve the import, so I'm punting on that test for now. 