### PR TITLE
Fix for bug #3086

### DIFF
--- a/packages/model-viewer/src/features/scene-graph/model.ts
+++ b/packages/model-viewer/src/features/scene-graph/model.ts
@@ -260,12 +260,9 @@ export class Model implements ModelInterface {
    * default/initial materials if 'null' is provided.
    */
   async[$switchVariant](variantName: string|null) {
-    const promises = new Array<Promise<ThreeMaterial|ThreeMaterial[]|null>>();
     for (const primitive of this[$primitivesList]) {
-      promises.push(primitive.enableVariant(variantName));
+      await primitive.enableVariant(variantName);
     }
-
-    await Promise.all(promises);
 
     for (const material of this.materials) {
       material[$setActive](false);


### PR DESCRIPTION
Resolve an async bug that occurs when two nodes reference the same material. The first node starts loading a material and marks it as loaded, then while waiting for Three to complete the actual material setup the second node begins loading the same material and which is now marked as loaded thus it tries to fetch the cached material which is not actually available because the first node was still waiting on Three.

Fixes #3086
