### PR TITLE
fixed AR button on  twitter card

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -178,7 +178,7 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       if (!changedProperties.has('ar') && !changedProperties.has('arModes') &&
-          !changedProperties.has('iosSrc')) {
+          !changedProperties.has('src') && !changedProperties.has('iosSrc')) {
         return;
       }
 

--- a/packages/modelviewer.dev/examples/twitter/player.html
+++ b/packages/modelviewer.dev/examples/twitter/player.html
@@ -71,7 +71,6 @@
     environment-image="neutral"
     shadow-intensity="1"
     autoplay
-    ar
     ar-modes="webxr scene-viewer quick-look"
     camera-controls
   >
@@ -90,5 +89,7 @@
         modelViewer[key] = isFinite(num) ? num : val;
       }
     }
+    // Work-around for a bug
+    modelViewer.ar = true;
   </script>
 </body>


### PR DESCRIPTION
This was actually a MV bug where if you  add the  `src` after  the `ar` attribute it wouldn't enable the AR button. In addition to fixing that, I put a work-around in the  twitter card, since that  operates off of the latest release, rather than master. 