### PR TITLE
allow deployment if fidelity fails

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -42,6 +42,7 @@ jobs:
       run: npm run build
 
     - name: Generate fidelity artifacts 
+      continue-on-error: true
       uses: GabrielBB/xvfb-action@v1.0
       with:
         run: ./node_modules/.bin/lerna run --scope @google/model-viewer-render-fidelity-tools test --stream


### PR DESCRIPTION
The fidelity tests have their own run on the PR anyway, so skip blocking the deployment step if they fail, especially since they are occasionally flaky anyway. 