### PR TITLE
Click triggering Progress when reveal strategy is auto fix

### DIFF
--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -419,7 +419,7 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     [$onClick] = () => {
-      if (this.reveal === RevealStrategy.MANUAL) {
+      if (this.reveal === RevealStrategy.MANUAL || this.reveal === RevealStrategy.AUTO) {
         return;
       }
       this.dismissPoster();


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
When the reveal strategy is AUTO, clicking on the screen was triggering progress change as every click was added as a new ongoing activity.
@elalish 
<!-- Example: Fixes #1234 -->
