### PR TITLE
fixed editor download regression

### DIFF
--- a/packages/space-opera/src/components/model_viewer_snippet/components/download_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/download_button.ts
@@ -108,7 +108,8 @@ async function prepareZipArchive(
   zip.file(glb.filename, glb.blob);
 
   // check if legal envrionment url
-  if (config.environmentImage) {
+  if (config.environmentImage != null &&
+      config.environmentImage !== 'neutral') {
     const response = await fetch(config.environmentImage);
     if (!response.ok) {
       throw new Error(`Failed to fetch url ${config.environmentImage}`);


### PR DESCRIPTION
Fixes #2810 / #2791

We really need some automated end-to-end regression tests, which means we need to figure out the module resolution issue on JSZip and Jasmine. 