### PR TITLE
switch back to WebGL1Renderer

### DIFF
--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {ACESFilmicToneMapping, Event, EventDispatcher, GammaEncoding, PCFSoftShadowMap, WebGLRenderer} from 'three';
+import {ACESFilmicToneMapping, Event, EventDispatcher, GammaEncoding, PCFSoftShadowMap, WebGL1Renderer} from 'three';
 import {RoughnessMipmapper} from 'three/examples/jsm/utils/RoughnessMipmapper';
 
 import {$updateEnvironment} from '../features/environment.js';
@@ -91,7 +91,7 @@ export class Renderer extends EventDispatcher {
     }
   }
 
-  public threeRenderer!: WebGLRenderer;
+  public threeRenderer!: WebGL1Renderer;
   public canvas3D: HTMLCanvasElement;
   public textureUtils: TextureUtils|null;
   public arRenderer: ARRenderer;
@@ -138,7 +138,7 @@ export class Renderer extends EventDispatcher {
     this.canvas3D.id = 'webgl-canvas';
 
     try {
-      this.threeRenderer = new WebGLRenderer({
+      this.threeRenderer = new WebGL1Renderer({
         canvas: this.canvas3D,
         alpha: true,
         antialias: true,


### PR DESCRIPTION
Fixes #2915 

There's a bunch of discussion in three.js and apparently there's a chrome bug in webGL2 around a particular sRGB format. Hopefully a better fix will be coming soon, but until then, it  seems our best way around this performance issue is to go back to WebGL1 for the moment.