### PR TITLE
Create texture from canvas

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -23,7 +23,7 @@ import {NumberNode, parseExpressions} from '../styles/parsers.js';
 import {GLTF} from '../three-components/gltf-instance/gltf-defaulted.js';
 import {ModelViewerGLTFInstance} from '../three-components/gltf-instance/ModelViewerGLTFInstance.js';
 import GLTFExporterMaterialsVariantsExtension from '../three-components/gltf-instance/VariantMaterialExporterPlugin';
-import {Constructor} from '../utilities.js';
+import {Constructor, defineLazyMemoizedProperty} from '../utilities.js';
 
 import {Image, PBRMetallicRoughness, Sampler, TextureInfo} from './scene-graph/api.js';
 import {Material} from './scene-graph/material.js';
@@ -153,22 +153,10 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       if (src instanceof HTMLCanvasElement) {
         const canvas = src;
+        const gltfImage = {name: 'canvas', uri: ''};
+        defineLazyMemoizedProperty(gltfImage, 'uri', () => canvas.toDataURL());
         return new ModelViewerTexture(
-            this[$getOnUpdateMethod](), texture, null, null, {
-              name: 'canvas',
-              // lazily set the canvas dataURL as the "uri"
-              get uri() {
-                // invoke own setter with dataURL
-                this.uri = canvas.toDataURL();
-                return this.uri;
-              },
-              set uri(uri) {
-                // delete getter and setter and set "uri" as a regular
-                // property
-                delete this.uri;
-                this.uri = uri;
-              }
-            });
+            this[$getOnUpdateMethod](), texture, null, null, gltfImage);
       }
       return new ModelViewerTexture(this[$getOnUpdateMethod](), texture);
     }

--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -52,8 +52,8 @@ export interface SceneGraphInterface {
   scale: string;
   readonly originalGltfJson: GLTF|null;
   exportScene(options?: SceneExportOptions): Promise<Blob>;
-  createTexture(canvas: HTMLCanvasElement): Promise<ModelViewerTexture|null>;
-  createTexture(uri: string, type?: string): Promise<ModelViewerTexture|null>;
+  createTexture(src: string|HTMLCanvasElement, type?: string):
+      Promise<ModelViewerTexture|null>;
   /**
    * Intersects a ray with the scene and returns a list of materials who's
    * objects were intersected.
@@ -120,12 +120,8 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       };
     }
 
-    async createTexture(canvas: HTMLCanvasElement):
-        Promise<ModelViewerTexture|null>;
-    async createTexture(uri: string, type?: string):
-        Promise<ModelViewerTexture|null>;
     async createTexture(
-        src: HTMLCanvasElement|string,
+        src: string|HTMLCanvasElement,
         type: string = 'image/png'): Promise<ModelViewerTexture|null> {
       const currentGLTF = this[$currentGLTF];
 

--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -149,8 +149,8 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       if (src instanceof HTMLCanvasElement) {
         const canvas = src;
-        const gltfImage = {name: 'canvas', uri: ''};
-        defineLazyMemoizedProperty(gltfImage, 'uri', () => canvas.toDataURL());
+        const gltfImage = defineLazyMemoizedProperty(
+            {name: 'canvas'}, 'uri', () => canvas.toDataURL());
         return new ModelViewerTexture(
             this[$getOnUpdateMethod](), texture, null, null, gltfImage);
       }

--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -151,6 +151,25 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
         texture.format = RGBFormat;
       }
 
+      if (src instanceof HTMLCanvasElement) {
+        const canvas = src;
+        return new ModelViewerTexture(
+            this[$getOnUpdateMethod](), texture, null, null, {
+              name: 'canvas',
+              // lazily set the canvas dataURL as the "uri"
+              get uri() {
+                // invoke own setter with dataURL
+                this.uri = canvas.toDataURL();
+                return this.uri;
+              },
+              set uri(uri) {
+                // delete getter and setter and set "uri" as a regular
+                // property
+                delete this.uri;
+                this.uri = uri;
+              }
+            });
+      }
       return new ModelViewerTexture(this[$getOnUpdateMethod](), texture);
     }
 

--- a/packages/model-viewer/src/features/scene-graph/image.ts
+++ b/packages/model-viewer/src/features/scene-graph/image.ts
@@ -36,7 +36,7 @@ export const $applyTexture = Symbol('applyTexture');
  * Image facade implementation for Three.js textures
  */
 export class Image extends ThreeDOMElement implements ImageInterface {
-  [$sourceObject]: GLTFImage;
+  readonly[$sourceObject]: GLTFImage;
 
   get[$threeTexture]() {
     console.assert(

--- a/packages/model-viewer/src/features/scene-graph/image.ts
+++ b/packages/model-viewer/src/features/scene-graph/image.ts
@@ -36,6 +36,8 @@ export const $applyTexture = Symbol('applyTexture');
  * Image facade implementation for Three.js textures
  */
 export class Image extends ThreeDOMElement implements ImageInterface {
+  [$sourceObject]: GLTFImage;
+
   get[$threeTexture]() {
     console.assert(
         this[$correlatedObjects] != null && this[$correlatedObjects]!.size > 0,
@@ -58,15 +60,15 @@ export class Image extends ThreeDOMElement implements ImageInterface {
   }
 
   get name(): string {
-    return (this[$sourceObject] as GLTFImage).name || '';
+    return this[$sourceObject].name || '';
   }
 
   get uri(): string|undefined {
-    return (this[$sourceObject] as GLTFImage).uri;
+    return this[$sourceObject].uri;
   }
 
   get bufferView(): number|undefined {
-    return (this[$sourceObject] as GLTFImage).bufferView;
+    return this[$sourceObject].bufferView;
   }
 
   get type(): 'embedded'|'external' {
@@ -74,12 +76,12 @@ export class Image extends ThreeDOMElement implements ImageInterface {
   }
 
   set name(name: string) {
-    (this[$sourceObject] as GLTFImage).name = name;
+    this[$sourceObject].name = name;
   }
 
   async setURI(uri: string): Promise<void> {
-    (this[$sourceObject] as GLTFImage).uri = uri;
-    (this[$sourceObject] as GLTFImage).name = uri.split('/').pop();
+    this[$sourceObject].uri = uri;
+    this[$sourceObject].name = uri.split('/').pop();
 
     const image = await new Promise((resolve, reject) => {
       loader.load(uri, resolve, undefined, reject);

--- a/packages/model-viewer/src/utilities.ts
+++ b/packages/model-viewer/src/utilities.ts
@@ -257,18 +257,20 @@ export const waitForEvent = <T extends AnyEvent = Event>(
       target.addEventListener(eventName, handler);
     });
 
-export const defineLazyMemoizedProperty = <P extends string, T>(
-    o: Record<P, T>, propertyKey: P, lazyGet: () => T) => {
-  Object.defineProperty(o, propertyKey, {
-    get() {
-      // invoke own setter with lazyGet result
-      this[propertyKey] = lazyGet();
-      return this[propertyKey];
-    },
-    set(value: T) {
-      // delete getter and setter and set as regular property
-      delete this[propertyKey];
-      this[propertyKey] = value;
-    }
-  });
-};
+export const defineLazyMemoizedProperty =
+    <O extends Record<keyof any, any>, P extends keyof any, T>(
+        o: O, propertyKey: P, lazyGet: () => T): Omit<O, P>&Record<P, T> => {
+      Object.defineProperty(o, propertyKey, {
+        get() {
+          // invoke own setter with lazyGet result
+          this[propertyKey] = lazyGet();
+          return this[propertyKey];
+        },
+        set(value: T) {
+          // delete getter and setter and set as regular property
+          delete this[propertyKey];
+          this[propertyKey] = value;
+        }
+      });
+      return o;
+    };

--- a/packages/model-viewer/src/utilities.ts
+++ b/packages/model-viewer/src/utilities.ts
@@ -256,3 +256,19 @@ export const waitForEvent = <T extends AnyEvent = Event>(
       }
       target.addEventListener(eventName, handler);
     });
+
+export const defineLazyMemoizedProperty = <P extends string, T>(
+    o: Record<P, T>, propertyKey: P, lazyGet: () => T) => {
+  Object.defineProperty(o, propertyKey, {
+    get() {
+      // invoke own setter with lazyGet result
+      this[propertyKey] = lazyGet();
+      return this[propertyKey];
+    },
+    set(value: T) {
+      // delete getter and setter and set as regular property
+      delete this[propertyKey];
+      this[propertyKey] = value;
+    }
+  });
+};


### PR DESCRIPTION
A naïve and incomplete attempt at #3211

I've never explored this part of the codebase so I'd like to hear your thoughts, particularly about using the canvas `dataURL` as the `gltfImage uri`, before I proceed any further.

Todo:
- [x] Add a sister method alongside [`Image.setURI`](https://github.com/google/model-viewer/blob/95006dc49ba61be783848d07700308d5c13cba15/packages/model-viewer/src/features/scene-graph/image.ts#L80) which accepts `canvas` input
- [ ] Add example to docs