### PR TITLE
Use TrustedTypes

### DIFF
--- a/packages/model-viewer/src/assets/close-material-svg.ts
+++ b/packages/model-viewer/src/assets/close-material-svg.ts
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
-export default `
+import {html} from 'lit-html';
+
+export default html`
 <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#000000">
     <!-- NOTE(cdata): This SVG filter is a stop-gap until we can implement
          support for dynamic re-coloring of UI components -->

--- a/packages/model-viewer/src/assets/controls-svg.ts
+++ b/packages/model-viewer/src/assets/controls-svg.ts
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
-export default `
+import {html} from 'lit-html';
+
+export default html`
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="25" height="36">
     <defs>
         <path id="A" d="M.001.232h24.997V36H.001z" />

--- a/packages/model-viewer/src/assets/view-in-ar-material-svg.ts
+++ b/packages/model-viewer/src/assets/view-in-ar-material-svg.ts
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
-export default `
+import {html} from 'lit-html';
+
+export default html`
 <svg version="1.1" id="view_x5F_in_x5F_AR_x5F_icon"
 	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="24px" height="24px"
 	 viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -34,7 +34,6 @@ const UNSIZED_MEDIA_HEIGHT = 150;
 
 export const blobCanvas = document.createElement('canvas');
 
-const $template = Symbol('template');
 const $fallbackResizeHandler = Symbol('fallbackResizeHandler');
 const $defaultAriaLabel = Symbol('defaultAriaLabel');
 const $resizeObserver = Symbol('resizeObserver');
@@ -108,19 +107,8 @@ export interface RendererInterface {
  * Definition for a basic <model-viewer> element.
  */
 export default class ModelViewerElementBase extends UpdatingElement {
-  protected static[$template]: HTMLTemplateElement|void;
-
   static get is() {
     return 'model-viewer';
-  }
-
-  /** @nocollapse */
-  static get template() {
-    if (!this.hasOwnProperty($template)) {
-      this[$template] = makeTemplate(this.is);
-    }
-
-    return this[$template];
   }
 
   /** @export */
@@ -203,22 +191,11 @@ export default class ModelViewerElementBase extends UpdatingElement {
   constructor() {
     super();
 
-    // NOTE(cdata): It is *very important* to access this template first so that
-    // the ShadyCSS template preparation steps happen before element styling in
-    // IE11:
-    const template = (this.constructor as any).template as HTMLTemplateElement;
-
-    if ((window as any).ShadyCSS) {
-      (window as any).ShadyCSS.styleElement(this, {});
-    }
-
-    // NOTE(cdata): The canonical ShadyCSS examples suggest that the Shadow Root
-    // should be created after the invocation of ShadyCSS.styleElement
     this.attachShadow({mode: 'open'});
 
     const shadowRoot = this.shadowRoot!;
 
-    shadowRoot.appendChild(template.content.cloneNode(true));
+    makeTemplate(shadowRoot);
 
     this[$container] = shadowRoot.querySelector('.container') as HTMLDivElement;
     this[$userInputElement] =

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -13,12 +13,13 @@
  * limitations under the License.
  */
 
+import {html, render} from 'lit-html';
+
 import CloseIcon from './assets/close-material-svg.js';
 import ControlsPrompt from './assets/controls-svg.js';
 import ARGlyph from './assets/view-in-ar-material-svg.js';
 
-const template = document.createElement('template');
-template.innerHTML = `
+const templateResult = html`
 <style>
 :host {
   display: block;
@@ -347,13 +348,6 @@ canvas.show {
   </div>
 </div>`;
 
-export default template;
-
-export const makeTemplate = (tagName: string) => {
-  const clone = document.createElement('template');
-  clone.innerHTML = template.innerHTML;
-  if ((window as any).ShadyCSS) {
-    (window as any).ShadyCSS.prepareTemplate(clone, tagName);
-  }
-  return clone;
+export const makeTemplate = (shadowRoot: ShadowRoot) => {
+  render(templateResult, shadowRoot);
 };


### PR DESCRIPTION
Our feedback from the security team was that instead of using `innerHTML` directly we should depend on  `lit-html` to provide trusted types for us, since they've been reviewed and approved. Since  we stopped supporting IE11, I also took the opportunity to remove ShadyCSS, since that's no longer needed. 