### PR TITLE
handle skinned mesh in bounds=tight

### DIFF
--- a/packages/model-viewer/src/three-components/ModelUtils.ts
+++ b/packages/model-viewer/src/three-components/ModelUtils.ts
@@ -76,7 +76,11 @@ export const reduceVertices = <T>(
 
             for (i = 0, l = vertices.length; i < l; i++) {
               vertex.copy(vertices[i]);
-              vertex.applyMatrix4(object.matrixWorld);
+              if (object.isSkinnedMesh) {
+                object.boneTransform(i, vertex);
+              } else {
+                vertex.applyMatrix4(object.matrixWorld);
+              }
               value = func(value, vertex);
             }
 
@@ -89,7 +93,11 @@ export const reduceVertices = <T>(
               for (i = 0, l = position.count; i < l; i++) {
                 vertex.fromBufferAttribute(position, i);
                 vertex.multiplyScalar(scale);
-                vertex.applyMatrix4(object.matrixWorld);
+                if (object.isSkinnedMesh) {
+                  object.boneTransform(i, vertex);
+                } else {
+                  vertex.applyMatrix4(object.matrixWorld);
+                }
 
                 value = func(value, vertex);
               }


### PR DESCRIPTION
Fixes #3189 

Sure enough, three's bounding box computation doesn't apply bone transforms at all. I fixed this so long as you set `bounds="tight"`, since that is our custom bounding logic we control (and it's better, so you should use it anyway). I'll also put in a PR to three.js to fix the underlying problem upstream.
