### PR TITLE
fixed scale attribute

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -156,12 +156,11 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
         const threeGLTF = this[$currentGLTF];
         const {variantName} = this;
 
-        if (threeGLTF == null) {
-          return;
+        if (threeGLTF != null) {
+          await this[$model]![$switchVariant](variantName!);
+          this[$needsRender]();
+          this.dispatchEvent(new CustomEvent('variant-applied'));
         }
-        await this[$model]![$switchVariant](variantName!);
-        this[$needsRender]();
-        this.dispatchEvent(new CustomEvent('variant-applied'));
       }
 
       if (changedProperties.has('orientation') ||

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -575,7 +575,7 @@ modelViewerTexture.addEventListener("load", () => {
           </div>
           <example-snippet stamp-to="pickMaterialExample" highlight-as="html">
             <template>
-<model-viewer id="pickMaterial" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A Material Picking Example">
+<model-viewer id="pickMaterial" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer" scale="0.001 0.001 0.001" alt="A Material Picking Example">
 </model-viewer>
 <script type="module">
 const modelViewer = document.querySelector("model-viewer#pickMaterial");


### PR DESCRIPTION
The original idea here was to turn off quick look because it wasn't working with this model. However, I also realized  it wasn't working  with WebXR, which turned out  to be because its scale was totally wrong (it's obviously modeled in mm instead of meters). However, changing the scale didn't work either. Turned out we had a bug I somehow missed where an early return  was keeping the scale/orientation  attributes from being read on first load. 