### PR TITLE
small fixes to examples

### DIFF
--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -583,7 +583,7 @@ const modelViewer = document.querySelector("model-viewer#pickMaterial");
 modelViewer.addEventListener("load", () => {
 
   const changeColor = async (event) => {
-    let material = modelViewer.materialFromPoint(event.layerX, event.layerY);
+    let material = modelViewer.materialFromPoint(event.offsetX, event.offsetY);
 
     if(material != null) {
       material.pbrMetallicRoughness.

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -199,9 +199,8 @@
           </div>
           <example-snippet stamp-to="panning" highlight-as="html">
             <template>
-<model-viewer id="pan-demo" auto-rotate camera-controls src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
-<script>
-(() => {
+<model-viewer id="pan-demo" auto-rotate camera-controls oncontextmenu="return false;" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum"></model-viewer>
+<script type="module">
   const modelViewer = document.querySelector('#pan-demo');
   const tapDistance = 2;
   let panning = false;
@@ -243,20 +242,17 @@
 
   const recenter = (pointer) => {
     panning = false;
-    if (Math.abs(pointer.clientX - startX) > tapDistance ||
-        Math.abs(pointer.clientY - startY) > tapDistance)
+    if (Math.abs(pointer.offsetX - startX) > tapDistance ||
+        Math.abs(pointer.offsetY - startY) > tapDistance)
       return;
-    const rect = modelViewer.getBoundingClientRect();
-    const x = pointer.clientX - rect.left;
-    const y = pointer.clientY - rect.top;
-    const hit = modelViewer.positionAndNormalFromPoint(x, y);
+    const hit = modelViewer.positionAndNormalFromPoint(pointer.offsetX, pointer.offsetY);
     modelViewer.cameraTarget =
         hit == null ? 'auto auto auto' : hit.position.toString();
   };
 
   modelViewer.addEventListener('mousedown', (event) => {
-    startX = event.clientX;
-    startY = event.clientY;
+    startX = event.offsetX;
+    startY = event.offsetY;
     panning = event.button === 2 || event.ctrlKey || event.metaKey ||
         event.shiftKey;
     if (!panning)
@@ -270,14 +266,14 @@
 
   modelViewer.addEventListener('touchstart', (event) => {
     const {targetTouches, touches} = event;
-    startX = targetTouches[0].clientX;
-    startY = targetTouches[0].clientY;
+    startX = targetTouches[0].offsetX;
+    startY = targetTouches[0].offsetY;
     panning = targetTouches.length === 2 && targetTouches.length === touches.length;
     if (!panning)
       return;
 
-    lastX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
-    lastY = 0.5 * (targetTouches[0].clientY + targetTouches[1].clientY);
+    lastX = 0.5 * (targetTouches[0].offsetX + targetTouches[1].offsetX);
+    lastY = 0.5 * (targetTouches[0].offsetY + targetTouches[1].offsetY);
     startPan();
   }, true);
 
@@ -285,7 +281,7 @@
     if (!panning)
       return;
 
-    movePan(event.clientX, event.clientY);
+    movePan(event.offsetX, event.offsetY);
     event.stopPropagation();
   }, true);
 
@@ -294,8 +290,8 @@
       return;
 
     const {targetTouches} = event;
-    const thisX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
-    const thisY = 0.5 * (targetTouches[0].clientY + targetTouches[1].clientY);
+    const thisX = 0.5 * (targetTouches[0].offsetX + targetTouches[1].offsetX);
+    const thisY = 0.5 * (targetTouches[0].offsetY + targetTouches[1].offsetY);
     movePan(thisX, thisY);
   }, true);
 
@@ -312,7 +308,6 @@
       }
     }
   }, true);
-})();
 </script>
             </template>
           </example-snippet>
@@ -332,11 +327,10 @@
           </div>
           <example-snippet stamp-to="turnSkybox" highlight-as="html">
             <template>
-<model-viewer id="envlight-demo" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf"  skybox-image="../../shared-assets/environments/spruit_sunrise_1k_HDR.hdr" alt="A 3D model of a damaged helmet"></model-viewer>
+<model-viewer id="envlight-demo" camera-controls oncontextmenu="return false;" src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf"  skybox-image="../../shared-assets/environments/spruit_sunrise_1k_HDR.hdr" alt="A 3D model of a damaged helmet"></model-viewer>
 
 <script type="module">
   const modelViewer = document.querySelector("#envlight-demo");
-  modelViewer.addEventListener('contextmenu', event => event.preventDefault());
   
   let lastX;
   let panning = false;
@@ -362,12 +356,11 @@
   }
   
   modelViewer.addEventListener('mousedown', (event) => {
-    panning = event.button === 2 || event.ctrlKey || event.metaKey ||
-        event.shiftKey;
+    panning = event.button === 2 || event.ctrlKey || event.metaKey || event.shiftKey;
     if (!panning)
       return;
 
-    lastX = event.clientX;
+    lastX = event.offsetX;
     startPan();
     event.stopPropagation();
   }, true);
@@ -378,7 +371,7 @@
     if (!panning)
       return;
 
-    lastX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
+    lastX = 0.5 * (targetTouches[0].offsetX + targetTouches[1].offsetX);
     startPan();
   }, true);
 
@@ -386,7 +379,7 @@
     if (!panning)
       return;
 
-    updatePan(event.clientX);
+    updatePan(event.offsetX);
     event.stopPropagation();
   }, true);
 
@@ -395,7 +388,7 @@
       return;
 
     const {targetTouches} = event;
-    const thisX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
+    const thisX = 0.5 * (targetTouches[0].offsetX + targetTouches[1].offsetX);
     updatePan(thisX);
   }, true);
 
@@ -418,6 +411,11 @@
         <li class="attribution">
           <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
           licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>.
+        </li>
+
+        <li class="attribution">
+          <a href="https://3d.si.edu/object/3d/neil-armstrong-spacesuit:d8c63ba6-4ebc-11ea-b77f-2e728ce88125">Neil Armstrong Space Suit</a> 
+          provided by the Smithsonian Digitization Programs Office and the National Air and Space Museum; <a href=https://www.si.edu/Termsofuse>Usage Conditions Apply</a>.
         </li>
 
         <li class="attribution">

--- a/packages/space-opera/src/components/materials_panel/materials_panel.ts
+++ b/packages/space-opera/src/components/materials_panel/materials_panel.ts
@@ -171,7 +171,7 @@ export class MaterialPanel extends ConnectedLitElement {
     const originalEmissiveFactor = this.selectedEmissiveFactor;
 
     let start = -1;
-    const DURATION = 1600;  // in milliseconds
+    const DURATION = 500;  // in milliseconds
 
     const material = this.getMaterial();
 
@@ -284,7 +284,7 @@ export class MaterialPanel extends ConnectedLitElement {
     }
     const modelviewer = getModelViewer();
     const pickedMaterial =
-        modelviewer.materialFromPoint(event.layerX, event.layerY);
+        modelviewer.materialFromPoint(event.offsetX, event.offsetY);
     if (pickedMaterial == null) {
       return;
     }

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -178,10 +178,8 @@ export class ModelViewerPreview extends ConnectedLitElement {
   }
 
   private addHotspot(event: MouseEvent) {
-    const rect = this.modelViewer.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
-    const positionAndNormal = this.modelViewer.positionAndNormalFromPoint(x, y);
+    const positionAndNormal = this.modelViewer.positionAndNormalFromPoint(
+        event.offsetX, event.offsetY);
     if (!positionAndNormal) {
       console.log('Click was not on model, no hotspot added.');
       return;


### PR DESCRIPTION
`layerX` is apparently deprecated, so I switched to `offsetX` instead, which despite being "experimental", seems to have universal browser support. It's also simpler than `clientX`. Additionally, I disabled the context menu on a couple of examples that use right-click. I also made the fade quicker on selecting materials in the  editor.