### PR TITLE
Work  around Safari  PMREM corruption

### DIFF
--- a/packages/model-viewer/src/features/environment.ts
+++ b/packages/model-viewer/src/features/environment.ts
@@ -143,10 +143,8 @@ export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
         if (skybox != null) {
           // When using the same environment and skybox, use the environment as
           // it gives HDR filtering.
-          this[$scene].background = (skybox as any).userData.url ===
-                  (environmentMap as any).userData.url ?
-              environmentMap :
-              skybox;
+          this[$scene].background =
+              skybox.name === environmentMap.name ? environmentMap : skybox;
         } else {
           this[$scene].background = null;
         }

--- a/packages/model-viewer/src/features/environment.ts
+++ b/packages/model-viewer/src/features/environment.ts
@@ -140,19 +140,18 @@ export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
                   resolve(await texturesLoad);
                 });
 
-        const environment = environmentMap.texture;
         if (skybox != null) {
           // When using the same environment and skybox, use the environment as
           // it gives HDR filtering.
           this[$scene].background = (skybox as any).userData.url ===
-                  (environment as any).userData.url ?
-              environment :
+                  (environmentMap as any).userData.url ?
+              environmentMap :
               skybox;
         } else {
           this[$scene].background = null;
         }
 
-        this[$applyEnvironmentMap](environmentMap.texture);
+        this[$applyEnvironmentMap](environmentMap);
         this[$scene].dispatchEvent({type: 'envmap-update'});
       } catch (errorOrPromise) {
         if (errorOrPromise instanceof Error) {

--- a/packages/model-viewer/src/test/features/environment-spec.ts
+++ b/packages/model-viewer/src/test/features/environment-spec.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import {Texture} from 'three';
+
 import {BASE_OPACITY, EnvironmentInterface, EnvironmentMixin} from '../../features/environment.js';
 import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
 import {ModelScene} from '../../three-components/ModelScene.js';
@@ -25,16 +27,6 @@ const expect = chai.expect;
 const ALT_BG_IMAGE_URL = assetPath('environments/white_furnace.hdr');
 const HDR_BG_IMAGE_URL = assetPath('environments/spruit_sunrise_1k_HDR.hdr');
 const MODEL_URL = assetPath('models/reflective-sphere.gltf');
-
-const backgroundHasMap =
-    (scene: ModelScene, url: string|null) => {
-      return (scene.background as any).userData.url === url;
-    }
-
-const modelUsingEnvMap =
-    (scene: ModelScene, url: string|null) => {
-      return (scene.environment as any).userData.url === url;
-    }
 
 /**
  * Returns a promise that resolves when a given element is loaded
@@ -83,10 +75,10 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
     element.src = MODEL_URL;
     document.body.insertBefore(element, document.body.firstChild);
     await rafPasses();
-    expect(environmentChangeCount).to.be.equal(0);
+    expect(environmentChangeCount).to.be.eq(0);
     element.style.display = 'block';
     await waitForEvent(element, 'environment-change');
-    expect(environmentChangeCount).to.be.equal(1);
+    expect(environmentChangeCount).to.be.eq(1);
     element.removeEventListener('environment-change', environmentChangeHandler);
   });
 
@@ -110,7 +102,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       });
 
       test('applies a generated environment map on model', async function() {
-        expect(modelUsingEnvMap(scene, null)).to.be.ok;
+        expect(scene.environment!.name).to.be.not.ok;
       });
 
       test('changes the environment exactly once', async function() {
@@ -179,7 +171,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
     });
 
     test('applies environment-image environment map on model', () => {
-      expect(modelUsingEnvMap(scene, element.environmentImage)).to.be.ok;
+      expect(scene.environment!.name).to.be.eq(element.environmentImage);
     });
 
     suite('and environment-image subsequently removed', () => {
@@ -190,7 +182,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       });
 
       test('reapplies generated environment map on model', () => {
-        expect(modelUsingEnvMap(scene, null)).to.be.ok;
+        expect(scene.environment!.name).to.be.not.ok;
       });
     });
   });
@@ -209,11 +201,11 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
     });
 
     test('displays background with skybox-image', async function() {
-      expect(backgroundHasMap(scene, element.skyboxImage!)).to.be.ok;
+      expect((scene.background as Texture).name).to.be.eq(element.skyboxImage);
     });
 
     test('applies skybox-image environment map on model', async function() {
-      expect(modelUsingEnvMap(scene, element.skyboxImage)).to.be.ok;
+      expect(scene.environment!.name).to.be.eq(element.skyboxImage);
     });
 
     suite('with an environment-image', () => {
@@ -224,7 +216,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       });
 
       test('prefers environment-image as environment map', () => {
-        expect(modelUsingEnvMap(scene, ALT_BG_IMAGE_URL)).to.be.ok;
+        expect(scene.environment!.name).to.be.eq(ALT_BG_IMAGE_URL);
       });
 
       suite('and environment-image subsequently removed', () => {
@@ -236,7 +228,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
         });
 
         test('uses skybox-image as environment map', () => {
-          expect(modelUsingEnvMap(scene, HDR_BG_IMAGE_URL)).to.be.ok;
+          expect(scene.environment!.name).to.be.eq(HDR_BG_IMAGE_URL);
         });
       });
 
@@ -249,7 +241,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
         });
 
         test('continues using environment-image as environment map', () => {
-          expect(modelUsingEnvMap(scene, ALT_BG_IMAGE_URL)).to.be.ok;
+          expect(scene.environment!.name).to.be.eq(ALT_BG_IMAGE_URL);
         });
 
         test('removes the background', async function() {
@@ -270,7 +262,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       });
 
       test('reapplies generated environment map on model', async function() {
-        expect(modelUsingEnvMap(scene, null)).to.be.ok;
+        expect(scene.environment!.name).to.be.not.ok;
       });
     });
   });

--- a/packages/model-viewer/src/test/features/environment-spec.ts
+++ b/packages/model-viewer/src/test/features/environment-spec.ts
@@ -102,7 +102,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       });
 
       test('applies a generated environment map on model', async function() {
-        expect(scene.environment!.name).to.be.not.ok;
+        expect(scene.environment!.name).to.be.eq('default');
       });
 
       test('changes the environment exactly once', async function() {
@@ -182,7 +182,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       });
 
       test('reapplies generated environment map on model', () => {
-        expect(scene.environment!.name).to.be.not.ok;
+        expect(scene.environment!.name).to.be.eq('default');
       });
     });
   });
@@ -262,7 +262,7 @@ suite('ModelViewerElementBase with EnvironmentMixin', () => {
       });
 
       test('reapplies generated environment map on model', async function() {
-        expect(scene.environment!.name).to.be.not.ok;
+        expect(scene.environment!.name).to.be.eq('default');
       });
     });
   });

--- a/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
+++ b/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
@@ -149,7 +149,7 @@ suite('TextureUtils', () => {
 
     test('throws if given an invalid url', async () => {
       try {
-        await textureUtils.generateEnvironmentMapAndSkybox({} as string);
+        await textureUtils.generateEnvironmentMapAndSkybox();
         expect(false).to.be.ok;
       } catch (e) {
         expect(true).to.be.ok;
@@ -162,7 +162,7 @@ suite('TextureUtils', () => {
       const environment =
           (await textureUtils.generateEnvironmentMapAndSkybox()).environmentMap;
 
-      expect(environment.name).to.be.eq(null);
+      expect(environment.name).to.be.eq('default');
       expect(environment.mapping).to.be.eq(CubeReflectionMapping);
     });
   });

--- a/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
+++ b/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
@@ -95,7 +95,7 @@ suite('TextureUtils', () => {
           await textureUtils.generateEnvironmentMapAndSkybox(EQUI_URL);
 
       const skybox = textures.skybox as any;
-      const environment = textures.environmentMap.texture as any;
+      const environment = textures.environmentMap as any;
 
       expect(skybox.isTexture).to.be.ok;
       expect(environment.isTexture).to.be.ok;
@@ -114,7 +114,7 @@ suite('TextureUtils', () => {
               await textureUtils.generateEnvironmentMapAndSkybox(HDR_EQUI_URL);
 
           const skybox = textures.skybox as any;
-          const environment = textures.environmentMap.texture as any;
+          const environment = textures.environmentMap as any;
 
           expect(skybox.isTexture).to.be.ok;
           expect(environment.isTexture).to.be.ok;
@@ -133,7 +133,7 @@ suite('TextureUtils', () => {
               EQUI_URL, HDR_EQUI_URL);
 
           const skybox = textures.skybox as any;
-          const environment = textures.environmentMap.texture as any;
+          const environment = textures.environmentMap as any;
 
           expect(skybox.isTexture).to.be.ok;
           expect(environment.isTexture).to.be.ok;
@@ -158,7 +158,7 @@ suite('TextureUtils', () => {
   suite('dynamically generating environment maps', () => {
     test('creates a cubemap render target with PMREM', async () => {
       const environment = (await textureUtils.generateEnvironmentMapAndSkybox())
-                              .environmentMap.texture as any;
+                              .environmentMap as any;
 
       expect(environment.userData.url).to.be.eq(null);
       expect(environment.mapping).to.be.eq(CubeUVReflectionMapping);

--- a/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
+++ b/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {Cache, CubeUVReflectionMapping, EquirectangularReflectionMapping, WebGLRenderer} from 'three';
+import {Cache, CubeReflectionMapping, EquirectangularReflectionMapping, WebGLRenderer} from 'three';
 
 import TextureUtils from '../../three-components/TextureUtils.js';
 import {assetPath} from '../helpers.js';
@@ -60,20 +60,20 @@ suite('TextureUtils', () => {
     test('loads a valid texture from URL', async () => {
       let texture = await textureUtils.load(EQUI_URL);
       texture.dispose();
-      expect((texture as any).isTexture).to.be.ok;
-      expect((texture as any).userData.url).to.be.eq(EQUI_URL);
+      expect(texture.isTexture).to.be.ok;
+      expect(texture.name).to.be.eq(EQUI_URL);
       expect(texture.mapping).to.be.eq(EquirectangularReflectionMapping);
     });
     test('loads a valid HDR texture from URL', async () => {
       let texture = await textureUtils.load(HDR_EQUI_URL);
       texture.dispose();
-      expect((texture as any).isTexture).to.be.ok;
-      expect((texture as any).userData.url).to.be.eq(HDR_EQUI_URL);
+      expect(texture.isTexture).to.be.ok;
+      expect(texture.name).to.be.eq(HDR_EQUI_URL);
       expect(texture.mapping).to.be.eq(EquirectangularReflectionMapping);
     });
     test('throws on invalid URL', async () => {
       try {
-        await (textureUtils.load as any)(null);
+        await textureUtils.load('');
         expect(false).to.be.ok;
       } catch (e) {
         expect(true).to.be.ok;
@@ -94,17 +94,17 @@ suite('TextureUtils', () => {
       const textures =
           await textureUtils.generateEnvironmentMapAndSkybox(EQUI_URL);
 
-      const skybox = textures.skybox as any;
-      const environment = textures.environmentMap as any;
+      const skybox = textures.skybox!;
+      const environment = textures.environmentMap;
 
       expect(skybox.isTexture).to.be.ok;
       expect(environment.isTexture).to.be.ok;
 
-      expect(skybox.userData.url).to.be.eq(EQUI_URL);
+      expect(skybox.name).to.be.eq(EQUI_URL);
       expect(skybox.mapping).to.be.eq(EquirectangularReflectionMapping);
 
-      expect(environment.userData.url).to.be.eq(EQUI_URL);
-      expect(environment.mapping).to.be.eq(CubeUVReflectionMapping);
+      expect(environment.name).to.be.eq(EQUI_URL);
+      expect(environment.mapping).to.be.eq(EquirectangularReflectionMapping);
     });
 
     test(
@@ -113,17 +113,18 @@ suite('TextureUtils', () => {
           const textures =
               await textureUtils.generateEnvironmentMapAndSkybox(HDR_EQUI_URL);
 
-          const skybox = textures.skybox as any;
-          const environment = textures.environmentMap as any;
+          const skybox = textures.skybox!;
+          const environment = textures.environmentMap;
 
           expect(skybox.isTexture).to.be.ok;
           expect(environment.isTexture).to.be.ok;
 
-          expect(skybox.userData.url).to.be.eq(HDR_EQUI_URL);
+          expect(skybox.name).to.be.eq(HDR_EQUI_URL);
           expect(skybox.mapping).to.be.eq(EquirectangularReflectionMapping);
 
-          expect(environment.userData.url).to.be.eq(HDR_EQUI_URL);
-          expect(environment.mapping).to.be.eq(CubeUVReflectionMapping);
+          expect(environment.name).to.be.eq(HDR_EQUI_URL);
+          expect(environment.mapping)
+              .to.be.eq(EquirectangularReflectionMapping);
         });
 
     test(
@@ -132,17 +133,18 @@ suite('TextureUtils', () => {
           const textures = await textureUtils.generateEnvironmentMapAndSkybox(
               EQUI_URL, HDR_EQUI_URL);
 
-          const skybox = textures.skybox as any;
-          const environment = textures.environmentMap as any;
+          const skybox = textures.skybox!;
+          const environment = textures.environmentMap;
 
           expect(skybox.isTexture).to.be.ok;
           expect(environment.isTexture).to.be.ok;
 
-          expect(skybox.userData.url).to.be.eq(EQUI_URL);
+          expect(skybox.name).to.be.eq(EQUI_URL);
           expect(skybox.mapping).to.be.eq(EquirectangularReflectionMapping);
 
-          expect(environment.userData.url).to.be.eq(HDR_EQUI_URL);
-          expect(environment.mapping).to.be.eq(CubeUVReflectionMapping);
+          expect(environment.name).to.be.eq(HDR_EQUI_URL);
+          expect(environment.mapping)
+              .to.be.eq(EquirectangularReflectionMapping);
         });
 
     test('throws if given an invalid url', async () => {
@@ -157,11 +159,11 @@ suite('TextureUtils', () => {
 
   suite('dynamically generating environment maps', () => {
     test('creates a cubemap render target with PMREM', async () => {
-      const environment = (await textureUtils.generateEnvironmentMapAndSkybox())
-                              .environmentMap as any;
+      const environment =
+          (await textureUtils.generateEnvironmentMapAndSkybox()).environmentMap;
 
-      expect(environment.userData.url).to.be.eq(null);
-      expect(environment.mapping).to.be.eq(CubeUVReflectionMapping);
+      expect(environment.name).to.be.eq(null);
+      expect(environment.mapping).to.be.eq(CubeReflectionMapping);
     });
   });
 });

--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -169,6 +169,7 @@ export default class TextureUtils extends EventDispatcher {
     if (this.generatedEnvironmentMap == null) {
       this.generatedEnvironmentMap =
           this.GenerateEnvironmentMap(new EnvironmentScene());
+      this.generatedEnvironmentMap.name = 'default';
     }
     return Promise.resolve(this.generatedEnvironmentMap);
   }
@@ -182,6 +183,7 @@ export default class TextureUtils extends EventDispatcher {
     if (this.generatedEnvironmentMapAlt == null) {
       this.generatedEnvironmentMapAlt =
           this.GenerateEnvironmentMap(new EnvironmentSceneAlt());
+      this.generatedEnvironmentMapAlt.name = 'neutral';
     }
     return Promise.resolve(this.generatedEnvironmentMapAlt);
   }

--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -38,14 +38,6 @@ const ldrLoader = new TextureLoader();
 const hdrLoader = new RGBELoader();
 hdrLoader.setDataType(UnsignedByteType);
 
-// Attach a `userData` object for arbitrary data on textures that
-// originate from TextureUtils, similar to Object3D's userData,
-// for help debugging, providing metadata for tests, and semantically
-// describe the type of texture within the context of this application.
-const userData = {
-  url: null,
-};
-
 export default class TextureUtils extends EventDispatcher {
   private generatedEnvironmentMap: CubeTexture|null = null;
   private generatedEnvironmentMapAlt: CubeTexture|null = null;
@@ -70,7 +62,7 @@ export default class TextureUtils extends EventDispatcher {
 
       progressCallback(1.0);
 
-      this.addMetadata(texture, url);
+      texture.name = url;
       texture.mapping = EquirectangularReflectionMapping;
 
       if (!isHDR) {
@@ -140,18 +132,6 @@ export default class TextureUtils extends EventDispatcher {
     } finally {
       updateGenerationProgress(1.0);
     }
-  }
-
-  private addMetadata(texture: Texture|null, url: string|null) {
-    if (texture == null) {
-      return;
-    }
-    (texture as any).userData = {
-      ...userData,
-      ...({
-        url: url,
-      })
-    };
   }
 
   /**

--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {CubeCamera, CubeTexture, EquirectangularReflectionMapping, EventDispatcher, GammaEncoding, LinearEncoding, NoToneMapping, RGBEEncoding, RGBEFormat, Scene, Texture, TextureLoader, UnsignedByteType, WebGLCubeRenderTarget, WebGLRenderer} from 'three';
+import {CubeCamera, CubeTexture, EquirectangularReflectionMapping, EventDispatcher, GammaEncoding, HalfFloatType, LinearEncoding, NoToneMapping, RGBAFormat, Scene, Texture, TextureLoader, WebGLCubeRenderTarget, WebGLRenderer} from 'three';
 import {RGBELoader} from 'three/examples/jsm/loaders/RGBELoader.js';
 
 import {deserializeUrl} from '../utilities.js';
@@ -36,7 +36,7 @@ export interface EnvironmentGenerationConfig {
 const HDR_FILE_RE = /\.hdr(\.js)?$/;
 const ldrLoader = new TextureLoader();
 const hdrLoader = new RGBELoader();
-hdrLoader.setDataType(UnsignedByteType);
+hdrLoader.setDataType(HalfFloatType);
 
 export default class TextureUtils extends EventDispatcher {
   private generatedEnvironmentMap: CubeTexture|null = null;
@@ -154,9 +154,9 @@ export default class TextureUtils extends EventDispatcher {
     const renderer = this.threeRenderer;
     const cubeTarget = new WebGLCubeRenderTarget(256, {
       generateMipmaps: false,
-      type: UnsignedByteType,
-      format: RGBEFormat,
-      encoding: RGBEEncoding,
+      type: HalfFloatType,
+      format: RGBAFormat,
+      encoding: LinearEncoding,
       depthBuffer: false
     });
     const cubeCamera = new CubeCamera(0.1, 100, cubeTarget);


### PR DESCRIPTION
Fixes #1955 

This problem has always been flaky, but has been getting steadily worse. In my testing it seems to be fine with this change where I've removed our PMREMGenerator in favor of using the one now built into three.js. This has exposed some odd things about three.js, but I've managed to work around them for now. I'll plan to add some PRs to three.js this cycle to address them.

All the random corruption issues seemed to come down to one render target disposal; I'm fine with a little extra GPU memory to keep Safari's driver from puking. 

However, I'm still seeing an occasional  bug (only on iOS and less common) where either some or all  of my GLB textures  are gone. It's not the lighting, because  even the emissive channel of DamagedHelmet disappears. I've also seen the mixer in this [example](https://modelviewer.dev/examples/lightingandenv/#neutralLighting) become totally chrome (no base color texture, and maybe something else wrong too). No leads on these yet.