### PR TITLE
Set texture name

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -52,7 +52,7 @@ export interface SceneGraphInterface {
   scale: string;
   readonly originalGltfJson: GLTF|null;
   exportScene(options?: SceneExportOptions): Promise<Blob>;
-  createTexture(uri: string, type?: string, name?: string): Promise<ModelViewerTexture|null>;
+  createTexture(uri: string, type?: string): Promise<ModelViewerTexture|null>;
   /**
    * Intersects a ray with the scene and returns a list of materials who's
    * objects were intersected.
@@ -119,7 +119,7 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       };
     }
 
-    async createTexture(uri: string, type: string = 'image/png', name: string):
+    async createTexture(uri: string, type: string = 'image/png'):
         Promise<ModelViewerTexture|null> {
       const currentGLTF = this[$currentGLTF];
       const texture: Texture = await new Promise<Texture>(
@@ -139,10 +139,6 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       // to PNGs, we allow the user of the API to specify the type.
       if (type === 'image/jpeg') {
         texture.format = RGBFormat;
-      }
-
-      if (name) {
-        texture.name = name;
       }
 
       return new ModelViewerTexture(this[$getOnUpdateMethod](), texture);

--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -52,7 +52,7 @@ export interface SceneGraphInterface {
   scale: string;
   readonly originalGltfJson: GLTF|null;
   exportScene(options?: SceneExportOptions): Promise<Blob>;
-  createTexture(uri: string, type?: string): Promise<ModelViewerTexture|null>;
+  createTexture(uri: string, type?: string, name?: string): Promise<ModelViewerTexture|null>;
   /**
    * Intersects a ray with the scene and returns a list of materials who's
    * objects were intersected.
@@ -119,7 +119,7 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       };
     }
 
-    async createTexture(uri: string, type: string = 'image/png'):
+    async createTexture(uri: string, type: string = 'image/png', name: string):
         Promise<ModelViewerTexture|null> {
       const currentGLTF = this[$currentGLTF];
       const texture: Texture = await new Promise<Texture>(
@@ -139,6 +139,10 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       // to PNGs, we allow the user of the API to specify the type.
       if (type === 'image/jpeg') {
         texture.format = RGBFormat;
+      }
+
+      if (name) {
+        texture.name = name;
       }
 
       return new ModelViewerTexture(this[$getOnUpdateMethod](), texture);

--- a/packages/model-viewer/src/features/scene-graph/image.ts
+++ b/packages/model-viewer/src/features/scene-graph/image.ts
@@ -47,7 +47,9 @@ export class Image extends ThreeDOMElement implements ImageInterface {
       onUpdate: () => void, texture: ThreeTexture|null,
       gltfImage: GLTFImage|null) {
     gltfImage = gltfImage ?? {
-      name: 'adhoc_image',
+      name: (texture && texture.image && texture.image.src) ?
+          texture.image.src.split('/').pop() :
+          'adhoc_image',
       uri: (texture && texture.image && texture.image.src) ?
           texture.image.src :
           'adhoc_image' + adhocNum++
@@ -77,6 +79,7 @@ export class Image extends ThreeDOMElement implements ImageInterface {
 
   async setURI(uri: string): Promise<void> {
     (this[$sourceObject] as GLTFImage).uri = uri;
+    (this[$sourceObject] as GLTFImage).name = uri.split('/').pop();
 
     const image = await new Promise((resolve, reject) => {
       loader.load(uri, resolve, undefined, reject);

--- a/packages/model-viewer/src/features/scene-graph/image.ts
+++ b/packages/model-viewer/src/features/scene-graph/image.ts
@@ -71,6 +71,10 @@ export class Image extends ThreeDOMElement implements ImageInterface {
     return this.uri != null ? 'external' : 'embedded';
   }
 
+  set name(name: string) {
+    (this[$sourceObject] as GLTFImage).name = "image_" + name;
+  }
+
   async setURI(uri: string): Promise<void> {
     (this[$sourceObject] as GLTFImage).uri = uri;
 

--- a/packages/model-viewer/src/features/scene-graph/image.ts
+++ b/packages/model-viewer/src/features/scene-graph/image.ts
@@ -74,7 +74,7 @@ export class Image extends ThreeDOMElement implements ImageInterface {
   }
 
   set name(name: string) {
-    (this[$sourceObject] as GLTFImage).name = "image_" + name;
+    (this[$sourceObject] as GLTFImage).name = name;
   }
 
   async setURI(uri: string): Promise<void> {

--- a/packages/model-viewer/src/features/scene-graph/texture.ts
+++ b/packages/model-viewer/src/features/scene-graph/texture.ts
@@ -54,6 +54,11 @@ export class Texture extends ThreeDOMElement implements TextureInterface {
     return (this[$sourceObject] as any).name || '';
   }
 
+  set name(name: string) {
+    (this[$sourceObject] as any).name = "texture_" + name;
+    this[$image].name = name;
+  }
+
   get sampler(): Sampler {
     return this[$sampler];
   }

--- a/packages/model-viewer/src/features/scene-graph/texture.ts
+++ b/packages/model-viewer/src/features/scene-graph/texture.ts
@@ -55,8 +55,7 @@ export class Texture extends ThreeDOMElement implements TextureInterface {
   }
 
   set name(name: string) {
-    (this[$sourceObject] as any).name = "texture_" + name;
-    this[$image].name = name;
+    (this[$sourceObject] as any).name = name;
   }
 
   get sampler(): Sampler {

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -16,6 +16,7 @@
 -->
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <title>&lt;model-viewer&gt; Scene Graph Worklet</title>
   <meta charset="utf-8">
@@ -23,610 +24,570 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link type="text/css" href="../../styles/examples.css" rel="stylesheet" />
   <link type="text/css" href="../../styles/docs.css" rel="stylesheet" />
-  <link rel="shortcut icon" type="image/png" href="../../assets/favicon.png"/>
-
+  <link rel="shortcut icon" type="image/png" href="../../assets/favicon.png" />
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../../node_modules/focus-visible/dist/focus-visible.js" defer></script>
-
   <script>
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+    window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments) }; ga.l = +new Date;
     ga('create', 'UA-169901325-1', { 'storage': 'none' });
     ga('set', 'referrer', document.referrer.split('?')[0]);
     ga('set', 'anonymizeIp', true);
     ga('send', 'pageview');
   </script>
   <script async src='https://www.google-analytics.com/analytics.js'></script>
-
   <style>
-.controls {
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  align-items: left;
-  bottom: 8px;
-  left: 8px;
-}
+    .controls {
+      position: absolute;
+      display: flex;
+      flex-direction: column;
+      align-items: left;
+      bottom: 8px;
+      left: 8px;
+    }
 
-button {
-  font-size: 1.3em;
-  margin: 0 0.25em;
-}
+    #texture-name,
+    #image-name {
+      font-size: 0.8em;
+    }
+
+    button {
+      font-size: 1.3em;
+      margin: 0 0.25em;
+    }
   </style>
 </head>
+
 <body>
-<div class="examples-page">
-  <div class="sidebar" id="sidenav"></div>
-  <div id="toggle"></div>
+  <div class="examples-page">
+    <div class="sidebar" id="sidenav"></div>
+    <div id="toggle"></div>
+    <div class="examples-container">
+      <div class="sample">
+        <div id="variants" class="demo"></div>
+        <div class="content">
+          <div class="wrapper">
+            <div class="heading">
+              <h2 class="demo-title">Swap Model Variants</h2>
+              <p>This demonstrates the use of the glTF <a href="https://www.khronos.org/blog/streamlining-3d-commerce-with-material-variant-support-in-gltf-assets">materials variants extension</a> which allows multiple materials and textures to be
+                packed with a single geometry in a GLB. Our API exposes these variant names as <code>availableVariants</code> and you can select one using the <code>variantName</code> attribute. This is similar functionality to the lower-level
+                scene-graph API below, but in that case it is up to you to choose the right texture URL, rather than having that information stored in the GLB. <i>Note: setting <code>variantName</code> to <code>null</code> reverts to the initial
+                  material.</i></p>
+            </div>
+            <example-snippet stamp-to="variants" highlight-as="html">
+              <template>
+                <model-viewer id="shoe" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a Shoe">
+                  <div class="controls">
+                    <div>Variant: <select id="variant"></select></div>
+                  </div>
+                </model-viewer>
+                <script>
+                  const modelViewerVariants = document.querySelector("model-viewer#shoe");
+                  const select = document.querySelector('#variant');
 
-  <div class="examples-container">
-    <div class="sample">
-      <div id="variants" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-          <div class="heading">
-            <h2 class="demo-title">Swap Model Variants</h2>
-            <p>This demonstrates the use of the glTF <a
-            href="https://www.khronos.org/blog/streamlining-3d-commerce-with-material-variant-support-in-gltf-assets">materials
-            variants extension</a> which allows multiple materials and textures
-            to be packed with a single geometry in a GLB. Our API exposes these
-            variant names as <code>availableVariants</code> and you can select
-            one using the <code>variantName</code> attribute. This is similar
-            functionality to the lower-level scene-graph API below, but in that
-            case it is up to you to choose the right texture URL, rather than
-            having that information stored in the GLB. <i>Note: setting <code>variantName</code>
-            to <code>null</code> reverts to the initial material.</i></p>
+                  modelViewerVariants.addEventListener('load', () => {
+                    const names = modelViewerVariants.availableVariants;
+                    for (const name of names) {
+                      const option = document.createElement('option');
+                      option.value = name;
+                      option.textContent = name;
+                      select.appendChild(option);
+                    }
+                    // Adds a default option.
+                    const option = document.createElement('option');
+                    option.value = 'default';
+                    option.textContent = 'Default';
+                    select.appendChild(option);
+                  });
+
+                  select.addEventListener('input', (event) => {
+                    modelViewerVariants.variantName = event.target.value === 'default' ? null : event.target.value;
+                  });
+                </script>
+              </template>
+            </example-snippet>
           </div>
-          <example-snippet stamp-to="variants" highlight-as="html">
-            <template>
-<model-viewer id="shoe" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a Shoe">
-  <div class="controls">
-    <div>Variant: <select id="variant"></select></div>
-  </div>
-</model-viewer>
-<script>
-const modelViewerVariants = document.querySelector("model-viewer#shoe");
-const select = document.querySelector('#variant');
-
-modelViewerVariants.addEventListener('load', () => {
-  const names = modelViewerVariants.availableVariants;
-  for (const name of names) {
-    const option = document.createElement('option');
-    option.value = name;
-    option.textContent = name;
-    select.appendChild(option);
-  }
-  // Adds a default option.
-  const option = document.createElement('option');
-    option.value = 'default';
-    option.textContent = 'Default';
-    select.appendChild(option);
-});
-
-select.addEventListener('input', (event) => {
-  modelViewerVariants.variantName = event.target.value === 'default' ? null : event.target.value;
-});
-</script>
-            </template>
-          </example-snippet>
         </div>
       </div>
-    </div>
+      <div class="sample">
+        <div id="transforms" class="demo"></div>
+        <div class="content">
+          <div class="wrapper">
+            <div class="heading">
+              <h2 class="demo-title">Model Transformations</h2>
+              <p>This demonstrates the <code>orientation</code> and <code>scale</code> attributes which allow the model to be transformed. Note that if specified before the model loads, they will be taken into account by the automatic camera framing.
+                If they are changed afterwards the camera will not move, so to get new automatic framing the <code>updateFraming()</code> method must be called. Also, the <code>bounds</code> attribute is set to <code>"tight"</code> to keep the
+                transformed model from floating over its shadow.</p>
+              <p>Note that these changes can be made in AR as well, but only in WebXR mode, as this is the only mode that remains in the browser. Changes you made ahead of time will not be reflected in Scene Viewer, since this app downloads the
+                original model again from its URL. iOS Quick Look will reflect your changes as long as <code>ios-src</code> is not specified, since in this case a USDZ will be generated on the fly from the current state.</p>
+            </div>
+            <example-snippet stamp-to="transforms" highlight-as="html">
+              <template>
+                <model-viewer id="transform" orientation="20deg 0 0" bounds="tight" shadow-intensity="1" camera-controls ar ar-modes="webxr scene-viewer quick-look" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
+                  <div class="controls">
+                    <div>Roll: <input id="roll" value="20" size="3" class="number"> degrees</div>
+                    <div>Pitch: <input id="pitch" value="0" size="3" class="number"> degrees</div>
+                    <div>Yaw: <input id="yaw" value="0" size="3" class="number"> degrees</div>
+                    <div> Scale: X: <input id="x" value="1" size="3" class="number">, Y: <input id="y" value="1" size="3" class="number">, Z: <input id="z" value="1" size="3" class="number">
+                    </div>
+                    <button id="frame">Update Framing</button>
+                  </div>
+                </model-viewer>
+                <script>
+                  const modelViewerTransform = document.querySelector("model-viewer#transform");
+                  const roll = document.querySelector('#roll');
+                  const pitch = document.querySelector('#pitch');
+                  const yaw = document.querySelector('#yaw');
+                  const x = document.querySelector('#x');
+                  const y = document.querySelector('#y');
+                  const z = document.querySelector('#z');
+                  const frame = document.querySelector('#frame');
 
-    <div class="sample">
-      <div id="transforms" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-          <div class="heading">
-            <h2 class="demo-title">Model Transformations</h2>
-            <p>This demonstrates the <code>orientation</code> and
-            <code>scale</code> attributes which allow the model to be
-            transformed. Note that if specified before the model loads, they
-            will be taken into account by the automatic camera framing. If they
-            are changed afterwards the camera will not move, so to get new
-            automatic framing the <code>updateFraming()</code> method must be
-            called. Also, the <code>bounds</code> attribute is set to
-            <code>"tight"</code> to keep the transformed model from floating
-            over its shadow.</p>
-            <p>Note that these changes can be made in AR as well, but only in
-            WebXR mode, as this is the only mode that remains in the browser.
-            Changes you made ahead of time will not be reflected in Scene
-            Viewer, since this app downloads the original model again from its
-            URL. iOS Quick Look will reflect your changes as long as
-            <code>ios-src</code> is not specified, since in this case a USDZ
-            will be generated on the fly from the current state.</p>
+                  frame.addEventListener('click', () => {
+                    modelViewerTransform.updateFraming();
+                  });
+
+                  const updateOrientation = () => {
+                    modelViewerTransform.orientation = `${roll.value}deg ${pitch.value}deg ${yaw.value}deg`;
+                  };
+
+                  const updateScale = () => {
+                    modelViewerTransform.scale = `${x.value} ${y.value} ${z.value}`;
+                  };
+
+                  roll.addEventListener('input', () => {
+                    updateOrientation();
+                  });
+                  pitch.addEventListener('input', () => {
+                    updateOrientation();
+                  });
+                  yaw.addEventListener('input', () => {
+                    updateOrientation();
+                  });
+                  x.addEventListener('input', () => {
+                    updateScale();
+                  });
+                  y.addEventListener('input', () => {
+                    updateScale();
+                  });
+                  z.addEventListener('input', () => {
+                    updateScale();
+                  });
+                </script>
+              </template>
+            </example-snippet>
           </div>
-          <example-snippet stamp-to="transforms" highlight-as="html">
-            <template>
-<model-viewer id="transform" orientation="20deg 0 0" bounds="tight" shadow-intensity="1" camera-controls ar ar-modes="webxr scene-viewer quick-look" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
-  <div class="controls">
-    <div>Roll: <input id="roll" value="20" size="3" class="number"> degrees</div>
-    <div>Pitch: <input id="pitch" value="0" size="3" class="number"> degrees</div>
-    <div>Yaw: <input id="yaw" value="0" size="3" class="number"> degrees</div>
-    <div>
-      Scale: X: <input id="x" value="1" size="3" class="number">,
-      Y: <input id="y" value="1" size="3" class="number">,
-      Z: <input id="z" value="1" size="3" class="number">
-    </div>
-    <button id="frame">Update Framing</button>
-  </div>
-</model-viewer>
-<script>
-const modelViewerTransform = document.querySelector("model-viewer#transform");
-const roll = document.querySelector('#roll');
-const pitch = document.querySelector('#pitch');
-const yaw = document.querySelector('#yaw');
-const x = document.querySelector('#x');
-const y = document.querySelector('#y');
-const z = document.querySelector('#z');
-const frame = document.querySelector('#frame');
-
-frame.addEventListener('click', () => {
-  modelViewerTransform.updateFraming();
-});
-
-const updateOrientation = () => {
-  modelViewerTransform.orientation = `${roll.value}deg ${pitch.value}deg ${yaw.value}deg`;
-};
-
-const updateScale = () => {
-  modelViewerTransform.scale = `${x.value} ${y.value} ${z.value}`;
-};
-
-roll.addEventListener('input', () => {
-  updateOrientation();
-});
-pitch.addEventListener('input', () => {
-  updateOrientation();
-});
-yaw.addEventListener('input', () => {
-  updateOrientation();
-});
-x.addEventListener('input', () => {
-  updateScale();
-});
-y.addEventListener('input', () => {
-  updateScale();
-});
-z.addEventListener('input', () => {
-  updateScale();
-});
-</script>
-            </template>
-          </example-snippet>
         </div>
       </div>
-    </div>
+      <div class="sample">
+        <div id="changeColor" class="demo"></div>
+        <div class="content">
+          <div class="wrapper">
+            <h4 id="intro"><span class="font-medium">Directly manipulate the scene graph</span></h4>
+            <div class="heading">
+              <h2 class="demo-title">Change Material Base Color</h2>
+              <p>This is an experimental feature, and the API is considered highly unstable. Please try it out, but be prepared for it to change!</p>
+              <p>As above, you can change these values in AR, but only in WebXR mode. iOS Quick Look does not reflect these color changes as USDZ does not appear to support colors multiplied onto textures.</p>
+            </div>
+            <example-snippet stamp-to="changeColor" highlight-as="html">
+              <template>
+                <model-viewer id="color" camera-controls interaction-prompt="none" src="../../shared-assets/models/Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of an astronaut">
+                  <div class="controls" , id="color-controls">
+                    <button data-color="1,0,0,1">Red</button>
+                    <button data-color="0,1,0,1">Green</button>
+                    <button data-color="0,0,1,1">Blue</button>
+                  </div>
+                </model-viewer>
+                <script>
+                  const modelViewerColor = document.querySelector("model-viewer#color");
 
-    <div class="sample">
-      <div id="changeColor" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-          <h4 id="intro"><span class="font-medium">Directly manipulate the scene graph</span></h4>
-          <div class="heading">
-            <h2 class="demo-title">Change Material Base Color</h2>
-            <p>This is an experimental feature, and the API is considered highly
-            unstable. Please try it out, but be prepared for it to change!</p>
-            <p>As above, you can change these values in AR, but only in WebXR
-            mode. iOS Quick Look does not reflect these color changes as USDZ
-            does not appear to support colors multiplied onto textures.</p>
+                  document.querySelector('#color-controls').addEventListener('click', (event) => {
+                    const colorString = event.target.dataset.color;
+
+                    if (!colorString) {
+                      return;
+                    }
+
+                    const color = colorString.split(',')
+                      .map(numberString => parseFloat(numberString));
+
+                    console.log('Changing color to: ', color);
+                    const [material] = modelViewerColor.model.materials;
+                    material.pbrMetallicRoughness.setBaseColorFactor(color);
+                  });
+                </script>
+              </template>
+            </example-snippet>
           </div>
-          <example-snippet stamp-to="changeColor" highlight-as="html">
-            <template>
-<model-viewer id="color" camera-controls interaction-prompt="none" src="../../shared-assets/models/Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of an astronaut">
-  <div class="controls", id="color-controls">
-    <button data-color="1,0,0,1">Red</button>
-    <button data-color="0,1,0,1">Green</button>
-    <button data-color="0,0,1,1">Blue</button>
-  </div>
-</model-viewer>
-<script>
-const modelViewerColor = document.querySelector("model-viewer#color");
-
-document.querySelector('#color-controls').addEventListener('click', (event) => {
-  const colorString = event.target.dataset.color;
-
-  if (!colorString) {
-    return;
-  }
-
-  const color = colorString.split(',')
-      .map(numberString => parseFloat(numberString));
-
-  console.log('Changing color to: ', color);
-  const [material] = modelViewerColor.model.materials;
-  material.pbrMetallicRoughness.setBaseColorFactor(color);
-});
-</script>
-            </template>
-          </example-snippet>
         </div>
       </div>
-    </div>
+      <div class="sample">
+        <div id="changeMaterial" class="demo"></div>
+        <div class="content">
+          <div class="wrapper">
+            <div class="heading">
+              <h2 class="demo-title">Change Material Metalness and Roughness Factors</h2>
+              <p>As above, you can change these values in AR, but only in WebXR mode. iOS Quick Look does reflect these property changes since they are not also textured.</p>
+            </div>
+            <example-snippet stamp-to="changeMaterial" highlight-as="html">
+              <template>
+                <model-viewer id="sphere" camera-controls interaction-prompt="none" src="../../shared-assets/models/reflective-sphere.gltf" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a sphere">
+                  <div class="controls">
+                    <div>
+                      <p>Metalness: <span id="metalness-value"></span></p>
+                      <input id="metalness" type="range" min="0" max="1" step="0.01" value="1" />
+                    </div>
+                    <div>
+                      <p>Roughness: <span id="roughness-value"></span></p>
+                      <input id="roughness" type="range" min="0" max="1" step="0.01" value="0" />
+                    </div>
+                  </div>
+                </model-viewer>
+                <script>
+                  const modelViewerParameters = document.querySelector("model-viewer#sphere");
 
+                  modelViewerParameters.addEventListener("load", (ev) => {
 
-    <div class="sample">
-      <div id="changeMaterial" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-          <div class="heading">
-            <h2 class="demo-title">Change Material Metalness and Roughness Factors</h2>
-            <p>As above, you can change these values in AR, but only in WebXR
-            mode. iOS Quick Look does reflect these property changes since they
-            are not also textured.</p>
+                    let material = modelViewerParameters.model.materials[0];
+
+                    let metalnessDisplay = document.querySelector("#metalness-value");
+                    let roughnessDisplay = document.querySelector("#roughness-value");
+
+                    metalnessDisplay.textContent = material.pbrMetallicRoughness.metallicFactor;
+                    roughnessDisplay.textContent = material.pbrMetallicRoughness.roughnessFactor;
+
+                    // Defaults to gold
+                    material.pbrMetallicRoughness.setBaseColorFactor([0.7294, 0.5333, 0.0392]);
+
+                    document.querySelector('#metalness').addEventListener('input', (event) => {
+                      material.pbrMetallicRoughness.setMetallicFactor(event.target.value);
+                      metalnessDisplay.textContent = event.target.value;
+                    });
+
+                    document.querySelector('#roughness').addEventListener('input', (event) => {
+                      material.pbrMetallicRoughness.setRoughnessFactor(event.target.value);
+                      roughnessDisplay.textContent = event.target.value;
+                    });
+                  })
+                </script>
+              </template>
+            </example-snippet>
           </div>
-          <example-snippet stamp-to="changeMaterial" highlight-as="html">
-            <template>
-<model-viewer id="sphere" camera-controls interaction-prompt="none" src="../../shared-assets/models/reflective-sphere.gltf" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a sphere">
-  <div class="controls">
-    <div>
-      <p>Metalness: <span id="metalness-value"></span></p>
-      <input id="metalness" type="range" min="0" max="1" step="0.01" value="1" />
-    </div>
-    <div>
-      <p>Roughness: <span id="roughness-value"></span></p>
-      <input id="roughness" type="range" min="0" max="1" step="0.01" value="0" />
-    </div>
-  </div>
-</model-viewer>
-<script>
-const modelViewerParameters = document.querySelector("model-viewer#sphere");
-
-modelViewerParameters.addEventListener("load", (ev) => {
-
-  let material = modelViewerParameters.model.materials[0];
-
-  let metalnessDisplay = document.querySelector("#metalness-value");
-  let roughnessDisplay = document.querySelector("#roughness-value");
-
-  metalnessDisplay.textContent = material.pbrMetallicRoughness.metallicFactor;
-  roughnessDisplay.textContent = material.pbrMetallicRoughness.roughnessFactor;
-
-  // Defaults to gold
-  material.pbrMetallicRoughness.setBaseColorFactor([0.7294, 0.5333, 0.0392]);
-
-  document.querySelector('#metalness').addEventListener('input', (event) => {
-    material.pbrMetallicRoughness.setMetallicFactor(event.target.value);
-    metalnessDisplay.textContent = event.target.value;
-  });
-
-  document.querySelector('#roughness').addEventListener('input', (event) => {
-    material.pbrMetallicRoughness.setRoughnessFactor(event.target.value);
-    roughnessDisplay.textContent = event.target.value;
-  });
-})
-</script>
-            </template>
-          </example-snippet>
         </div>
       </div>
-    </div>
+      <div class="sample">
+        <div id="createTexturesExample" class="demo"></div>
+        <div class="content">
+          <div class="wrapper">
+            <div class="heading">
+              <h2 class="demo-title">Create textures</h2>
+              <p>As above, you can change these values in AR, but only in WebXR mode. iOS Quick Look reflects these texture changes so long as the USDZ is auto-generated.</p>
+            </div>
+            <example-snippet stamp-to="createTexturesExample" highlight-as="html">
+              <template>
+                <model-viewer id="duck" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Duck/glTF-Binary/Duck.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a helmet">
+                  <div class="controls">
+                    <p>Normals</p>
+                    <select id="normals2">
+                      <option>None</option>
+                      <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_normal.jpg">Damaged helmet</option>
+                      <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_normal.png">Lantern Pole</option>
+                      <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_normal.png">Water Bottle</option>
+                    </select>
+                    <p>Custom texture name</p>
+                    <p id="texture-name">None</p>
+                    <p>Image name from file name</p>
+                    <p id="image-name">None</p>
+                  </div>
+                </model-viewer>
+                <script type="module">
+                  const modelViewerTexture = document.querySelector("model-viewer#duck");
 
+                  modelViewerTexture.addEventListener("load", () => {
 
-    <div class="sample">
-      <div id="createTexturesExample" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-          <div class="heading">
-            <h2 class="demo-title">Create textures</h2>
-            <p>As above, you can change these values in AR, but only in WebXR
-              mode. iOS Quick Look reflects these texture changes so long as the
-              USDZ is auto-generated.</p>
+                    const material = modelViewerTexture.model.materials[0];
+
+                    const createAndApplyTexture = async (channel, event) => {
+                      if (event.target.value == "None") {
+                        // Clears the texture.
+                        material[channel].setTexture(null);
+                      } else if (event.target.value) {
+                        // Creates a new texture.
+                        const texture = await modelViewerTexture.createTexture(event.target.value);
+                        texture.name = event.target.options[event.target.selectedIndex].text.replace(/ /g, "_").toLowerCase();
+                        // Applies the new texture to the specified channel.
+                        material[channel].setTexture(texture);
+                        document.querySelector('#texture-name').innerText = texture.name;
+                        document.querySelector('#image-name').innerText = texture.source.name;
+                      }
+                    }
+
+                    document.querySelector('#normals2').addEventListener('input', (event) => {
+                      createAndApplyTexture('normalTexture', event);
+                    });
+                  });
+
+                </script>
+              </template>
+            </example-snippet>
           </div>
-          <example-snippet stamp-to="createTexturesExample" highlight-as="html">
-            <template>
-<model-viewer id="duck" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Duck/glTF-Binary/Duck.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a helmet">
-  <div class="controls">
-      <p>Normals</p>
-      <select id="normals2">
-        <option>None</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_normal.jpg">Damaged helmet</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_normal.png">Lantern Pole</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_normal.png">Water Bottle</option>
-      </select>
-    </div>
-</model-viewer>
-<script type="module">
-const modelViewerTexture = document.querySelector("model-viewer#duck");
-
-modelViewerTexture.addEventListener("load", () => {
-
-  const material = modelViewerTexture.model.materials[0];
-
-  const createAndApplyTexture = async (channel, event) => {
-    if (event.target.value == "None") {
-      // Clears the texture.
-      material[channel].setTexture(null);
-    } else if (event.target.value) {
-      // Creates a new texture.
-      const texture = await modelViewerTexture.createTexture(event.target.value);
-      texture.name = "ciao";
-      // Applies the new texture to the specified channel.
-      material[channel].setTexture(texture);
-      console.log(material[channel])
-    }
-  }
-
-  document.querySelector('#normals2').addEventListener('input', (event) => {
-    console.log("here")
-    createAndApplyTexture('normalTexture', event);
-  });
-});
-
-</script>
-            </template>
-          </example-snippet>
         </div>
       </div>
-    </div>
+      <div class="sample">
+        <div id="swapTextures" class="demo"></div>
+        <div class="content">
+          <div class="wrapper">
+            <div class="heading">
+              <h2 class="demo-title">Swap textures</h2>
+              <p>As above, you can change these values in AR, but only in WebXR mode. iOS Quick Look reflects these texture changes so long as the USDZ is auto-generated.</p>
+            </div>
+            <example-snippet stamp-to="swapTextures" highlight-as="html">
+              <template>
+                <model-viewer id="helmet" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a helmet">
+                  <div class="controls">
+                    <div>
+                      <p>Diffuse</p>
+                      <select id="diffuse">
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_albedo.jpg">Damaged helmet</option>
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_baseColor.png">Lantern Pole</option>
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_baseColor.png">Water Bottle</option>
+                      </select>
+                    </div>
+                    <div>
+                      <p>Metallic-roughness</p>
+                      <select id="metallicRoughness">
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_metalRoughness.jpg">Damaged helmet</option>
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_roughnessMetallic.png">Lantern Pole</option>
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
+                      </select>
+                    </div>
+                    <div>
+                      <p>Normals</p>
+                      <select id="normals">
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_normal.jpg">Damaged helmet</option>
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_normal.png">Lantern Pole</option>
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_normal.png">Water Bottle</option>
+                      </select>
+                    </div>
+                    <div>
+                      <p>Occlusion</p>
+                      <select id="occlusion">
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_AO.jpg">Damaged helmet</option>
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
+                      </select>
+                    </div>
+                    <div>
+                      <p>Emission</p>
+                      <select id="emission">
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_emissive.jpg">Damaged helmet</option>
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_emissive.png">Lantern Pole</option>
+                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_emissive.png">Water Bottle</option>
+                      </select>
+                    </div>
+                  </div>
+                </model-viewer>
+                <script type="module">
+                  const modelViewerTexture = document.querySelector("model-viewer#helmet");
 
+                  modelViewerTexture.addEventListener("load", () => {
 
-    <div class="sample">
-      <div id="swapTextures" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-          <div class="heading">
-            <h2 class="demo-title">Swap textures</h2>
-            <p>As above, you can change these values in AR, but only in WebXR
-              mode. iOS Quick Look reflects these texture changes so long as the
-              USDZ is auto-generated.</p>
+                    const material = modelViewerTexture.model.materials[0];
+
+                    const createAndApplyTexture = async (channel, event) => {
+                      const texture = await modelViewerTexture.createTexture(event.target.value);
+                      if (channel.includes('base') || channel.includes('metallic')) {
+                        material.pbrMetallicRoughness[channel].setTexture(texture);
+                      } else {
+                        material[channel].setTexture(texture);
+                      }
+                    }
+
+                    document.querySelector('#normals').addEventListener('input', (event) => {
+                      createAndApplyTexture('normalTexture', event);
+                    });
+
+                    document.querySelector('#occlusion').addEventListener('input', (event) => {
+                      createAndApplyTexture('occlusionTexture', event);
+                    });
+
+                    document.querySelector('#emission').addEventListener('input', (event) => {
+                      createAndApplyTexture('emissiveTexture', event);
+                    });
+
+                    document.querySelector('#diffuse').addEventListener('input', (event) => {
+                      createAndApplyTexture('baseColorTexture', event);
+                    });
+
+                    document.querySelector('#metallicRoughness').addEventListener('input', (event) => {
+                      createAndApplyTexture('metallicRoughnessTexture', event);
+                    });
+                  });
+
+                </script>
+              </template>
+            </example-snippet>
           </div>
-          <example-snippet stamp-to="swapTextures" highlight-as="html">
-            <template>
-<model-viewer id="helmet" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a helmet">
-  <div class="controls">
-    <div>
-      <p>Diffuse</p>
-      <select id="diffuse">
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_albedo.jpg">Damaged helmet</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_baseColor.png">Lantern Pole</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_baseColor.png">Water Bottle</option>
-      </select>
-    </div>
-    <div>
-      <p>Metallic-roughness</p>
-      <select id="metallicRoughness">
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_metalRoughness.jpg">Damaged helmet</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_roughnessMetallic.png">Lantern Pole</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
-      </select>
-    </div>
-    <div>
-      <p>Normals</p>
-      <select id="normals">
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_normal.jpg">Damaged helmet</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_normal.png">Lantern Pole</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_normal.png">Water Bottle</option>
-      </select>
-    </div>
-    <div>
-      <p>Occlusion</p>
-      <select id="occlusion">
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_AO.jpg">Damaged helmet</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
-      </select>
-    </div>
-    <div>
-      <p>Emission</p>
-      <select id="emission">
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_emissive.jpg">Damaged helmet</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_emissive.png">Lantern Pole</option>
-        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_emissive.png">Water Bottle</option>
-      </select>
-    </div>
-  </div>
-</model-viewer>
-<script type="module">
-const modelViewerTexture = document.querySelector("model-viewer#helmet");
-
-modelViewerTexture.addEventListener("load", () => {
-
-  const material = modelViewerTexture.model.materials[0];
-
-  const createAndApplyTexture = async (channel, event) => {
-    const texture = await modelViewerTexture.createTexture(event.target.value);
-    if (channel.includes('base') || channel.includes('metallic')) {
-      material.pbrMetallicRoughness[channel].setTexture(texture);
-    } else {
-      material[channel].setTexture(texture);
-    }
-  }
-
-  document.querySelector('#normals').addEventListener('input', (event) => {
-    createAndApplyTexture('normalTexture', event);
-  });
-
-  document.querySelector('#occlusion').addEventListener('input', (event) => {
-    createAndApplyTexture('occlusionTexture', event);
-  });
-
-  document.querySelector('#emission').addEventListener('input', (event) => {
-    createAndApplyTexture('emissiveTexture', event);
-  });
-
-  document.querySelector('#diffuse').addEventListener('input', (event) => {
-    createAndApplyTexture('baseColorTexture', event);
-  });
-
-  document.querySelector('#metallicRoughness').addEventListener('input', (event) => {
-    createAndApplyTexture('metallicRoughnessTexture', event);
-  });
-});
-
-</script>
-            </template>
-          </example-snippet>
         </div>
       </div>
-    </div>
+      <div class="sample">
+        <div id="pickMaterialExample" class="demo"></div>
+        <div class="content">
+          <div class="wrapper">
+            <div class="heading">
+              <h2 class="demo-title">Pick a Material</h2>
+              <p>Demonstrates selecting a material with pointer input and changing its color. Note this also works in the WebXR AR mode. Also demonstrates the use of the scale attribute since this GLB was erroneously modeled in mm instead of meters.
+              </p>
+            </div>
+            <example-snippet stamp-to="pickMaterialExample" highlight-as="html">
+              <template>
+                <model-viewer id="pickMaterial" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer" scale="0.001 0.001 0.001" alt="A Material Picking Example">
+                </model-viewer>
+                <script type="module">
+                  const modelViewer = document.querySelector("model-viewer#pickMaterial");
 
+                  modelViewer.addEventListener("load", () => {
 
-    <div class="sample">
-      <div id="pickMaterialExample" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-          <div class="heading">
-            <h2 class="demo-title">Pick a Material</h2>
-            <p>Demonstrates selecting a material with pointer input and changing its color. Note this also works in the WebXR AR mode. Also demonstrates the use of the scale attribute since this GLB was erroneously modeled in mm instead of meters.</p>
+                    const changeColor = async (event) => {
+                      let material = modelViewer.materialFromPoint(event.clientX, event.clientY);
+
+                      if (material != null) {
+                        material.pbrMetallicRoughness.
+                          setBaseColorFactor([Math.random(), Math.random(), Math.random()]);
+                      }
+                    }
+
+                    modelViewer.addEventListener("click", changeColor);
+
+                  });
+
+                </script>
+              </template>
+            </example-snippet>
           </div>
-          <example-snippet stamp-to="pickMaterialExample" highlight-as="html">
-            <template>
-<model-viewer id="pickMaterial" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer" scale="0.001 0.001 0.001" alt="A Material Picking Example">
-</model-viewer>
-<script type="module">
-const modelViewer = document.querySelector("model-viewer#pickMaterial");
-
-modelViewer.addEventListener("load", () => {
-
-  const changeColor = async (event) => {
-    let material = modelViewer.materialFromPoint(event.clientX, event.clientY);
-
-    if(material != null) {
-      material.pbrMetallicRoughness.
-        setBaseColorFactor([Math.random(), Math.random(), Math.random()]);
-    }
-  }
-
-  modelViewer.addEventListener("click", changeColor);
-
-});
-
-</script>
-</template>
-          </example-snippet>
         </div>
       </div>
-    </div>
-
-    <div class="sample">
-      <div id="exporter" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-
-          <a class="lockup" href="../../index.html"><div class="icon-button icon-modelviewer-black"></div><h1>examples</h1></a>
-          <div class="heading">
-            <h2 class="demo-title">Exporter</h2>
+      <div class="sample">
+        <div id="exporter" class="demo"></div>
+        <div class="content">
+          <div class="wrapper">
+            <a class="lockup" href="../../index.html">
+              <div class="icon-button icon-modelviewer-black"></div>
+              <h1>examples</h1>
+            </a>
+            <div class="heading">
+              <h2 class="demo-title">Exporter</h2>
+            </div>
+            <example-snippet stamp-to="exporter" highlight-as="html">
+              <template>
+                <model-viewer id="static-model" src="../../shared-assets/models/Astronaut.glb" shadow-intensity="1" camera-controls alt="A 3D model of an astronaut">
+                  <div class="controls">
+                    <button onclick="exportGLB()">Export GLB</button>
+                  </div>
+                </model-viewer>
+                <script>
+                  async function exportGLB() {
+                    let modelViewer = document.getElementById("static-model");
+                    const glTF = await modelViewer.exportScene();
+                    var file = new File([glTF], "export.glb");
+                    var link = document.createElement("a");
+                    link.download = file.name;
+                    link.href = URL.createObjectURL(file);
+                    link.click();
+                  }
+                </script>
+              </template>
+            </example-snippet>
           </div>
-          <example-snippet stamp-to="exporter" highlight-as="html">
-            <template>
-<model-viewer id="static-model" src="../../shared-assets/models/Astronaut.glb" shadow-intensity="1" camera-controls alt="A 3D model of an astronaut">
-  <div class="controls">
-    <button onclick="exportGLB()">Export GLB</button>
-  </div>
-</model-viewer>
-<script>
-  async function exportGLB(){
-    let modelViewer = document.getElementById("static-model");
-    const glTF = await modelViewer.exportScene();
-    var file = new File([glTF], "export.glb");
-    var link = document.createElement("a");
-    link.download =file.name;
-    link.href = URL.createObjectURL(file);
-    link.click();
-  }
-</script>
-            </template>
-          </example-snippet>
         </div>
       </div>
-    </div>
-
-    <div class="sample">
-      <div id="exporterWithOptions" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-          <div class="heading">
-            <h2 class="demo-title">Exporter with options</h2>
+      <div class="sample">
+        <div id="exporterWithOptions" class="demo"></div>
+        <div class="content">
+          <div class="wrapper">
+            <div class="heading">
+              <h2 class="demo-title">Exporter with options</h2>
+            </div>
+            <example-snippet stamp-to="exporterWithOptions" highlight-as="html">
+              <template>
+                <model-viewer id="animated-model" src="../../shared-assets/models/Horse.glb" autoplay camera-controls alt="A 3D model of a horse galloping">
+                  <div class="controls">
+                    <button onclick="exportScene(true)">Export GLB</button>
+                    <button onclick="exportScene(false)">Export GLTF</button>
+                  </div>
+                </model-viewer>
+                <script>
+                  async function exportScene(binary) {
+                    let options = {
+                      binary: binary,
+                      trs: true,
+                      onlyVisible: true,
+                      maxTextureSize: 256,
+                      forcePowerOfTwoTextures: true,
+                      includeCustomExtensions: false,
+                      embedImages: true
+                    };
+                    let modelViewer = document.getElementById("animated-model");
+                    const glTF = await modelViewer.exportScene(options);
+                    var file = new File([glTF], binary ? "export.glb" : "export.gltf");
+                    var link = document.createElement("a");
+                    link.download = file.name;
+                    link.href = URL.createObjectURL(file);
+                    link.click();
+                  }
+                </script>
+              </template>
+            </example-snippet>
           </div>
-          <example-snippet stamp-to="exporterWithOptions" highlight-as="html">
-            <template>
-<model-viewer id="animated-model" src="../../shared-assets/models/Horse.glb" autoplay camera-controls alt="A 3D model of a horse galloping">
-  <div class="controls">
-    <button onclick="exportScene(true)">Export GLB</button>
-    <button onclick="exportScene(false)">Export GLTF</button>
-  </div>
-</model-viewer>
-<script>
-  async function exportScene(binary){
-    let options = {
-      binary: binary,
-      trs: true,
-      onlyVisible: true,
-      maxTextureSize: 256,
-      forcePowerOfTwoTextures: true,
-      includeCustomExtensions: false,
-      embedImages: true
-    };
-    let modelViewer = document.getElementById("animated-model");
-    const glTF = await modelViewer.exportScene(options);
-    var file = new File([glTF], binary ? "export.glb" : "export.gltf");
-    var link = document.createElement("a");
-    link.download =file.name;
-    link.href = URL.createObjectURL(file);
-    link.click();
-  }
-</script>
-            </template>
-          </example-snippet>
         </div>
       </div>
-    </div>
-
-    <div class="footer">
-      <ul>
-        <li class="attribution">
-          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/MaterialsVariantsShoe">Shoe</a> ©Copyright 2020 <a href="https://www.shopify.com/">Shopify Inc.</a>,
-          licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>.
-        </li>
-        <li class="attribution">
-          <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
-          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>.
-        </li>
-        <li class="attribution">
-          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet">Damaged Helmet</a> by <a href="https://sketchfab.com/theblueturtle_">theblueturtle_</a>,
-          licensed under <a href="https://creativecommons.org/licenses/by-nc/3.0/us/">Creative Commons Attribution-NonCommercial</a>.
-        </li>
-        <li class="attribution">
-          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Lantern">Lantern</a>,
-          licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero</a>.
-        </li>
-        <li class="attribution">
-          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/WaterBottle">Water Bottle</a>,
-          licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero</a>.
-        </li>
-        <li class="attribution">
-          <a href="https://github.com/dataarts/3-dreams-of-black/tree/master/deploy/files/models/soup">Horse</a> by <a href="https://github.com/dataarts">Google Data Arts Team</a>,
-          licensed under <a href="https://github.com/dataarts/3-dreams-of-black/blob/master/deploy/files/models/soup/LICENSE.txt">Creative Commons Attribution-NonCommercial-ShareAlike</a>.
-        </li>
-        <li class="attribution">
-          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Duck">Duck</a> by Sony Computer Entertainment Inc.,
-          licensed under <a href="https://web.archive.org/web/20160320123355/http://research.scea.com/scea_shared_source_license.html">the SCEA Shared Source License, Version 1.0</a>.
-        </li>
-        <li class="attribution">
-          <a href="https://github.com/dataarts/3-dreams-of-black/tree/master/deploy/files/models/soup">Buggy</a> by Okino Computer Graphics,
-          Data conversion from original JT to COLLADA has been kindly performed by Okino Computer Graphics, using <a href="http://www.okino.com/conv/conv.htm">Okino Polytrans Software</a>.
-        </li>
-      </ul>
-      <div style="margin-top:24px;" class="copyright">©Copyright 2018-2020 Google Inc. Licensed under the Apache License 2.0.</div>
-      <div id='footer-links'></div>
+      <div class="footer">
+        <ul>
+          <li class="attribution">
+            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/MaterialsVariantsShoe">Shoe</a> ©Copyright 2020 <a href="https://www.shopify.com/">Shopify Inc.</a>, licensed under <a
+              href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>.
+          </li>
+          <li class="attribution">
+            <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>, licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>.
+          </li>
+          <li class="attribution">
+            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet">Damaged Helmet</a> by <a href="https://sketchfab.com/theblueturtle_">theblueturtle_</a>, licensed under <a
+              href="https://creativecommons.org/licenses/by-nc/3.0/us/">Creative Commons Attribution-NonCommercial</a>.
+          </li>
+          <li class="attribution">
+            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Lantern">Lantern</a>, licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero</a>.
+          </li>
+          <li class="attribution">
+            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/WaterBottle">Water Bottle</a>, licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero</a>.
+          </li>
+          <li class="attribution">
+            <a href="https://github.com/dataarts/3-dreams-of-black/tree/master/deploy/files/models/soup">Horse</a> by <a href="https://github.com/dataarts">Google Data Arts Team</a>, licensed under <a
+              href="https://github.com/dataarts/3-dreams-of-black/blob/master/deploy/files/models/soup/LICENSE.txt">Creative Commons Attribution-NonCommercial-ShareAlike</a>.
+          </li>
+          <li class="attribution">
+            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Duck">Duck</a> by Sony Computer Entertainment Inc., licensed under <a
+              href="https://web.archive.org/web/20160320123355/http://research.scea.com/scea_shared_source_license.html">the SCEA Shared Source License, Version 1.0</a>.
+          </li>
+          <li class="attribution">
+            <a href="https://github.com/dataarts/3-dreams-of-black/tree/master/deploy/files/models/soup">Buggy</a> by Okino Computer Graphics, Data conversion from original JT to COLLADA has been kindly performed by Okino Computer Graphics, using <a
+              href="http://www.okino.com/conv/conv.htm">Okino Polytrans Software</a>.
+          </li>
+        </ul>
+        <div style="margin-top:24px;" class="copyright">©Copyright 2018-2020 Google Inc. Licensed under the Apache License 2.0.</div>
+        <div id='footer-links'></div>
+      </div>
     </div>
   </div>
-</div>
-
   <script type="module" src="../../examples/built/docs-and-examples.js">
   </script>
   <script type="module">
     (() => { init('examples-scenegraph'); })();
-    (() => { initFooterLinks();})();
+    (() => { initFooterLinks(); })();
   </script>
-
   <!-- Documentation-specific dependencies: -->
-  <script type="module"
-      src="../built/dependencies.js">
+  <script type="module" src="../built/dependencies.js">
   </script>
-
   <!-- Loads <model-viewer> on modern browsers: -->
-  <script type="module"
-      src="../../node_modules/@google/model-viewer/dist/model-viewer.js">
+  <script type="module" src="../../node_modules/@google/model-viewer/dist/model-viewer.js">
   </script>
 </body>
+
 </html>

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -339,12 +339,15 @@ modelViewerTexture.addEventListener("load", () => {
     } else if (event.target.value) {
       // Creates a new texture.
       const texture = await modelViewerTexture.createTexture(event.target.value);
+      texture.name = "ciao";
       // Applies the new texture to the specified channel.
       material[channel].setTexture(texture);
+      console.log(material[channel])
     }
   }
 
   document.querySelector('#normals2').addEventListener('input', (event) => {
+    console.log("here")
     createAndApplyTexture('normalTexture', event);
   });
 });

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -16,7 +16,6 @@
 -->
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <title>&lt;model-viewer&gt; Scene Graph Worklet</title>
   <meta charset="utf-8">
@@ -24,570 +23,621 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link type="text/css" href="../../styles/examples.css" rel="stylesheet" />
   <link type="text/css" href="../../styles/docs.css" rel="stylesheet" />
-  <link rel="shortcut icon" type="image/png" href="../../assets/favicon.png" />
+  <link rel="shortcut icon" type="image/png" href="../../assets/favicon.png"/>
+
   <!-- 💁 OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
   <script src="../../node_modules/focus-visible/dist/focus-visible.js" defer></script>
+
   <script>
-    window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments) }; ga.l = +new Date;
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
     ga('create', 'UA-169901325-1', { 'storage': 'none' });
     ga('set', 'referrer', document.referrer.split('?')[0]);
     ga('set', 'anonymizeIp', true);
     ga('send', 'pageview');
   </script>
   <script async src='https://www.google-analytics.com/analytics.js'></script>
+
   <style>
-    .controls {
-      position: absolute;
-      display: flex;
-      flex-direction: column;
-      align-items: left;
-      bottom: 8px;
-      left: 8px;
-    }
+.controls {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+  bottom: 8px;
+  left: 8px;
+}
 
-    #texture-name,
-    #image-name {
-      font-size: 0.8em;
-    }
+#texture-name,
+#image-name {
+  font-size: 0.8em;
+}
 
-    button {
-      font-size: 1.3em;
-      margin: 0 0.25em;
-    }
+button {
+  font-size: 1.3em;
+  margin: 0 0.25em;
+}
   </style>
 </head>
-
 <body>
-  <div class="examples-page">
-    <div class="sidebar" id="sidenav"></div>
-    <div id="toggle"></div>
-    <div class="examples-container">
-      <div class="sample">
-        <div id="variants" class="demo"></div>
-        <div class="content">
-          <div class="wrapper">
-            <div class="heading">
-              <h2 class="demo-title">Swap Model Variants</h2>
-              <p>This demonstrates the use of the glTF <a href="https://www.khronos.org/blog/streamlining-3d-commerce-with-material-variant-support-in-gltf-assets">materials variants extension</a> which allows multiple materials and textures to be
-                packed with a single geometry in a GLB. Our API exposes these variant names as <code>availableVariants</code> and you can select one using the <code>variantName</code> attribute. This is similar functionality to the lower-level
-                scene-graph API below, but in that case it is up to you to choose the right texture URL, rather than having that information stored in the GLB. <i>Note: setting <code>variantName</code> to <code>null</code> reverts to the initial
-                  material.</i></p>
-            </div>
-            <example-snippet stamp-to="variants" highlight-as="html">
-              <template>
-                <model-viewer id="shoe" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a Shoe">
-                  <div class="controls">
-                    <div>Variant: <select id="variant"></select></div>
-                  </div>
-                </model-viewer>
-                <script>
-                  const modelViewerVariants = document.querySelector("model-viewer#shoe");
-                  const select = document.querySelector('#variant');
+<div class="examples-page">
+  <div class="sidebar" id="sidenav"></div>
+  <div id="toggle"></div>
 
-                  modelViewerVariants.addEventListener('load', () => {
-                    const names = modelViewerVariants.availableVariants;
-                    for (const name of names) {
-                      const option = document.createElement('option');
-                      option.value = name;
-                      option.textContent = name;
-                      select.appendChild(option);
-                    }
-                    // Adds a default option.
-                    const option = document.createElement('option');
-                    option.value = 'default';
-                    option.textContent = 'Default';
-                    select.appendChild(option);
-                  });
-
-                  select.addEventListener('input', (event) => {
-                    modelViewerVariants.variantName = event.target.value === 'default' ? null : event.target.value;
-                  });
-                </script>
-              </template>
-            </example-snippet>
+  <div class="examples-container">
+    <div class="sample">
+      <div id="variants" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <div class="heading">
+            <h2 class="demo-title">Swap Model Variants</h2>
+            <p>This demonstrates the use of the glTF <a
+            href="https://www.khronos.org/blog/streamlining-3d-commerce-with-material-variant-support-in-gltf-assets">materials
+            variants extension</a> which allows multiple materials and textures
+            to be packed with a single geometry in a GLB. Our API exposes these
+            variant names as <code>availableVariants</code> and you can select
+            one using the <code>variantName</code> attribute. This is similar
+            functionality to the lower-level scene-graph API below, but in that
+            case it is up to you to choose the right texture URL, rather than
+            having that information stored in the GLB. <i>Note: setting <code>variantName</code>
+            to <code>null</code> reverts to the initial material.</i></p>
           </div>
+          <example-snippet stamp-to="variants" highlight-as="html">
+            <template>
+<model-viewer id="shoe" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a Shoe">
+  <div class="controls">
+    <div>Variant: <select id="variant"></select></div>
+  </div>
+</model-viewer>
+<script>
+const modelViewerVariants = document.querySelector("model-viewer#shoe");
+const select = document.querySelector('#variant');
+
+modelViewerVariants.addEventListener('load', () => {
+  const names = modelViewerVariants.availableVariants;
+  for (const name of names) {
+    const option = document.createElement('option');
+    option.value = name;
+    option.textContent = name;
+    select.appendChild(option);
+  }
+  // Adds a default option.
+  const option = document.createElement('option');
+    option.value = 'default';
+    option.textContent = 'Default';
+    select.appendChild(option);
+});
+
+select.addEventListener('input', (event) => {
+  modelViewerVariants.variantName = event.target.value === 'default' ? null : event.target.value;
+});
+</script>
+            </template>
+          </example-snippet>
         </div>
-      </div>
-      <div class="sample">
-        <div id="transforms" class="demo"></div>
-        <div class="content">
-          <div class="wrapper">
-            <div class="heading">
-              <h2 class="demo-title">Model Transformations</h2>
-              <p>This demonstrates the <code>orientation</code> and <code>scale</code> attributes which allow the model to be transformed. Note that if specified before the model loads, they will be taken into account by the automatic camera framing.
-                If they are changed afterwards the camera will not move, so to get new automatic framing the <code>updateFraming()</code> method must be called. Also, the <code>bounds</code> attribute is set to <code>"tight"</code> to keep the
-                transformed model from floating over its shadow.</p>
-              <p>Note that these changes can be made in AR as well, but only in WebXR mode, as this is the only mode that remains in the browser. Changes you made ahead of time will not be reflected in Scene Viewer, since this app downloads the
-                original model again from its URL. iOS Quick Look will reflect your changes as long as <code>ios-src</code> is not specified, since in this case a USDZ will be generated on the fly from the current state.</p>
-            </div>
-            <example-snippet stamp-to="transforms" highlight-as="html">
-              <template>
-                <model-viewer id="transform" orientation="20deg 0 0" bounds="tight" shadow-intensity="1" camera-controls ar ar-modes="webxr scene-viewer quick-look" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
-                  <div class="controls">
-                    <div>Roll: <input id="roll" value="20" size="3" class="number"> degrees</div>
-                    <div>Pitch: <input id="pitch" value="0" size="3" class="number"> degrees</div>
-                    <div>Yaw: <input id="yaw" value="0" size="3" class="number"> degrees</div>
-                    <div> Scale: X: <input id="x" value="1" size="3" class="number">, Y: <input id="y" value="1" size="3" class="number">, Z: <input id="z" value="1" size="3" class="number">
-                    </div>
-                    <button id="frame">Update Framing</button>
-                  </div>
-                </model-viewer>
-                <script>
-                  const modelViewerTransform = document.querySelector("model-viewer#transform");
-                  const roll = document.querySelector('#roll');
-                  const pitch = document.querySelector('#pitch');
-                  const yaw = document.querySelector('#yaw');
-                  const x = document.querySelector('#x');
-                  const y = document.querySelector('#y');
-                  const z = document.querySelector('#z');
-                  const frame = document.querySelector('#frame');
-
-                  frame.addEventListener('click', () => {
-                    modelViewerTransform.updateFraming();
-                  });
-
-                  const updateOrientation = () => {
-                    modelViewerTransform.orientation = `${roll.value}deg ${pitch.value}deg ${yaw.value}deg`;
-                  };
-
-                  const updateScale = () => {
-                    modelViewerTransform.scale = `${x.value} ${y.value} ${z.value}`;
-                  };
-
-                  roll.addEventListener('input', () => {
-                    updateOrientation();
-                  });
-                  pitch.addEventListener('input', () => {
-                    updateOrientation();
-                  });
-                  yaw.addEventListener('input', () => {
-                    updateOrientation();
-                  });
-                  x.addEventListener('input', () => {
-                    updateScale();
-                  });
-                  y.addEventListener('input', () => {
-                    updateScale();
-                  });
-                  z.addEventListener('input', () => {
-                    updateScale();
-                  });
-                </script>
-              </template>
-            </example-snippet>
-          </div>
-        </div>
-      </div>
-      <div class="sample">
-        <div id="changeColor" class="demo"></div>
-        <div class="content">
-          <div class="wrapper">
-            <h4 id="intro"><span class="font-medium">Directly manipulate the scene graph</span></h4>
-            <div class="heading">
-              <h2 class="demo-title">Change Material Base Color</h2>
-              <p>This is an experimental feature, and the API is considered highly unstable. Please try it out, but be prepared for it to change!</p>
-              <p>As above, you can change these values in AR, but only in WebXR mode. iOS Quick Look does not reflect these color changes as USDZ does not appear to support colors multiplied onto textures.</p>
-            </div>
-            <example-snippet stamp-to="changeColor" highlight-as="html">
-              <template>
-                <model-viewer id="color" camera-controls interaction-prompt="none" src="../../shared-assets/models/Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of an astronaut">
-                  <div class="controls" , id="color-controls">
-                    <button data-color="1,0,0,1">Red</button>
-                    <button data-color="0,1,0,1">Green</button>
-                    <button data-color="0,0,1,1">Blue</button>
-                  </div>
-                </model-viewer>
-                <script>
-                  const modelViewerColor = document.querySelector("model-viewer#color");
-
-                  document.querySelector('#color-controls').addEventListener('click', (event) => {
-                    const colorString = event.target.dataset.color;
-
-                    if (!colorString) {
-                      return;
-                    }
-
-                    const color = colorString.split(',')
-                      .map(numberString => parseFloat(numberString));
-
-                    console.log('Changing color to: ', color);
-                    const [material] = modelViewerColor.model.materials;
-                    material.pbrMetallicRoughness.setBaseColorFactor(color);
-                  });
-                </script>
-              </template>
-            </example-snippet>
-          </div>
-        </div>
-      </div>
-      <div class="sample">
-        <div id="changeMaterial" class="demo"></div>
-        <div class="content">
-          <div class="wrapper">
-            <div class="heading">
-              <h2 class="demo-title">Change Material Metalness and Roughness Factors</h2>
-              <p>As above, you can change these values in AR, but only in WebXR mode. iOS Quick Look does reflect these property changes since they are not also textured.</p>
-            </div>
-            <example-snippet stamp-to="changeMaterial" highlight-as="html">
-              <template>
-                <model-viewer id="sphere" camera-controls interaction-prompt="none" src="../../shared-assets/models/reflective-sphere.gltf" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a sphere">
-                  <div class="controls">
-                    <div>
-                      <p>Metalness: <span id="metalness-value"></span></p>
-                      <input id="metalness" type="range" min="0" max="1" step="0.01" value="1" />
-                    </div>
-                    <div>
-                      <p>Roughness: <span id="roughness-value"></span></p>
-                      <input id="roughness" type="range" min="0" max="1" step="0.01" value="0" />
-                    </div>
-                  </div>
-                </model-viewer>
-                <script>
-                  const modelViewerParameters = document.querySelector("model-viewer#sphere");
-
-                  modelViewerParameters.addEventListener("load", (ev) => {
-
-                    let material = modelViewerParameters.model.materials[0];
-
-                    let metalnessDisplay = document.querySelector("#metalness-value");
-                    let roughnessDisplay = document.querySelector("#roughness-value");
-
-                    metalnessDisplay.textContent = material.pbrMetallicRoughness.metallicFactor;
-                    roughnessDisplay.textContent = material.pbrMetallicRoughness.roughnessFactor;
-
-                    // Defaults to gold
-                    material.pbrMetallicRoughness.setBaseColorFactor([0.7294, 0.5333, 0.0392]);
-
-                    document.querySelector('#metalness').addEventListener('input', (event) => {
-                      material.pbrMetallicRoughness.setMetallicFactor(event.target.value);
-                      metalnessDisplay.textContent = event.target.value;
-                    });
-
-                    document.querySelector('#roughness').addEventListener('input', (event) => {
-                      material.pbrMetallicRoughness.setRoughnessFactor(event.target.value);
-                      roughnessDisplay.textContent = event.target.value;
-                    });
-                  })
-                </script>
-              </template>
-            </example-snippet>
-          </div>
-        </div>
-      </div>
-      <div class="sample">
-        <div id="createTexturesExample" class="demo"></div>
-        <div class="content">
-          <div class="wrapper">
-            <div class="heading">
-              <h2 class="demo-title">Create textures</h2>
-              <p>As above, you can change these values in AR, but only in WebXR mode. iOS Quick Look reflects these texture changes so long as the USDZ is auto-generated.</p>
-            </div>
-            <example-snippet stamp-to="createTexturesExample" highlight-as="html">
-              <template>
-                <model-viewer id="duck" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Duck/glTF-Binary/Duck.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a helmet">
-                  <div class="controls">
-                    <p>Normals</p>
-                    <select id="normals2">
-                      <option>None</option>
-                      <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_normal.jpg">Damaged helmet</option>
-                      <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_normal.png">Lantern Pole</option>
-                      <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_normal.png">Water Bottle</option>
-                    </select>
-                    <p>Custom texture name</p>
-                    <p id="texture-name">None</p>
-                    <p>Image name from file name</p>
-                    <p id="image-name">None</p>
-                  </div>
-                </model-viewer>
-                <script type="module">
-                  const modelViewerTexture = document.querySelector("model-viewer#duck");
-
-                  modelViewerTexture.addEventListener("load", () => {
-
-                    const material = modelViewerTexture.model.materials[0];
-
-                    const createAndApplyTexture = async (channel, event) => {
-                      if (event.target.value == "None") {
-                        // Clears the texture.
-                        material[channel].setTexture(null);
-                      } else if (event.target.value) {
-                        // Creates a new texture.
-                        const texture = await modelViewerTexture.createTexture(event.target.value);
-                        texture.name = event.target.options[event.target.selectedIndex].text.replace(/ /g, "_").toLowerCase();
-                        // Applies the new texture to the specified channel.
-                        material[channel].setTexture(texture);
-                        document.querySelector('#texture-name').innerText = texture.name;
-                        document.querySelector('#image-name').innerText = texture.source.name;
-                      }
-                    }
-
-                    document.querySelector('#normals2').addEventListener('input', (event) => {
-                      createAndApplyTexture('normalTexture', event);
-                    });
-                  });
-
-                </script>
-              </template>
-            </example-snippet>
-          </div>
-        </div>
-      </div>
-      <div class="sample">
-        <div id="swapTextures" class="demo"></div>
-        <div class="content">
-          <div class="wrapper">
-            <div class="heading">
-              <h2 class="demo-title">Swap textures</h2>
-              <p>As above, you can change these values in AR, but only in WebXR mode. iOS Quick Look reflects these texture changes so long as the USDZ is auto-generated.</p>
-            </div>
-            <example-snippet stamp-to="swapTextures" highlight-as="html">
-              <template>
-                <model-viewer id="helmet" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a helmet">
-                  <div class="controls">
-                    <div>
-                      <p>Diffuse</p>
-                      <select id="diffuse">
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_albedo.jpg">Damaged helmet</option>
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_baseColor.png">Lantern Pole</option>
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_baseColor.png">Water Bottle</option>
-                      </select>
-                    </div>
-                    <div>
-                      <p>Metallic-roughness</p>
-                      <select id="metallicRoughness">
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_metalRoughness.jpg">Damaged helmet</option>
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_roughnessMetallic.png">Lantern Pole</option>
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
-                      </select>
-                    </div>
-                    <div>
-                      <p>Normals</p>
-                      <select id="normals">
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_normal.jpg">Damaged helmet</option>
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_normal.png">Lantern Pole</option>
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_normal.png">Water Bottle</option>
-                      </select>
-                    </div>
-                    <div>
-                      <p>Occlusion</p>
-                      <select id="occlusion">
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_AO.jpg">Damaged helmet</option>
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
-                      </select>
-                    </div>
-                    <div>
-                      <p>Emission</p>
-                      <select id="emission">
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_emissive.jpg">Damaged helmet</option>
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_emissive.png">Lantern Pole</option>
-                        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_emissive.png">Water Bottle</option>
-                      </select>
-                    </div>
-                  </div>
-                </model-viewer>
-                <script type="module">
-                  const modelViewerTexture = document.querySelector("model-viewer#helmet");
-
-                  modelViewerTexture.addEventListener("load", () => {
-
-                    const material = modelViewerTexture.model.materials[0];
-
-                    const createAndApplyTexture = async (channel, event) => {
-                      const texture = await modelViewerTexture.createTexture(event.target.value);
-                      if (channel.includes('base') || channel.includes('metallic')) {
-                        material.pbrMetallicRoughness[channel].setTexture(texture);
-                      } else {
-                        material[channel].setTexture(texture);
-                      }
-                    }
-
-                    document.querySelector('#normals').addEventListener('input', (event) => {
-                      createAndApplyTexture('normalTexture', event);
-                    });
-
-                    document.querySelector('#occlusion').addEventListener('input', (event) => {
-                      createAndApplyTexture('occlusionTexture', event);
-                    });
-
-                    document.querySelector('#emission').addEventListener('input', (event) => {
-                      createAndApplyTexture('emissiveTexture', event);
-                    });
-
-                    document.querySelector('#diffuse').addEventListener('input', (event) => {
-                      createAndApplyTexture('baseColorTexture', event);
-                    });
-
-                    document.querySelector('#metallicRoughness').addEventListener('input', (event) => {
-                      createAndApplyTexture('metallicRoughnessTexture', event);
-                    });
-                  });
-
-                </script>
-              </template>
-            </example-snippet>
-          </div>
-        </div>
-      </div>
-      <div class="sample">
-        <div id="pickMaterialExample" class="demo"></div>
-        <div class="content">
-          <div class="wrapper">
-            <div class="heading">
-              <h2 class="demo-title">Pick a Material</h2>
-              <p>Demonstrates selecting a material with pointer input and changing its color. Note this also works in the WebXR AR mode. Also demonstrates the use of the scale attribute since this GLB was erroneously modeled in mm instead of meters.
-              </p>
-            </div>
-            <example-snippet stamp-to="pickMaterialExample" highlight-as="html">
-              <template>
-                <model-viewer id="pickMaterial" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer" scale="0.001 0.001 0.001" alt="A Material Picking Example">
-                </model-viewer>
-                <script type="module">
-                  const modelViewer = document.querySelector("model-viewer#pickMaterial");
-
-                  modelViewer.addEventListener("load", () => {
-
-                    const changeColor = async (event) => {
-                      let material = modelViewer.materialFromPoint(event.clientX, event.clientY);
-
-                      if (material != null) {
-                        material.pbrMetallicRoughness.
-                          setBaseColorFactor([Math.random(), Math.random(), Math.random()]);
-                      }
-                    }
-
-                    modelViewer.addEventListener("click", changeColor);
-
-                  });
-
-                </script>
-              </template>
-            </example-snippet>
-          </div>
-        </div>
-      </div>
-      <div class="sample">
-        <div id="exporter" class="demo"></div>
-        <div class="content">
-          <div class="wrapper">
-            <a class="lockup" href="../../index.html">
-              <div class="icon-button icon-modelviewer-black"></div>
-              <h1>examples</h1>
-            </a>
-            <div class="heading">
-              <h2 class="demo-title">Exporter</h2>
-            </div>
-            <example-snippet stamp-to="exporter" highlight-as="html">
-              <template>
-                <model-viewer id="static-model" src="../../shared-assets/models/Astronaut.glb" shadow-intensity="1" camera-controls alt="A 3D model of an astronaut">
-                  <div class="controls">
-                    <button onclick="exportGLB()">Export GLB</button>
-                  </div>
-                </model-viewer>
-                <script>
-                  async function exportGLB() {
-                    let modelViewer = document.getElementById("static-model");
-                    const glTF = await modelViewer.exportScene();
-                    var file = new File([glTF], "export.glb");
-                    var link = document.createElement("a");
-                    link.download = file.name;
-                    link.href = URL.createObjectURL(file);
-                    link.click();
-                  }
-                </script>
-              </template>
-            </example-snippet>
-          </div>
-        </div>
-      </div>
-      <div class="sample">
-        <div id="exporterWithOptions" class="demo"></div>
-        <div class="content">
-          <div class="wrapper">
-            <div class="heading">
-              <h2 class="demo-title">Exporter with options</h2>
-            </div>
-            <example-snippet stamp-to="exporterWithOptions" highlight-as="html">
-              <template>
-                <model-viewer id="animated-model" src="../../shared-assets/models/Horse.glb" autoplay camera-controls alt="A 3D model of a horse galloping">
-                  <div class="controls">
-                    <button onclick="exportScene(true)">Export GLB</button>
-                    <button onclick="exportScene(false)">Export GLTF</button>
-                  </div>
-                </model-viewer>
-                <script>
-                  async function exportScene(binary) {
-                    let options = {
-                      binary: binary,
-                      trs: true,
-                      onlyVisible: true,
-                      maxTextureSize: 256,
-                      forcePowerOfTwoTextures: true,
-                      includeCustomExtensions: false,
-                      embedImages: true
-                    };
-                    let modelViewer = document.getElementById("animated-model");
-                    const glTF = await modelViewer.exportScene(options);
-                    var file = new File([glTF], binary ? "export.glb" : "export.gltf");
-                    var link = document.createElement("a");
-                    link.download = file.name;
-                    link.href = URL.createObjectURL(file);
-                    link.click();
-                  }
-                </script>
-              </template>
-            </example-snippet>
-          </div>
-        </div>
-      </div>
-      <div class="footer">
-        <ul>
-          <li class="attribution">
-            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/MaterialsVariantsShoe">Shoe</a> ©Copyright 2020 <a href="https://www.shopify.com/">Shopify Inc.</a>, licensed under <a
-              href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>.
-          </li>
-          <li class="attribution">
-            <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>, licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>.
-          </li>
-          <li class="attribution">
-            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet">Damaged Helmet</a> by <a href="https://sketchfab.com/theblueturtle_">theblueturtle_</a>, licensed under <a
-              href="https://creativecommons.org/licenses/by-nc/3.0/us/">Creative Commons Attribution-NonCommercial</a>.
-          </li>
-          <li class="attribution">
-            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Lantern">Lantern</a>, licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero</a>.
-          </li>
-          <li class="attribution">
-            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/WaterBottle">Water Bottle</a>, licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero</a>.
-          </li>
-          <li class="attribution">
-            <a href="https://github.com/dataarts/3-dreams-of-black/tree/master/deploy/files/models/soup">Horse</a> by <a href="https://github.com/dataarts">Google Data Arts Team</a>, licensed under <a
-              href="https://github.com/dataarts/3-dreams-of-black/blob/master/deploy/files/models/soup/LICENSE.txt">Creative Commons Attribution-NonCommercial-ShareAlike</a>.
-          </li>
-          <li class="attribution">
-            <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Duck">Duck</a> by Sony Computer Entertainment Inc., licensed under <a
-              href="https://web.archive.org/web/20160320123355/http://research.scea.com/scea_shared_source_license.html">the SCEA Shared Source License, Version 1.0</a>.
-          </li>
-          <li class="attribution">
-            <a href="https://github.com/dataarts/3-dreams-of-black/tree/master/deploy/files/models/soup">Buggy</a> by Okino Computer Graphics, Data conversion from original JT to COLLADA has been kindly performed by Okino Computer Graphics, using <a
-              href="http://www.okino.com/conv/conv.htm">Okino Polytrans Software</a>.
-          </li>
-        </ul>
-        <div style="margin-top:24px;" class="copyright">©Copyright 2018-2020 Google Inc. Licensed under the Apache License 2.0.</div>
-        <div id='footer-links'></div>
       </div>
     </div>
+
+    <div class="sample">
+      <div id="transforms" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <div class="heading">
+            <h2 class="demo-title">Model Transformations</h2>
+            <p>This demonstrates the <code>orientation</code> and
+            <code>scale</code> attributes which allow the model to be
+            transformed. Note that if specified before the model loads, they
+            will be taken into account by the automatic camera framing. If they
+            are changed afterwards the camera will not move, so to get new
+            automatic framing the <code>updateFraming()</code> method must be
+            called. Also, the <code>bounds</code> attribute is set to
+            <code>"tight"</code> to keep the transformed model from floating
+            over its shadow.</p>
+            <p>Note that these changes can be made in AR as well, but only in
+            WebXR mode, as this is the only mode that remains in the browser.
+            Changes you made ahead of time will not be reflected in Scene
+            Viewer, since this app downloads the original model again from its
+            URL. iOS Quick Look will reflect your changes as long as
+            <code>ios-src</code> is not specified, since in this case a USDZ
+            will be generated on the fly from the current state.</p>
+          </div>
+          <example-snippet stamp-to="transforms" highlight-as="html">
+            <template>
+<model-viewer id="transform" orientation="20deg 0 0" bounds="tight" shadow-intensity="1" camera-controls ar ar-modes="webxr scene-viewer quick-look" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
+  <div class="controls">
+    <div>Roll: <input id="roll" value="20" size="3" class="number"> degrees</div>
+    <div>Pitch: <input id="pitch" value="0" size="3" class="number"> degrees</div>
+    <div>Yaw: <input id="yaw" value="0" size="3" class="number"> degrees</div>
+    <div>
+      Scale: X: <input id="x" value="1" size="3" class="number">,
+      Y: <input id="y" value="1" size="3" class="number">,
+      Z: <input id="z" value="1" size="3" class="number">
+    </div>
+    <button id="frame">Update Framing</button>
   </div>
+</model-viewer>
+<script>
+const modelViewerTransform = document.querySelector("model-viewer#transform");
+const roll = document.querySelector('#roll');
+const pitch = document.querySelector('#pitch');
+const yaw = document.querySelector('#yaw');
+const x = document.querySelector('#x');
+const y = document.querySelector('#y');
+const z = document.querySelector('#z');
+const frame = document.querySelector('#frame');
+
+frame.addEventListener('click', () => {
+  modelViewerTransform.updateFraming();
+});
+
+const updateOrientation = () => {
+  modelViewerTransform.orientation = `${roll.value}deg ${pitch.value}deg ${yaw.value}deg`;
+};
+
+const updateScale = () => {
+  modelViewerTransform.scale = `${x.value} ${y.value} ${z.value}`;
+};
+
+roll.addEventListener('input', () => {
+  updateOrientation();
+});
+pitch.addEventListener('input', () => {
+  updateOrientation();
+});
+yaw.addEventListener('input', () => {
+  updateOrientation();
+});
+x.addEventListener('input', () => {
+  updateScale();
+});
+y.addEventListener('input', () => {
+  updateScale();
+});
+z.addEventListener('input', () => {
+  updateScale();
+});
+</script>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+    <div class="sample">
+      <div id="changeColor" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <h4 id="intro"><span class="font-medium">Directly manipulate the scene graph</span></h4>
+          <div class="heading">
+            <h2 class="demo-title">Change Material Base Color</h2>
+            <p>This is an experimental feature, and the API is considered highly
+            unstable. Please try it out, but be prepared for it to change!</p>
+            <p>As above, you can change these values in AR, but only in WebXR
+            mode. iOS Quick Look does not reflect these color changes as USDZ
+            does not appear to support colors multiplied onto textures.</p>
+          </div>
+          <example-snippet stamp-to="changeColor" highlight-as="html">
+            <template>
+<model-viewer id="color" camera-controls interaction-prompt="none" src="../../shared-assets/models/Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of an astronaut">
+  <div class="controls", id="color-controls">
+    <button data-color="1,0,0,1">Red</button>
+    <button data-color="0,1,0,1">Green</button>
+    <button data-color="0,0,1,1">Blue</button>
+  </div>
+</model-viewer>
+<script>
+const modelViewerColor = document.querySelector("model-viewer#color");
+
+document.querySelector('#color-controls').addEventListener('click', (event) => {
+  const colorString = event.target.dataset.color;
+
+  if (!colorString) {
+    return;
+  }
+
+  const color = colorString.split(',')
+      .map(numberString => parseFloat(numberString));
+
+  console.log('Changing color to: ', color);
+  const [material] = modelViewerColor.model.materials;
+  material.pbrMetallicRoughness.setBaseColorFactor(color);
+});
+</script>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+
+    <div class="sample">
+      <div id="changeMaterial" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <div class="heading">
+            <h2 class="demo-title">Change Material Metalness and Roughness Factors</h2>
+            <p>As above, you can change these values in AR, but only in WebXR
+            mode. iOS Quick Look does reflect these property changes since they
+            are not also textured.</p>
+          </div>
+          <example-snippet stamp-to="changeMaterial" highlight-as="html">
+            <template>
+<model-viewer id="sphere" camera-controls interaction-prompt="none" src="../../shared-assets/models/reflective-sphere.gltf" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a sphere">
+  <div class="controls">
+    <div>
+      <p>Metalness: <span id="metalness-value"></span></p>
+      <input id="metalness" type="range" min="0" max="1" step="0.01" value="1" />
+    </div>
+    <div>
+      <p>Roughness: <span id="roughness-value"></span></p>
+      <input id="roughness" type="range" min="0" max="1" step="0.01" value="0" />
+    </div>
+  </div>
+</model-viewer>
+<script>
+const modelViewerParameters = document.querySelector("model-viewer#sphere");
+
+modelViewerParameters.addEventListener("load", (ev) => {
+
+  let material = modelViewerParameters.model.materials[0];
+
+  let metalnessDisplay = document.querySelector("#metalness-value");
+  let roughnessDisplay = document.querySelector("#roughness-value");
+
+  metalnessDisplay.textContent = material.pbrMetallicRoughness.metallicFactor;
+  roughnessDisplay.textContent = material.pbrMetallicRoughness.roughnessFactor;
+
+  // Defaults to gold
+  material.pbrMetallicRoughness.setBaseColorFactor([0.7294, 0.5333, 0.0392]);
+
+  document.querySelector('#metalness').addEventListener('input', (event) => {
+    material.pbrMetallicRoughness.setMetallicFactor(event.target.value);
+    metalnessDisplay.textContent = event.target.value;
+  });
+
+  document.querySelector('#roughness').addEventListener('input', (event) => {
+    material.pbrMetallicRoughness.setRoughnessFactor(event.target.value);
+    roughnessDisplay.textContent = event.target.value;
+  });
+})
+</script>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+
+    <div class="sample">
+      <div id="createTexturesExample" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <div class="heading">
+            <h2 class="demo-title">Create textures</h2>
+            <p>As above, you can change these values in AR, but only in WebXR
+              mode. iOS Quick Look reflects these texture changes so long as the
+              USDZ is auto-generated.</p>
+          </div>
+          <example-snippet stamp-to="createTexturesExample" highlight-as="html">
+            <template>
+<model-viewer id="duck" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Duck/glTF-Binary/Duck.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a helmet">
+  <div class="controls">
+      <p>Normals</p>
+      <select id="normals2">
+        <option>None</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_normal.jpg">Damaged helmet</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_normal.png">Lantern Pole</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_normal.png">Water Bottle</option>
+      </select>
+      <p>Custom texture name</p>
+      <p id="texture-name">None</p>
+      <p>Image name from file name</p>
+      <p id="image-name">None</p>
+    </div>
+</model-viewer>
+<script type="module">
+const modelViewerTexture = document.querySelector("model-viewer#duck");
+
+modelViewerTexture.addEventListener("load", () => {
+
+  const material = modelViewerTexture.model.materials[0];
+
+  const createAndApplyTexture = async (channel, event) => {
+    if (event.target.value == "None") {
+      // Clears the texture.
+      material[channel].setTexture(null);
+    } else if (event.target.value) {
+      // Creates a new texture.
+      const texture = await modelViewerTexture.createTexture(event.target.value);
+      // Set the texture name
+      texture.name = event.target.options[event.target.selectedIndex].text.replace(/ /g, "_").toLowerCase();
+      // Applies the new texture to the specified channel.
+      material[channel].setTexture(texture);
+      // Display the names values
+      document.querySelector('#texture-name').innerText = texture.name;
+      document.querySelector('#image-name').innerText = texture.source.name;
+    }
+  }
+
+  document.querySelector('#normals2').addEventListener('input', (event) => {
+    createAndApplyTexture('normalTexture', event);
+  });
+});
+
+</script>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+
+    <div class="sample">
+      <div id="swapTextures" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <div class="heading">
+            <h2 class="demo-title">Swap textures</h2>
+            <p>As above, you can change these values in AR, but only in WebXR
+              mode. iOS Quick Look reflects these texture changes so long as the
+              USDZ is auto-generated.</p>
+          </div>
+          <example-snippet stamp-to="swapTextures" highlight-as="html">
+            <template>
+<model-viewer id="helmet" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a helmet">
+  <div class="controls">
+    <div>
+      <p>Diffuse</p>
+      <select id="diffuse">
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_albedo.jpg">Damaged helmet</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_baseColor.png">Lantern Pole</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_baseColor.png">Water Bottle</option>
+      </select>
+    </div>
+    <div>
+      <p>Metallic-roughness</p>
+      <select id="metallicRoughness">
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_metalRoughness.jpg">Damaged helmet</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_roughnessMetallic.png">Lantern Pole</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
+      </select>
+    </div>
+    <div>
+      <p>Normals</p>
+      <select id="normals">
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_normal.jpg">Damaged helmet</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_normal.png">Lantern Pole</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_normal.png">Water Bottle</option>
+      </select>
+    </div>
+    <div>
+      <p>Occlusion</p>
+      <select id="occlusion">
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_AO.jpg">Damaged helmet</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">Water Bottle</option>
+      </select>
+    </div>
+    <div>
+      <p>Emission</p>
+      <select id="emission">
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/Default_emissive.jpg">Damaged helmet</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/Lantern/glTF/Lantern_emissive.png">Lantern Pole</option>
+        <option value="../../shared-assets/models/glTF-Sample-Models/2.0/WaterBottle/glTF/WaterBottle_emissive.png">Water Bottle</option>
+      </select>
+    </div>
+  </div>
+</model-viewer>
+<script type="module">
+const modelViewerTexture = document.querySelector("model-viewer#helmet");
+
+modelViewerTexture.addEventListener("load", () => {
+
+  const material = modelViewerTexture.model.materials[0];
+
+  const createAndApplyTexture = async (channel, event) => {
+    const texture = await modelViewerTexture.createTexture(event.target.value);
+    if (channel.includes('base') || channel.includes('metallic')) {
+      material.pbrMetallicRoughness[channel].setTexture(texture);
+    } else {
+      material[channel].setTexture(texture);
+    }
+  }
+
+  document.querySelector('#normals').addEventListener('input', (event) => {
+    createAndApplyTexture('normalTexture', event);
+  });
+
+  document.querySelector('#occlusion').addEventListener('input', (event) => {
+    createAndApplyTexture('occlusionTexture', event);
+  });
+
+  document.querySelector('#emission').addEventListener('input', (event) => {
+    createAndApplyTexture('emissiveTexture', event);
+  });
+
+  document.querySelector('#diffuse').addEventListener('input', (event) => {
+    createAndApplyTexture('baseColorTexture', event);
+  });
+
+  document.querySelector('#metallicRoughness').addEventListener('input', (event) => {
+    createAndApplyTexture('metallicRoughnessTexture', event);
+  });
+});
+
+</script>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+
+    <div class="sample">
+      <div id="pickMaterialExample" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <div class="heading">
+            <h2 class="demo-title">Pick a Material</h2>
+            <p>Demonstrates selecting a material with pointer input and changing its color. Note this also works in the WebXR AR mode. Also demonstrates the use of the scale attribute since this GLB was erroneously modeled in mm instead of meters.</p>
+          </div>
+          <example-snippet stamp-to="pickMaterialExample" highlight-as="html">
+            <template>
+<model-viewer id="pickMaterial" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer" scale="0.001 0.001 0.001" alt="A Material Picking Example">
+</model-viewer>
+<script type="module">
+const modelViewer = document.querySelector("model-viewer#pickMaterial");
+
+modelViewer.addEventListener("load", () => {
+
+  const changeColor = async (event) => {
+    let material = modelViewer.materialFromPoint(event.clientX, event.clientY);
+
+    if(material != null) {
+      material.pbrMetallicRoughness.
+        setBaseColorFactor([Math.random(), Math.random(), Math.random()]);
+    }
+  }
+
+  modelViewer.addEventListener("click", changeColor);
+
+});
+
+</script>
+</template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+    <div class="sample">
+      <div id="exporter" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+
+          <a class="lockup" href="../../index.html"><div class="icon-button icon-modelviewer-black"></div><h1>examples</h1></a>
+          <div class="heading">
+            <h2 class="demo-title">Exporter</h2>
+          </div>
+          <example-snippet stamp-to="exporter" highlight-as="html">
+            <template>
+<model-viewer id="static-model" src="../../shared-assets/models/Astronaut.glb" shadow-intensity="1" camera-controls alt="A 3D model of an astronaut">
+  <div class="controls">
+    <button onclick="exportGLB()">Export GLB</button>
+  </div>
+</model-viewer>
+<script>
+  async function exportGLB(){
+    let modelViewer = document.getElementById("static-model");
+    const glTF = await modelViewer.exportScene();
+    var file = new File([glTF], "export.glb");
+    var link = document.createElement("a");
+    link.download =file.name;
+    link.href = URL.createObjectURL(file);
+    link.click();
+  }
+</script>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+    <div class="sample">
+      <div id="exporterWithOptions" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <div class="heading">
+            <h2 class="demo-title">Exporter with options</h2>
+          </div>
+          <example-snippet stamp-to="exporterWithOptions" highlight-as="html">
+            <template>
+<model-viewer id="animated-model" src="../../shared-assets/models/Horse.glb" autoplay camera-controls alt="A 3D model of a horse galloping">
+  <div class="controls">
+    <button onclick="exportScene(true)">Export GLB</button>
+    <button onclick="exportScene(false)">Export GLTF</button>
+  </div>
+</model-viewer>
+<script>
+  async function exportScene(binary){
+    let options = {
+      binary: binary,
+      trs: true,
+      onlyVisible: true,
+      maxTextureSize: 256,
+      forcePowerOfTwoTextures: true,
+      includeCustomExtensions: false,
+      embedImages: true
+    };
+    let modelViewer = document.getElementById("animated-model");
+    const glTF = await modelViewer.exportScene(options);
+    var file = new File([glTF], binary ? "export.glb" : "export.gltf");
+    var link = document.createElement("a");
+    link.download =file.name;
+    link.href = URL.createObjectURL(file);
+    link.click();
+  }
+</script>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer">
+      <ul>
+        <li class="attribution">
+          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/MaterialsVariantsShoe">Shoe</a> ©Copyright 2020 <a href="https://www.shopify.com/">Shopify Inc.</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>.
+        </li>
+        <li class="attribution">
+          <a href="https://poly.google.com/view/dLHpzNdygsg">Astronaut</a> by <a href="https://poly.google.com/user/4aEd8rQgKu2">Poly</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by/2.0/">CC-BY</a>.
+        </li>
+        <li class="attribution">
+          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet">Damaged Helmet</a> by <a href="https://sketchfab.com/theblueturtle_">theblueturtle_</a>,
+          licensed under <a href="https://creativecommons.org/licenses/by-nc/3.0/us/">Creative Commons Attribution-NonCommercial</a>.
+        </li>
+        <li class="attribution">
+          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Lantern">Lantern</a>,
+          licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero</a>.
+        </li>
+        <li class="attribution">
+          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/WaterBottle">Water Bottle</a>,
+          licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero</a>.
+        </li>
+        <li class="attribution">
+          <a href="https://github.com/dataarts/3-dreams-of-black/tree/master/deploy/files/models/soup">Horse</a> by <a href="https://github.com/dataarts">Google Data Arts Team</a>,
+          licensed under <a href="https://github.com/dataarts/3-dreams-of-black/blob/master/deploy/files/models/soup/LICENSE.txt">Creative Commons Attribution-NonCommercial-ShareAlike</a>.
+        </li>
+        <li class="attribution">
+          <a href="https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/Duck">Duck</a> by Sony Computer Entertainment Inc.,
+          licensed under <a href="https://web.archive.org/web/20160320123355/http://research.scea.com/scea_shared_source_license.html">the SCEA Shared Source License, Version 1.0</a>.
+        </li>
+        <li class="attribution">
+          <a href="https://github.com/dataarts/3-dreams-of-black/tree/master/deploy/files/models/soup">Buggy</a> by Okino Computer Graphics,
+          Data conversion from original JT to COLLADA has been kindly performed by Okino Computer Graphics, using <a href="http://www.okino.com/conv/conv.htm">Okino Polytrans Software</a>.
+        </li>
+      </ul>
+      <div style="margin-top:24px;" class="copyright">©Copyright 2018-2020 Google Inc. Licensed under the Apache License 2.0.</div>
+      <div id='footer-links'></div>
+    </div>
+  </div>
+</div>
+
   <script type="module" src="../../examples/built/docs-and-examples.js">
   </script>
   <script type="module">
     (() => { init('examples-scenegraph'); })();
-    (() => { initFooterLinks(); })();
+    (() => { initFooterLinks();})();
   </script>
+
   <!-- Documentation-specific dependencies: -->
-  <script type="module" src="../built/dependencies.js">
+  <script type="module"
+      src="../built/dependencies.js">
   </script>
+
   <!-- Loads <model-viewer> on modern browsers: -->
-  <script type="module" src="../../node_modules/@google/model-viewer/dist/model-viewer.js">
+  <script type="module"
+      src="../../node_modules/@google/model-viewer/dist/model-viewer.js">
   </script>
 </body>
-
 </html>


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Discussion #3132

Added the possibility to set a custom name to the model-viewer texture object.
The model-viewer image name has been set to the file name (plus extension) if the source field is valorized. 

The CreateTextures example has been updated in order to display these new values.

![image](https://user-images.githubusercontent.com/12815732/152215333-949c1064-fc2e-4dd7-8fe7-ef1c5178c872.png)
