### PR TITLE
improved transparency  example

### DIFF
--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -407,8 +407,8 @@
             <example-snippet stamp-to="transparentBackground" highlight-as="html">
               <template>
 <div class="demo" style="background: linear-gradient(#ffffff, #ada996); overflow-x: hidden;">
-  <span style="position: absolute; text-align: center; font-size: 100px; top:50%;">Background</span>
-  <model-viewer camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/AlphaBlendModeTest/glTF-Binary/AlphaBlendModeTest.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D transparency test" style="background-color: unset;"></model-viewer>
+  <span style="position: absolute; text-align: center; font-size: 100px; line-height: 100px; left: 50%; transform: translateX(-50%);">Background<br>is visible<br>through<br>transparent<br>objects.</span>
+  <model-viewer camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/ToyCar/glTF-Binary/ToyCar.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D transparency test" style="background-color: unset;"></model-viewer>
 </div>
               </template>
             </example-snippet>

--- a/packages/modelviewer.dev/scripts/ci-before-deploy.sh
+++ b/packages/modelviewer.dev/scripts/ci-before-deploy.sh
@@ -54,6 +54,7 @@ DEPLOYABLE_STATIC_FILES=( \
   shared-assets/models/glTF-Sample-Models/2.0/WaterBottle \
   shared-assets/models/glTF-Sample-Models/2.0/MaterialsVariantsShoe \
   shared-assets/models/glTF-Sample-Models/2.0/Buggy \
+  shared-assets/models/glTF-Sample-Models/2.0/ToyCar \
   shared-assets/environments \
   shared-assets/icons \
 )


### PR DESCRIPTION
Demonstrates how the background can show through the (glTF transmission extension) windows of the ToyCar, while preserving the specular reflections. 