### PR TITLE
Remove unnecessary async/await in TextureUtils

### DIFF
--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -178,7 +178,7 @@ export default class TextureUtils extends EventDispatcher {
 
     cubeCamera.update(renderer, scene);
 
-    await this.blurCubemap(cubeTarget, GENERATED_SIGMA);
+    this.blurCubemap(cubeTarget, GENERATED_SIGMA);
 
     renderer.toneMapping = toneMapping;
     renderer.outputEncoding = outputEncoding;
@@ -210,7 +210,7 @@ export default class TextureUtils extends EventDispatcher {
     return this.generatedEnvironmentMapAlt;
   }
 
-  private async blurCubemap(cubeTarget: WebGLCubeRenderTarget, sigma: number) {
+  private blurCubemap(cubeTarget: WebGLCubeRenderTarget, sigma: number) {
     if (this.blurMaterial == null) {
       this.blurMaterial = this.getBlurShader(MAX_SAMPLES);
       const box = new BoxBufferGeometry();
@@ -229,7 +229,7 @@ export default class TextureUtils extends EventDispatcher {
     /** tempTarget.dispose(); */
   }
 
-  private async halfblur(
+  private halfblur(
       targetIn: WebGLCubeRenderTarget, targetOut: WebGLCubeRenderTarget,
       sigmaRadians: number, direction: 'latitudinal'|'longitudinal') {
     // Number of standard deviations at which to cut off the discrete


### PR DESCRIPTION
Async functions without an `await` expression are executed synchronously. So there is no need to make them `async`.

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function ("The body of an async function can be thought of as being split by zero or more await expressions. Top-level code, up to and including the first await expression (if there is one), is run synchronously. In this way, an async function without an await expression will run synchronously.")