### PR TITLE
fixed some bugs and updated  an  example

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -15,6 +15,7 @@
 
 import {property} from 'lit-element';
 import {Event, PerspectiveCamera, Spherical, Vector3} from 'three';
+
 import {style} from '../decorators.js';
 import ModelViewerElementBase, {$ariaLabel, $container, $hasTransitioned, $loadedTime, $needsRender, $onModelLoad, $onResize, $renderer, $scene, $tick, $userInputElement, toVector3D, Vector3D} from '../model-viewer-base.js';
 import {degreesToRadians, normalizeUnit} from '../styles/conversions.js';
@@ -25,6 +26,7 @@ import {SAFE_RADIUS_RATIO} from '../three-components/ModelScene.js';
 import {ChangeEvent, ChangeSource, PointerChangeEvent, SmoothControls} from '../three-components/SmoothControls.js';
 import {Constructor} from '../utilities.js';
 import {timeline} from '../utilities/animation.js';
+
 
 
 // NOTE(cdata): The following "animation" timing functions are deliberately
@@ -251,6 +253,7 @@ export declare interface ControlsInterface {
   jumpCameraToGoal(): void;
   updateFraming(): Promise<void>;
   resetInteractionPrompt(): void;
+  zoom(keyPresses: number): void;
 }
 
 export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
@@ -409,6 +412,11 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       this[$waitingToPromptUser] =
           this.interactionPrompt === InteractionPromptStrategy.AUTO &&
           this.cameraControls;
+    }
+
+    zoom(keyPresses: number) {
+      const event = new WheelEvent('wheel', {deltaY: -30 * keyPresses});
+      this[$userInputElement].dispatchEvent(event);
     }
 
     connectedCallback() {

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -449,11 +449,11 @@ export class ModelScene extends Scene {
     const goal = this.goalTarget;
     const target = this.target.position;
     if (!goal.equals(target)) {
-      const radius = this.idealCameraDistance;
+      const normalization = this.idealCameraDistance / 10;
       let {x, y, z} = target;
-      x = this.targetDamperX.update(x, goal.x, delta, radius);
-      y = this.targetDamperY.update(y, goal.y, delta, radius);
-      z = this.targetDamperZ.update(z, goal.z, delta, radius);
+      x = this.targetDamperX.update(x, goal.x, delta, normalization);
+      y = this.targetDamperY.update(y, goal.y, delta, normalization);
+      z = this.targetDamperZ.update(z, goal.z, delta, normalization);
       this.target.position.set(x, y, z);
       this.target.updateMatrixWorld();
       this.setShadowRotation(this.yaw);
@@ -655,13 +655,13 @@ export class ModelScene extends Scene {
   }
 
   /**
-   * This method returns the world position, model-space normal and texture 
-   * coordinate of the point on the mesh corresponding to the input pixel 
-   * coordinates given relative to the model-viewer element. If the mesh 
+   * This method returns the world position, model-space normal and texture
+   * coordinate of the point on the mesh corresponding to the input pixel
+   * coordinates given relative to the model-viewer element. If the mesh
    * is not hit, the result is null.
    */
   positionAndNormalFromPoint(ndcPosition: Vector2, object: Object3D = this):
-      {position: Vector3, normal: Vector3, uv: Vector2 | null}|null {
+      {position: Vector3, normal: Vector3, uv: Vector2|null}|null {
     this.raycaster.setFromCamera(ndcPosition, this.getCamera());
     const hits = this.raycaster.intersectObject(object, true);
 

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -386,9 +386,6 @@ export class SmoothControls extends EventDispatcher {
 
     if (deltaZoom !== 0) {
       const goalLogFov = this.goalLogFov + deltaZoom;
-      console.log(
-          'radius: ', radius, ', goal: ', goalRadius, ', ratio: ', deltaRatio);
-      console.log('logFov: ', this.goalLogFov, ', goal: ', goalLogFov);
       this.setFieldOfView(Math.exp(goalLogFov));
     }
   }

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -380,13 +380,15 @@ export class SmoothControls extends EventDispatcher {
 
     const goalRadius = radius +
         deltaZoom *
-            Math.min(
-                isFinite(deltaRatio) ? deltaRatio : Infinity,
-                maximumRadius! - minimumRadius!);
+            (isFinite(deltaRatio) ? deltaRatio :
+                                    (maximumRadius! - minimumRadius!) * 2);
     this.setOrbit(goalTheta, goalPhi, goalRadius);
 
     if (deltaZoom !== 0) {
       const goalLogFov = this.goalLogFov + deltaZoom;
+      console.log(
+          'radius: ', radius, ', goal: ', goalRadius, ', ratio: ', deltaRatio);
+      console.log('logFov: ', this.goalLogFov, ', goal: ', goalLogFov);
       this.setFieldOfView(Math.exp(goalLogFov));
     }
   }

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -663,6 +663,11 @@
         "name": "getMaximumFieldOfView()",
         "htmlName": "getMaximumFieldOfView",
         "description": "Returns the maximum camera vertical field of view in degrees."
+      },
+      {
+        "name": "zoom(keyPresses)",
+        "htmlName": "zoom",
+        "description": "Applies the default zoom behavior (a combination of radius and field of view change), mimicking keyboard or mouse wheel inputs. If keyPresses = 1.0, it will zoom in as much as a single keystroke; negative values zoom out."
       }
     ],
     "Events": [

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -330,82 +330,77 @@
       id="hotspot-camera-view-demo" 
       src="../../assets/SketchfabModels/ThorAndTheMidgardSerpent.glb"
       alt="Thor and the Midgard Serpent"
-      shadow-intensity="0"
-      exposure="1"
       camera-controls
       touch-action="none"
       camera-orbit="-8.142746deg 68.967deg 0.6179899m"
       camera-target="-0.003m 0.0722m 0.0391m"
       min-field-of-view="45deg"
       interpolation-decay="200"
-      min-camera-orbit="auto auto 5%"
+      min-camera-orbit="auto auto 10%"
       touch-action="none"
       poster="../../assets/SketchfabModels/ThorAndTheMidgardSerpent.webp"
-      interaction-prompt="auto"
-      autoplay
       ar
       ar-modes="webxr scene-viewer quick-look"
-      quick-look-browsers="safari chrome"
       oncontextmenu="return false;"
     >
   <button class="view-button" slot="hotspot-0" 
     data-position="-0.0569m 0.0969m -0.1398m" data-normal="-0.5829775m 0.2863482m -0.7603565m" 
-    data-orbit="-50.94862deg 84.56856deg 0.06545582m" data-target="-0.04384604m 0.07348397m -0.1213202m" data-fov="4.91deg">
+    data-orbit="-50.94862deg 84.56856deg 0.06545582m" data-target="-0.04384604m 0.07348397m -0.1213202m">
     The Fighters
   </button>      
   <button class="view-button" slot="hotspot-1" 
     data-position="-0.1997m 0.11766m 0.0056m" data-normal="-0.4421014m 0.04410423m 0.8958802m" 
-    data-orbit="3.711166deg 92.3035deg 0.04335197m" data-target="-0.1879433m 0.1157161m -0.01563221m" data-fov="3.25deg">
+    data-orbit="3.711166deg 92.3035deg 0.04335197m" data-target="-0.1879433m 0.1157161m -0.01563221m">
     Hold Tight!
   </button>      
   <button class="view-button" slot="hotspot-2" 
     data-position="0.0608m 0.0566m 0.0605m" data-normal="0.2040984m 0.7985359m -0.56629m" 
-    data-orbit="42.72974deg 84.74043deg 0.07104211m" data-target="0.0757959m 0.04128428m 0.07109568m" data-fov="5.33deg">
+    data-orbit="42.72974deg 84.74043deg 0.07104211m" data-target="0.0757959m 0.04128428m 0.07109568m">
     The Encounter
   </button>      
   <button class="view-button" slot="hotspot-3" 
     data-position="0.1989m 0.16711m -0.0749m" data-normal="0.7045857m 0.1997957m -0.6809117m" 
-    data-orbit="-40.11996deg 88.17818deg 0.07090651m" data-target="0.2011831m 0.1398312m -0.07917573m" data-fov="5.32deg">
+    data-orbit="-40.11996deg 88.17818deg 0.07090651m" data-target="0.2011831m 0.1398312m -0.07917573m">
     Catapult
   </button>      
   <button class="view-button" slot="hotspot-4" 
     data-position="0.0677m 0.18906m -0.0158m" data-normal="-0.008245394m 0.6207898m 0.7839338m" 
-    data-orbit="-118.8446deg 98.83521deg 0.02526586m" data-target="0.06528695m 0.1753406m -0.01964653m" data-fov="1.89deg">
+    data-orbit="-118.8446deg 98.83521deg 0.06m" data-target="0.06528695m 0.1753406m -0.01964653m">
     Thunder and Lightning
   </button>      
   <button class="view-button" slot="hotspot-5" 
     data-position="-0.1418m -0.041m 0.174m" data-normal="-0.4924125m 0.4698265m 0.7326617m" 
-    data-orbit="-2.305313deg 110.1798deg 0.04504082m" data-target="-0.1151219m -0.04192762m 0.1523764m" data-fov="3.38deg">
+    data-orbit="-2.305313deg 110.1798deg 0.04504082m" data-target="-0.1151219m -0.04192762m 0.1523764m">
     Knock Knock
   </button>     
   <button class="view-button" slot="hotspot-6" 
     data-position="0.08414419m 0.134m -0.215m" data-normal="0.03777227m 0.06876653m -0.9969176m" 
-    data-orbit="-37.54149deg 82.16209deg 0.0468692m" data-target="0.08566038m 0.1249514m -0.1939646m" data-fov="3.52deg">
+    data-orbit="-37.54149deg 82.16209deg 0.0468692m" data-target="0.08566038m 0.1249514m -0.1939646m">
     Lucky Shot
   </button>      
   <button class="view-button" slot="hotspot-7" 
     data-position="0.14598m 0.03177m -0.05945886m" data-normal="-0.9392524m 0.2397608m -0.2456009m" 
-    data-orbit="-142.3926deg 86.45934deg 0.06213665m" data-target="0.1519967m 0.01904771m -0.05945886m" data-fov="0.06deg">
+    data-orbit="-142.3926deg 86.45934deg 0.06213665m" data-target="0.1519967m 0.01904771m -0.05945886m">
     Get Away!
   </button>      
   <button class="view-button" slot="hotspot-8" 
     data-position="0.0094m 0.0894m -0.15103m" data-normal="-0.3878782m 0.4957891m -0.7770094m" 
-    data-orbit="-118.6729deg 117.571deg 0.03905975m" data-target="0.007600758m 0.06771782m -0.1386167m" data-fov="2.93deg">
+    data-orbit="-118.6729deg 117.571deg 0.03905975m" data-target="0.007600758m 0.06771782m -0.1386167m">
     The Jump
   </button>      
   <button class="view-button" slot="hotspot-9" 
     data-position="-0.0658m 0.1786m -0.0183m" data-normal="0.7857152m 0.4059967m 0.46671m" 
-    data-orbit="53.28236deg 95.91318deg 0.1102844m" data-target="-0.07579391m 0.1393538m -0.00851791m" data-fov="8.27deg">
+    data-orbit="53.28236deg 95.91318deg 0.1102844m" data-target="-0.07579391m 0.1393538m -0.00851791m">
     The Beast
   </button>     
   <button class="view-button" slot="hotspot-10" 
     data-position="0.02610224m 0.01458751m -0.004978945m" data-normal="-0.602551m 0.7856147m -0.1405055m" 
-    data-orbit="-78.89725deg 77.17752deg 0.08451112m" data-target="0.02610223m 0.0145875m -0.004978945m" data-fov="6.34deg">
+    data-orbit="-78.89725deg 77.17752deg 0.08451112m" data-target="0.02610223m 0.0145875m -0.004978945m">
     Treasure
   </button>
   <button class="view-button" slot="hotspot-11" 
     data-position="-0.1053838m 0.01610652m 0.1076345m" data-normal="-0.624763m 0.5176854m 0.5845283m" 
-    data-orbit="10.89188deg 119.9775deg 0.03543022m" data-target="-0.1053838m 0.01610652m 0.1076345m" data-fov="2.66deg">
+    data-orbit="10.89188deg 119.9775deg 0.03543022m" data-target="-0.1053838m 0.01610652m 0.1076345m">
     Desperation
   </button>
 </model-viewer>
@@ -416,8 +411,6 @@
     let dataset = annotation.dataset;
     modelViewer.cameraTarget = dataset.target;
     modelViewer.cameraOrbit = dataset.orbit;
-    if(dataset.fov !== undefined)
-        modelViewer.fieldOfView = dataset.fov;
   }
 
   modelViewer.querySelectorAll('button').forEach((hotspot) => {


### PR DESCRIPTION
Fixes #3071 
Fixes #3012 

I also simplified the Midgard Serpent example and set the min radius up to 10% which helps with the nonlinear zoom. The reason I didn't use a log like for FoV is because the radius can  go to  zero (or even negative). There's a lot of assumptions about what you're actually looking at, so it's hard to get it  right for all cases. I think I'm going to leave  it as is for now instead of trying to solve #3013. 

I've also added  a `zoom(keyPresses)` function to allow mimicking of the default  zoom behavior using buttons and such. This  was requested to aid accessibility and generally make programatic control more similar to interactions. 