### PR TITLE
default editor to neutral lighting

### DIFF
--- a/packages/space-opera/src/components/ibl_selector/ibl_selector.ts
+++ b/packages/space-opera/src/components/ibl_selector/ibl_selector.ts
@@ -80,17 +80,14 @@ export class IblSelector extends ConnectedLitElement {
     const dropdownElement = event.target as Dropdown;
     // Polymer dropdown emits an deselect event before selection, we need to
     // filter that out
-    if (dropdownElement.selectedItem &&
-        dropdownElement.selectedItem.getAttribute('value') !==
-            this.config.environmentImage) {
-      reduxStore.dispatch(dispatchEnvrionmentImage(
-          dropdownElement.selectedItem.getAttribute('value') || undefined));
+    const value = dropdownElement.selectedItem.getAttribute('value');
+    if (value !== this.config.environmentImage) {
+      reduxStore.dispatch(dispatchEnvrionmentImage(value || undefined));
       // dropdown value equals null when "Default" is selected
-      if (dropdownElement.selectedItem.getAttribute('value') === null) {
+      if (value === null) {
         reduxStore.dispatch(dispatchSetEnvironmentName(undefined));
       } else {
-        const envImageList =
-            dropdownElement.selectedItem.getAttribute('value')?.split('/');
+        const envImageList = value.split('/');
         const envImageName = envImageList![envImageList!.length - 1];
         reduxStore.dispatch(dispatchSetEnvironmentName(envImageName));
       }
@@ -135,11 +132,12 @@ export class IblSelector extends ConnectedLitElement {
   // TODO: On snippet input if IBL is defined, select the
   // correct option from the dropdown.
   render() {
-    const selectedIndex = this.config.environmentImage ?
-        this.environmentImages.findIndex(
-            (image) => image.uri === this.config.environmentImage) +
-            1 :
-        0;  // 0 is the default state
+    const value = this.config.environmentImage;
+    const selectedIndex = value === 'neutral' ?
+        0 :
+        value == null ?
+        1 :
+        2 + this.environmentImages.findIndex((image) => image.uri === value);
     return html`
       <me-expandable-tab tabName="Lighting" .open=${true}>
         <div slot="content">
@@ -150,6 +148,7 @@ export class IblSelector extends ConnectedLitElement {
               selectedIndex=${selectedIndex}
               style="align-self: center; width: 70%;"
               @select=${this.onSelectEnvironmentImage}>
+              <paper-item value="neutral">Neutral</paper-item>
               <paper-item>Default</paper-item>
               ${
         this.environmentImages.map(

--- a/packages/space-opera/src/test/ibl_selector/ibl_selector_test.ts
+++ b/packages/space-opera/src/test/ibl_selector/ibl_selector_test.ts
@@ -142,9 +142,16 @@ describe('ibl selector test', () => {
 
        // Click on the Default item in dropdown unsets environment image.
        const noneItem =
-           dropdown.querySelectorAll('paper-item')[0] as HTMLElement;
+           dropdown.querySelectorAll('paper-item')[1] as HTMLElement;
        noneItem.click();
        expect(getConfig(reduxStore.getState()).environmentImage)
            .not.toBeDefined();
+
+       // Click on the Default item in dropdown unsets environment image.
+       const neutralItem =
+           dropdown.querySelectorAll('paper-item')[0] as HTMLElement;
+       neutralItem.click();
+       expect(getConfig(reduxStore.getState()).environmentImage)
+           .toBe('neutral');
      });
 });

--- a/packages/space-opera/src/types.ts
+++ b/packages/space-opera/src/types.ts
@@ -65,9 +65,9 @@ interface UIState {
 }
 
 export interface RelativeFilePathsState {
-  modelName?: string|undefined;
-  environmentName?: string|undefined;
-  posterName: string|undefined;
+  modelName?: string;
+  environmentName?: string;
+  posterName: string;
 }
 
 export interface EnvironmentState {
@@ -124,10 +124,15 @@ export const INITIAL_STATE: State = {
     modelViewerSnippet: {
       arConfig: {ar: true, arModes: 'webxr scene-viewer quick-look'},
       bestPractices: {progressBar: true, arButton: true, arPrompt: true},
-      config: {cameraControls: true, shadowIntensity: 1},
+      config: {
+        cameraControls: true,
+        shadowIntensity: 1,
+        environmentImage: 'neutral'
+      },
       poster: {height: 512, mimeType: 'image/webp'},
       hotspots: [],
-      relativeFilePaths: {posterName: 'poster.webp'},
+      relativeFilePaths:
+          {posterName: 'poster.webp', environmentName: 'neutral'},
       extraAttributes: {},
     },
   },


### PR DESCRIPTION
Now neutral lighting is available in the editor, and we're default to it as well. We don't change the MV default to avoid breaking changes, but the purpose of  the editor is to be opinionated and choose what we think is best for most users. And we can change it whenever we want without anything being a breaking change. 