### PR TITLE
keep roughnessMipmapper from breaking USDZExporter

### DIFF
--- a/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
@@ -157,7 +157,9 @@ export class ModelViewerGLTFInstance extends GLTFInstance {
       // clobber the camera.
       const {enabled} = threeRenderer.xr;
       threeRenderer.xr.enabled = false;
+      const {image} = clone.roughnessMap;
       roughnessMipmapper.generateMipmaps(clone as MeshStandardMaterial);
+      clone.roughnessMap.image = image;
       threeRenderer.xr.enabled = enabled;
     }
 


### PR DESCRIPTION
I noticed this was keeping Neil Armstrong from auto-converting to USDZ. The fix was simple, but I should add it upstream to three.js too. It was probably causing quite a few other files from auto-converting too (anything with  a larger dimension normal map than roughness map on any  material). 