### PR TITLE
Spherical harmonics

### DIFF
--- a/packages/model-viewer/src/features/environment.ts
+++ b/packages/model-viewer/src/features/environment.ts
@@ -233,7 +233,7 @@ export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
         return;
       }
       this[$currentEnvironmentMap] = environmentMap;
-      this[$scene].environment = this[$currentEnvironmentMap];
+      // this[$scene].environment = this[$currentEnvironmentMap];
       this.dispatchEvent(new CustomEvent('environment-change'));
 
       this[$needsRender]();

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -76,7 +76,7 @@
 <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
 
 <!-- Use it like any other HTML element -->
-<model-viewer alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" src="shared-assets/models/NeilArmstrong.glb" ar ar-modes="webxr scene-viewer quick-look" environment-image="shared-assets/environments/moon_1k.hdr" poster="shared-assets/models/NeilArmstrong.webp" seamless-poster shadow-intensity="1" camera-controls></model-viewer>
+<model-viewer alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" src="shared-assets/models/NeilArmstrong.glb" ar ar-modes="webxr scene-viewer quick-look" poster="shared-assets/models/NeilArmstrong.webp" seamless-poster shadow-intensity="1" camera-controls spherical-harmonics="0.46519692492969905 0.4241956607683382 0.4576711877824825 0.30826216320384436 0.27945656813465236 0.35219365313061146 0.03157084678012829 0.058602426333643216 0.07542049516981003 0.07828354031579374 -0.1251996711220649 -0.29448362136934575 0.1021822613078809 -0.12605373673262707 -0.32908371308308876 0.03329369607846006 0.06737488425270019 0.08468130688268709 -0.04482661611401552 -0.04074374804135103 -0.06285593291723642 0.06323356089983638 -0.029427772724582465 -0.07708623359768785 0.034812559526965166 0.03877050841818562 0.0025564137010261915" spherical-harmonics-intensity="2"></model-viewer>
                 </template>
               </example-snippet>
             </div>


### PR DESCRIPTION
One of the things we've been thinking about here at Shopify is adding support for Light Probes + Spherical Harmonics to light a Model rather than using an environment map.

I've created this Draft PR that shows how this could function. It should be noted:

- This PR does not include tests yet (if there's appetite tests will be added)
- The example and some core code has been disabled to fully leverage Light Probes + Spherical Harmonics
- Some work will need to be done to support specular reflections in Three.js
- There would need to be some discussion around how environment maps and spherical harmonics would work together

Some context. We've been interested in using Spherical Harmonics to light our Models because they are lower weight than downloading a large HDR image. 27 floats vs large image. They could also be leveraged before the environment map has been loaded.

Some questions we've had with Model Viewer and Spherical Harmonics:

1. Can lighting with Spherical Harmonics be expressive enough for selling Products
2. Given this is new functionality to Three.js does it function fully

Below is a video of the output from this PR:

https://user-images.githubusercontent.com/496903/146046350-9be604a8-726e-4e45-867a-76d04bdffc20.mp4

The above demo uses the same coefficients as the demo here:
https://threejs.org/examples/?q=lightpro#webgl_lightprobe

From this demo we've learned that:
1. Lighting is expressive enough for Merchant Products
2. The Three.js implementation isn't fully complete

There's a missing concept in Three.js which is the idea of Reflection probes. This is likely something we could help push forward but we wanted to see if there would be appetite for this kind of functionality in `<model-viewer>`. The current implementation of `LightProbes` in Three only calculate diffuse lighting. No specular lighting.

Anyway overall wanted to see if adding this kind of functionality would make sense as an optimization