### PR TITLE
Return intersected object to manage mouse events 

### DIFF
--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -34,7 +34,7 @@ const worldToModelNormal = new Matrix3();
 export declare interface AnnotationInterface {
   updateHotspot(config: HotspotConfiguration): void;
   positionAndNormalFromPoint(pixelX: number, pixelY: number):
-      {position: Vector3D, normal: Vector3D}|null
+    {position: Vector3D, normal: Vector3D, object?: any }|null
 }
 
 /**
@@ -132,9 +132,12 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
      * model-viewer element. The position and normal are returned as strings in
      * the format suitable for putting in a hotspot's data-position and
      * data-normal attributes. If the mesh is not hit, the result is null.
+     * 
+     * The third return value is the entire 3D object intersected at the pixel coordinates.
+     * This is usefull to apply material changes on mouse events (hover/click).
      */
     positionAndNormalFromPoint(pixelX: number, pixelY: number):
-        {position: Vector3D, normal: Vector3D}|null {
+      {position: Vector3D, normal: Vector3D, object?: any }|null {
       const scene = this[$scene];
       const {width, height, target} = scene;
       pixelPosition.set(pixelX / width, pixelY / height)
@@ -154,7 +157,7 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       const normal =
           toVector3D(hit.normal.applyNormalMatrix(worldToModelNormal));
 
-      return {position: position, normal: normal};
+      return {position: position, normal: normal, object: hit.object };
     }
 
     private[$addHotspot](node: Node) {

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -622,9 +622,12 @@ export class ModelScene extends Scene {
    * This method returns the world position and model-space normal of the point
    * on the mesh corresponding to the input pixel coordinates given relative to
    * the model-viewer element. If the mesh is not hit, the result is null.
+   * 
+   * The third return value is the entire 3D object intersected at the pixel coordinates.
+   * This is usefull to apply material changes on mouse events (hover/click).
    */
   positionAndNormalFromPoint(pixelPosition: Vector2, object: Object3D = this):
-      {position: Vector3, normal: Vector3}|null {
+    {position: Vector3, normal: Vector3, object?: any }|null {
     raycaster.setFromCamera(pixelPosition, this.getCamera());
     const hits = raycaster.intersectObject(object, true);
 
@@ -640,7 +643,7 @@ export class ModelScene extends Scene {
     hit.face.normal.applyNormalMatrix(
         new Matrix3().getNormalMatrix(hit.object.matrixWorld));
 
-    return {position: hit.point, normal: hit.face.normal};
+    return {position: hit.point, normal: hit.face.normal, object: hit.object };
   }
 
   /**


### PR DESCRIPTION
### Reference Discussion: # 2702

I added the intersected object to the return of the positionAndNormalFromPoint functions. Within this object I would like to provide the possibility to manage the logic of materials or base colors changing on click or mouse-over events outside the model-viewer library.



