### PR TITLE
added Huawei P30 to automation

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -42,6 +42,7 @@ jobs:
       run: npm run build
 
     - name: Generate fidelity artifacts 
+      continue-on-error: true
       uses: GabrielBB/xvfb-action@v1.0
       with:
         run: ./node_modules/.bin/lerna run --scope @google/model-viewer-render-fidelity-tools test --stream

--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -160,6 +160,15 @@ module.exports = function(config) {
         real_mobile: 'true',
         browserstack: {localIdentifier: 'iOS14'}
       },
+      'Android (Huawei P30)': {
+        base: 'BrowserStack',
+        os: 'Android',
+        os_version: '9.0',
+        device: 'Huawei P30',
+        browser: 'Android',
+        real_mobile: 'true',
+        browserstack: {localIdentifier: 'AndroidP30'}
+      },
     };
 
     config.set({

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {IS_IOS} from '../../constants.js';
+import {IS_ANDROID, IS_IOS} from '../../constants.js';
 import {$openIOSARQuickLook, $openSceneViewer, ARInterface, ARMixin} from '../../features/ar.js';
 import ModelViewerElementBase from '../../model-viewer-base.js';
 import {Constructor, timePasses, waitForEvent} from '../../utilities.js';
@@ -166,7 +166,11 @@ suite('ModelViewerElementBase with ARMixin', () => {
         expect(element.canActivateAR).to.be.equal(false);
       });
 
-      test('shows the AR button if on AR platform');
+      test('shows the AR button if on AR platform', () => {
+        if (IS_ANDROID) {
+          expect(element.canActivateAR).to.be.equal(true);
+        }
+      });
     });
 
     suite('ios-src', () => {
@@ -205,8 +209,8 @@ suite('ModelViewerElementBase with ARMixin', () => {
             });
           });
         });
-      } else {
-        suite('on browsers that are not iOS Safari', () => {
+      } else if (!IS_ANDROID) {
+        suite('on browsers that do not support AR', () => {
           test('hides the AR button', () => {
             expect(element.canActivateAR).to.be.equal(false);
           });

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -162,14 +162,8 @@ suite('ModelViewerElementBase with ARMixin', () => {
         }
       });
 
-      test('hides the AR button if not on AR platform', () => {
-        expect(element.canActivateAR).to.be.equal(false);
-      });
-
-      test('shows the AR button if on AR platform', () => {
-        if (IS_ANDROID) {
-          expect(element.canActivateAR).to.be.equal(true);
-        }
+      test('shows the AR button if on a WebXR platform', () => {
+        expect(element.canActivateAR).to.be.equal(IS_ANDROID);
       });
     });
 

--- a/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
@@ -15,6 +15,7 @@
 
 import {Matrix4, PerspectiveCamera, Vector2, Vector3} from 'three';
 
+import {IS_ANDROID} from '../../constants.js';
 import {ControlsInterface, ControlsMixin} from '../../features/controls.js';
 import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
 import {ARRenderer} from '../../three-components/ARRenderer.js';
@@ -171,9 +172,8 @@ suite('ARRenderer', () => {
     arRenderer = Renderer.singleton.arRenderer;
   });
 
-  // NOTE(cdata): It will be a notable day when this test fails
   test('does not support presenting to AR on any browser', async () => {
-    expect(await arRenderer.supportsPresentation()).to.be.equal(false);
+    expect(await arRenderer.supportsPresentation()).to.be.equal(IS_ANDROID);
   });
 
   test('is not presenting if present has not been invoked', () => {


### PR DESCRIPTION
Fixes #2949 

To catch regressions like #2949 since we do have basic tests for black renders, and this device has an old GPU which reproduces problems like the above. I expect  our unit tests to fail  on this PR until I revert #2936, so I'm double-checking here first.

Edit: the new tests successfully caught the problem, and also verify its  solution, so we're good to go.