### PR TITLE
use fewer shaders

### DIFF
--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -233,7 +233,7 @@ export class ARRenderer extends EventDispatcher {
     scene.background = null;
 
     this.oldShadowIntensity = scene.shadowIntensity;
-    scene.setShadowIntensity(0);
+    scene.setShadowIntensity(0.01);  // invisible, but not changing the shader
 
     this.oldTarget.copy(scene.getTarget());
     this.oldFramedFieldOfView = scene.framedFieldOfView;

--- a/packages/model-viewer/src/three-components/PlacementBox.ts
+++ b/packages/model-viewer/src/three-components/PlacementBox.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {BufferGeometry, DoubleSide, Float32BufferAttribute, Material, Mesh, MeshBasicMaterial, PlaneBufferGeometry, Vector2, Vector3} from 'three';
+import {BufferGeometry, Float32BufferAttribute, FrontSide, Material, Mesh, MeshBasicMaterial, PlaneBufferGeometry, Vector2, Vector3} from 'three';
 
 import {Damper} from './Damper.js';
 import {ModelScene} from './ModelScene.js';
@@ -93,7 +93,7 @@ export class PlacementBox extends Mesh {
 
     this.side = side;
     const material = this.material as MeshBasicMaterial;
-    material.side = DoubleSide;
+    material.side = FrontSide;
     material.transparent = true;
     material.opacity = 0;
     this.goalOpacity = 0;


### PR DESCRIPTION
While debugging WebXR mode I noticed we were recompiling some shaders that shouldn't. A couple of small fixes: 
1) The placement box is transparent  and was double-sided, which was causing it to be rendered twice (with two different shaders).
2) The shadow is turned off in AR until the model is set on  the floor. Turning  off the  shadow recompiles the  shader, so instead I turn it to a small (invisible) value.