### PR TITLE
added dimensions to editor validation report

### DIFF
--- a/packages/space-opera/src/components/model_viewer_snippet/components/validation.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/validation.ts
@@ -20,7 +20,7 @@ import {customElement, html, internalProperty, LitElement, property, query} from
 import {validationStyles} from '../../../styles.css.js';
 import {State} from '../../../types.js';
 import {ConnectedLitElement} from '../../connected_lit_element/connected_lit_element';
-import {getModel} from '../../model_viewer_preview/reducer.js';
+import {getModel, getModelViewer} from '../../model_viewer_preview/reducer.js';
 
 import {resolveExternalResource, validateGltf} from './validation_utils.js';
 
@@ -81,6 +81,9 @@ export class ValidationModal extends LitElement {
         <li>${this.report.info!.materialCount} materials</li>
         <li>${this.report.info!.totalVertexCount} vertices</li>
         <li>${this.report.info!.totalTriangleCount} triangles</li>
+        <li>${this.report.info!.width!.toPrecision(3)} x-width (meters)</li>
+        <li>${this.report.info!.height!.toPrecision(3)} y-height (meters)</li>
+        <li>${this.report.info!.length!.toPrecision(3)} z-length (meters)</li>
       </ul>
     </li>
   </ul>
@@ -158,6 +161,14 @@ export class Validation extends ConnectedLitElement {
 
       await this.awaitLoad(gltfUrl);
       this.countJoints(originalGltf);
+
+      const dimensions = getModelViewer().getDimensions();
+      this.report.info = {
+        ...this.report?.info,
+        width: dimensions.x,
+        length: dimensions.z,
+        height: dimensions.y
+      };
     }
   }
 
@@ -194,7 +205,7 @@ export class Validation extends ConnectedLitElement {
         }
       }
     }
-    this.report.info = {...this.report?.info, totalJointCount: jointSet.size }
+    this.report.info = {...this.report?.info, totalJointCount: jointSet.size};
   }
 
   onOpen() {

--- a/packages/space-opera/src/components/model_viewer_snippet/components/validation_utils.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/components/validation_utils.ts
@@ -32,6 +32,9 @@ export type Report = {
     totalVertexCount?: number;
     totalTriangleCount?: number;
     totalJointCount?: number;
+    width?: number;
+    length?: number;
+    height?: number;
   };
   validatorVersion?: string;
   issues?: {


### PR DESCRIPTION
Helpful to determine if the units are off for AR. If it's wrong, you can use our `scale` attribute to correct it.
<img width="1325" alt="image" src="https://user-images.githubusercontent.com/1649964/156829065-f985ee5b-5c19-428f-891a-4af3cdc08c06.png">
