### PR TITLE
added poster type dropdown

### DIFF
--- a/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/open_button.ts
@@ -24,25 +24,21 @@ import {SimpleDropzone} from 'simple-dropzone';
 import {dispatchConfig, dispatchEnvrionmentImage, getConfig} from '../../../components/config/reducer.js';
 import {reduxStore} from '../../../space_opera_base.js';
 import {fileModalStyles, openModalStyles} from '../../../styles.css.js';
-import {ArConfigState, extractStagingConfig, ImageType, INITIAL_STATE, ModelViewerConfig, RelativeFilePathsState, State} from '../../../types.js';
+import {ArConfigState, extractStagingConfig, ModelViewerConfig, RelativeFilePathsState, State} from '../../../types.js';
 import {ConnectedLitElement} from '../../connected_lit_element/connected_lit_element.js';
 import {dispatchSetHotspots} from '../../hotspot_panel/reducer.js';
 import {dispatchAddEnvironmentImage} from '../../ibl_selector/reducer.js';
 import {dispatchArConfig, getArConfig} from '../../mobile_view/reducer.js';
 import {dispatchFileMap, dispatchGltfUrl, dispatchRootPath, getGltfUrl, getModelViewer} from '../../model_viewer_preview/reducer.js';
-import {dispatchSetEnvironmentName, dispatchSetModelName, dispatchSetPosterName, getRelativeFilePaths} from '../../relative_file_paths/reducer.js';
+import {dispatchSetEnvironmentName, dispatchSetModelName, getRelativeFilePaths} from '../../relative_file_paths/reducer.js';
 import {Dropdown} from '../../shared/dropdown/dropdown.js';
-import {SliderWithInputElement} from '../../shared/slider_with_input/slider_with_input.js';
 import {SnippetViewer} from '../../shared/snippet_viewer/snippet_viewer.js';
 import {isObjectUrl} from '../../utils/create_object_url.js';
 import {renderModelViewer} from '../../utils/render_model_viewer.js';
 import {parseHotspotsFromSnippet} from '../parse_hotspot_config.js';
-import {applyRelativeFilePaths, dispatchExtraAttributes, dispatchHeight, dispatchMimeType, getExtraAttributes} from '../reducer.js';
+import {applyRelativeFilePaths, dispatchExtraAttributes, getExtraAttributes} from '../reducer.js';
 
 import {parseExtraAttributes, parseSnippet, parseSnippetAr} from './parsing.js';
-
-const DEFAULT_POSTER_HEIGHT =
-    INITIAL_STATE.entities.modelViewerSnippet.poster.height;
 
 @customElement('me-open-modal')
 export class OpenModal extends ConnectedLitElement {
@@ -209,7 +205,6 @@ export class OpenModal extends ConnectedLitElement {
 export class ImportCard extends LitElement {
   @query('me-open-modal#open-modal') openModal!: OpenModal;
   @query('input#file-input') fileInput!: HTMLInputElement;
-  @query('me-slider-with-input#height') heightSlider!: SliderWithInputElement;
   @internalProperty() selectedDefaultOption: number = 0;
   static styles = fileModalStyles;
 
@@ -325,18 +320,6 @@ export class ImportCard extends LitElement {
     reduxStore.dispatch(dispatchGltfUrl(src));
   }
 
-  onHeightChange() {
-    reduxStore.dispatch(dispatchHeight(this.heightSlider.value));
-  }
-
-  onPosterSelect(event: CustomEvent) {
-    const dropdown = event.target as Dropdown;
-    const type = dropdown.selectedItem.getAttribute('value') as ImageType;
-    reduxStore.dispatch(dispatchMimeType(type));
-    const name = 'poster.' + type.substring(6);
-    reduxStore.dispatch(dispatchSetPosterName(name));
-  }
-
   render() {
     return html`
     <me-open-modal id="open-modal"></me-open-modal>
@@ -367,13 +350,6 @@ export class ImportCard extends LitElement {
       
     </div>
     <me-validation></me-validation>
-    <div style="font-size: 14px; font-weight: 500; margin-top: 10px;">Poster:</div>
-    <me-section-row class="Row" label="Height">
-      <me-slider-with-input min="256" max="2048" step="8" id="height"
-        @change="${this.onHeightChange}"
-        value="${DEFAULT_POSTER_HEIGHT}">
-      </me-slider-with-input>
-    </me-section-row>
     `;
   }
 }


### PR DESCRIPTION
Just a small feature request from an internal user. I still  think WebP is the only way to  go  for  posters, but apparently the poster button is also used  for quickly generating images  for other  purposes.