### PR TITLE
v1.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3320,9 +3320,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -11013,9 +11013,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",

--- a/packages/model-viewer/package-lock.json
+++ b/packages/model-viewer/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@google/model-viewer",
-	"version": "1.10.0",
+	"version": "1.10.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@google/model-viewer",
-			"version": "1.10.0",
+			"version": "1.10.1",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@jsantell/event-target": "^1.1.3",
@@ -1955,9 +1955,9 @@
 			"dev": true
 		},
 		"node_modules/@types/http-errors": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.1.tgz",
-			"integrity": "sha512-e+2rjEwK6KDaNOm5Aa9wNGgyS9oSZU/4pfSMMPYNOfjvFI0WVXm29+ITRFr6aKDvvKo7uU1jV68MW4ScsfDi7Q==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+			"integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
 			"dev": true
 		},
 		"node_modules/@types/keygrip": {
@@ -3416,9 +3416,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.44",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-			"integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==",
+			"version": "1.4.46",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz",
+			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -4880,15 +4880,15 @@
 			}
 		},
 		"node_modules/karma": {
-			"version": "6.3.10",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.10.tgz",
-			"integrity": "sha512-Ofv+sgrkT8Czo6bzzQCvrwVyRSG8/3e7RbawEuxjfsINony+IR/S2csNRUFgPNfmWvju+dqi/MzQGOJ2LnlmfQ==",
+			"version": "6.3.11",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
+			"integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
 			"dev": true,
 			"dependencies": {
 				"body-parser": "^1.19.0",
 				"braces": "^3.0.2",
 				"chokidar": "^3.5.1",
-				"colors": "^1.4.0",
+				"colors": "1.4.0",
 				"connect": "^3.7.0",
 				"di": "^0.0.1",
 				"dom-serialize": "^2.2.1",
@@ -5398,9 +5398,9 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.4.tgz",
+			"integrity": "sha512-+q2aV5VlJZuLgCWoBvGI5zEwPF9eEI0kr/sAA9Jm4xMND7RfIEyF8JE7C0JIg8WXRG+P1sdIAb5ccoHPlXLzcw==",
 			"dev": true,
 			"dependencies": {
 				"@ungap/promise-all-settled": "1.1.2",
@@ -6616,9 +6616,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-			"integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+			"version": "2.64.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+			"integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -9335,9 +9335,9 @@
 			"dev": true
 		},
 		"@types/http-errors": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.1.tgz",
-			"integrity": "sha512-e+2rjEwK6KDaNOm5Aa9wNGgyS9oSZU/4pfSMMPYNOfjvFI0WVXm29+ITRFr6aKDvvKo7uU1jV68MW4ScsfDi7Q==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+			"integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
 			"dev": true
 		},
 		"@types/keygrip": {
@@ -10547,9 +10547,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.44",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-			"integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==",
+			"version": "1.4.46",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz",
+			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -11668,15 +11668,15 @@
 			}
 		},
 		"karma": {
-			"version": "6.3.10",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.10.tgz",
-			"integrity": "sha512-Ofv+sgrkT8Czo6bzzQCvrwVyRSG8/3e7RbawEuxjfsINony+IR/S2csNRUFgPNfmWvju+dqi/MzQGOJ2LnlmfQ==",
+			"version": "6.3.11",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
+			"integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
 			"dev": true,
 			"requires": {
 				"body-parser": "^1.19.0",
 				"braces": "^3.0.2",
 				"chokidar": "^3.5.1",
-				"colors": "^1.4.0",
+				"colors": "1.4.0",
 				"connect": "^3.7.0",
 				"di": "^0.0.1",
 				"dom-serialize": "^2.2.1",
@@ -12109,9 +12109,9 @@
 			}
 		},
 		"mocha": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-			"integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+			"version": "9.1.4",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.4.tgz",
+			"integrity": "sha512-+q2aV5VlJZuLgCWoBvGI5zEwPF9eEI0kr/sAA9Jm4xMND7RfIEyF8JE7C0JIg8WXRG+P1sdIAb5ccoHPlXLzcw==",
 			"dev": true,
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
@@ -13055,9 +13055,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-			"integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+			"version": "2.64.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+			"integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google/model-viewer",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Easily display interactive 3D models on the web and in AR!",
   "repository": "https://github.com/google/model-viewer",
   "bugs": {

--- a/packages/modelviewer.dev/package-lock.json
+++ b/packages/modelviewer.dev/package-lock.json
@@ -425,9 +425,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-			"integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+			"version": "2.64.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+			"integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -830,9 +830,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-			"integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+			"version": "2.64.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+			"integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"

--- a/packages/modelviewer.dev/package.json
+++ b/packages/modelviewer.dev/package.json
@@ -22,7 +22,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "@google/model-viewer": "^1.10.0",
+    "@google/model-viewer": "^1.10.1",
     "@types/prismjs": "^1.16.6",
     "focus-visible": "^5.2.0",
     "lit-element": "^2.5.1",

--- a/packages/render-fidelity-tools/package-lock.json
+++ b/packages/render-fidelity-tools/package-lock.json
@@ -3009,9 +3009,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.44",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-			"integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==",
+			"version": "1.4.46",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz",
+			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==",
 			"dev": true
 		},
 		"node_modules/emitter-component": {
@@ -5878,9 +5878,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-			"integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+			"version": "2.64.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+			"integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -9531,9 +9531,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.44",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-			"integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==",
+			"version": "1.4.46",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz",
+			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==",
 			"dev": true
 		},
 		"emitter-component": {
@@ -11843,9 +11843,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-			"integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+			"version": "2.64.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+			"integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"

--- a/packages/render-fidelity-tools/package.json
+++ b/packages/render-fidelity-tools/package.json
@@ -25,7 +25,7 @@
     "@actions/core": "^1.2.4",
     "@babylonjs/core": "*5.0.0-alpha.31",
     "@babylonjs/loaders": "*5.0.0-alpha.31",
-    "@google/model-viewer": "^1.10.0",
+    "@google/model-viewer": "^1.10.1",
     "@khronosgroup/gltf-viewer": "^1.0.7",
     "@polymer/paper-button": "^3.0.1",
     "@polymer/paper-radio-group": "^3.0.1",

--- a/packages/space-opera/package-lock.json
+++ b/packages/space-opera/package-lock.json
@@ -2858,9 +2858,9 @@
 			"dev": true
 		},
 		"node_modules/@types/http-errors": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.1.tgz",
-			"integrity": "sha512-e+2rjEwK6KDaNOm5Aa9wNGgyS9oSZU/4pfSMMPYNOfjvFI0WVXm29+ITRFr6aKDvvKo7uU1jV68MW4ScsfDi7Q==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+			"integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
 			"dev": true
 		},
 		"node_modules/@types/jasmine": {
@@ -4324,9 +4324,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.44",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-			"integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==",
+			"version": "1.4.46",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz",
+			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -5777,15 +5777,15 @@
 			}
 		},
 		"node_modules/karma": {
-			"version": "6.3.10",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.10.tgz",
-			"integrity": "sha512-Ofv+sgrkT8Czo6bzzQCvrwVyRSG8/3e7RbawEuxjfsINony+IR/S2csNRUFgPNfmWvju+dqi/MzQGOJ2LnlmfQ==",
+			"version": "6.3.11",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
+			"integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
 			"dev": true,
 			"dependencies": {
 				"body-parser": "^1.19.0",
 				"braces": "^3.0.2",
 				"chokidar": "^3.5.1",
-				"colors": "^1.4.0",
+				"colors": "1.4.0",
 				"connect": "^3.7.0",
 				"di": "^0.0.1",
 				"dom-serialize": "^2.2.1",
@@ -7312,9 +7312,9 @@
 			"dev": true
 		},
 		"node_modules/rollup": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-			"integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+			"version": "2.64.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+			"integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -10896,9 +10896,9 @@
 			"dev": true
 		},
 		"@types/http-errors": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.1.tgz",
-			"integrity": "sha512-e+2rjEwK6KDaNOm5Aa9wNGgyS9oSZU/4pfSMMPYNOfjvFI0WVXm29+ITRFr6aKDvvKo7uU1jV68MW4ScsfDi7Q==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+			"integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
 			"dev": true
 		},
 		"@types/jasmine": {
@@ -12105,9 +12105,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.44",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.44.tgz",
-			"integrity": "sha512-tHGWiUUmY7GABK8+DNcr474cnZDTzD8x1736SlDosVH8+/vRJeqfaIBAEHFtMjddz/0T4rKKYsxEc8BwQRdBpw==",
+			"version": "1.4.46",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.46.tgz",
+			"integrity": "sha512-UtV0xUA/dibCKKP2JMxOpDtXR74zABevuUEH4K0tvduFSIoxRVcYmQsbB51kXsFTX8MmOyWMt8tuZAlmDOqkrQ==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -13220,15 +13220,15 @@
 			}
 		},
 		"karma": {
-			"version": "6.3.10",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.10.tgz",
-			"integrity": "sha512-Ofv+sgrkT8Czo6bzzQCvrwVyRSG8/3e7RbawEuxjfsINony+IR/S2csNRUFgPNfmWvju+dqi/MzQGOJ2LnlmfQ==",
+			"version": "6.3.11",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
+			"integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
 			"dev": true,
 			"requires": {
 				"body-parser": "^1.19.0",
 				"braces": "^3.0.2",
 				"chokidar": "^3.5.1",
-				"colors": "^1.4.0",
+				"colors": "1.4.0",
 				"connect": "^3.7.0",
 				"di": "^0.0.1",
 				"dom-serialize": "^2.2.1",
@@ -14495,9 +14495,9 @@
 			"dev": true
 		},
 		"rollup": {
-			"version": "2.63.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
-			"integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
+			"version": "2.64.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
+			"integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"

--- a/packages/space-opera/package.json
+++ b/packages/space-opera/package.json
@@ -34,7 +34,7 @@
     "Chris George <chrisgeorge@google.com>"
   ],
   "devDependencies": {
-    "@google/model-viewer": "^1.10.0",
+    "@google/model-viewer": "^1.10.1",
     "@material/mwc-dialog": "^0.18.0",
     "@material/mwc-button": "^0.18.0",
     "@material/mwc-checkbox": "^0.18.0",


### PR DESCRIPTION
Fixes #3126

Somehow I managed to build v1.10.0 wrong for the npm release (I had locally linked in an unstable version of three.js). I've  now updated our release process doc to avoid this in the future. So, v1.10.1 is actually identical to v1.10.0 in terms of what you'd get if you pull  these release tags from github and built them. But the npm versions will be different, and v1.10.1 will be  correct.