### PR TITLE
Pan attribute

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -243,6 +243,8 @@ export declare interface ControlsInterface {
   touchAction: TouchAction;
   bounds: Bounds;
   interpolationDecay: number;
+  disableZoom: boolean;
+  enablePan: boolean;
   getCameraOrbit(): SphericalPosition;
   getCameraTarget(): Vector3D;
   getFieldOfView(): number;
@@ -342,6 +344,9 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     @property({type: Boolean, attribute: 'disable-zoom'})
     disableZoom: boolean = false;
 
+    @property({type: Boolean, attribute: 'enable-pan'})
+    enablePan: boolean = false;
+
     @property({type: Number, attribute: 'interpolation-decay'})
     interpolationDecay: number = DECAY_MILLISECONDS;
 
@@ -360,7 +365,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     protected[$waitingToPromptUser] = false;
 
     protected[$controls] = new SmoothControls(
-        this[$scene].camera as PerspectiveCamera, this[$userInputElement]);
+        this[$scene].camera as PerspectiveCamera, this[$userInputElement],
+        this[$scene]);
 
     protected[$lastSpherical] = new Spherical();
     protected[$jumpCamera] = false;
@@ -474,6 +480,13 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       if (changedProperties.has('disableZoom')) {
         controls.disableZoom = this.disableZoom;
+      }
+
+      if (changedProperties.has('enablePan')) {
+        controls.enablePan = this.enablePan;
+        this.oncontextmenu = this.enablePan ? function() {
+          return false;
+        } : null;
       }
 
       if (changedProperties.has('bounds')) {

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -148,7 +148,7 @@ export const cameraOrbitIntrinsics = (() => {
 })();
 
 const minCameraOrbitIntrinsics = (element: ModelViewerElementBase) => {
-  const radius = MINIMUM_RADIUS_RATIO * element[$scene].boundingRadius;
+  const radius = MINIMUM_RADIUS_RATIO * element[$scene].boundingSphere.radius;
 
   return {
     basis: [
@@ -678,7 +678,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
      * orbiting at the supplied radius.
      */
     [$updateCameraForRadius](radius: number) {
-      const maximumRadius = Math.max(this[$scene].boundingRadius, radius);
+      const maximumRadius =
+          Math.max(this[$scene].boundingSphere.radius, radius);
 
       const near = 0;
       const far = 2 * maximumRadius;

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -22,11 +22,9 @@ import {degreesToRadians, normalizeUnit} from '../styles/conversions.js';
 import {EvaluatedStyle, Intrinsics, SphericalIntrinsics, StyleEvaluator, Vector3Intrinsics} from '../styles/evaluators.js';
 import {IdentNode, NumberNode, numberNode, parseExpressions} from '../styles/parsers.js';
 import {DECAY_MILLISECONDS} from '../three-components/Damper.js';
-import {DEFAULT_FOV_DEG} from '../three-components/ModelScene.js';
 import {ChangeEvent, ChangeSource, PointerChangeEvent, SmoothControls} from '../three-components/SmoothControls.js';
 import {Constructor} from '../utilities.js';
 import {timeline} from '../utilities/animation.js';
-
 
 
 // NOTE(cdata): The following "animation" timing functions are deliberately
@@ -52,6 +50,11 @@ const fade = timeline(0, [
   {frames: 1, value: 0},
   {frames: 6, value: 0}
 ]);
+
+export const DEFAULT_FOV_DEG = 30;
+export const OLD_DEFAULT_FOV_DEG = 45;
+const DEFAULT_MIN_FOV_DEG = 12;
+const OLD_DEFAULT_MIN_FOV_DEG = 25;
 
 export const DEFAULT_CAMERA_ORBIT = '0deg 75deg 105%';
 const DEFAULT_CAMERA_TARGET = 'auto auto auto';
@@ -106,25 +109,22 @@ export const TouchAction: {[index: string]: TouchAction} = {
   NONE: 'none'
 };
 
-export const fieldOfViewIntrinsics = () => {
-  return {
-    basis:
-        [degreesToRadians(numberNode(DEFAULT_FOV_DEG, 'deg')) as
-         NumberNode<'rad'>],
-    keywords: {auto: [null]}
-  };
-};
+export const fieldOfViewIntrinsics =
+    (element: ModelViewerElementBase&ControlsInterface) => {
+      const fov = element.enablePan ? DEFAULT_FOV_DEG : OLD_DEFAULT_FOV_DEG;
 
-const minFieldOfViewIntrinsics = {
-  basis: [degreesToRadians(numberNode(25, 'deg')) as NumberNode<'rad'>],
-  keywords: {auto: [null]}
-};
+      return {
+        basis: [degreesToRadians(numberNode(fov, 'deg')) as NumberNode<'rad'>],
+        keywords: {auto: [null]}
+      };
+    };
 
-const maxFieldOfViewIntrinsics = () => {
+const minFieldOfViewIntrinsics = (element: ModelViewerElementBase&
+                                  ControlsInterface) => {
+  const fov = element.enablePan ? DEFAULT_MIN_FOV_DEG : OLD_DEFAULT_MIN_FOV_DEG;
+
   return {
-    basis:
-        [degreesToRadians(numberNode(DEFAULT_FOV_DEG, 'deg')) as
-         NumberNode<'rad'>],
+    basis: [degreesToRadians(numberNode(fov, 'deg')) as NumberNode<'rad'>],
     keywords: {auto: [null]}
   };
 };
@@ -147,18 +147,20 @@ export const cameraOrbitIntrinsics = (() => {
   };
 })();
 
-const minCameraOrbitIntrinsics = (element: ModelViewerElementBase) => {
-  const radius = MINIMUM_RADIUS_RATIO * element[$scene].boundingSphere.radius;
+const minCameraOrbitIntrinsics =
+    (element: ModelViewerElementBase&ControlsInterface) => {
+      const radius = MINIMUM_RADIUS_RATIO *
+          element[$scene].boundingSphere.radius * (element.enablePan ? 2 : 1);
 
-  return {
-    basis: [
-      numberNode(-Infinity, 'rad'),
-      numberNode(Math.PI / 8, 'rad'),
-      numberNode(radius, 'm')
-    ],
-    keywords: {auto: [null, null, null]}
-  };
-};
+      return {
+        basis: [
+          numberNode(-Infinity, 'rad'),
+          numberNode(Math.PI / 8, 'rad'),
+          numberNode(radius, 'm')
+        ],
+        keywords: {auto: [null, null, null]}
+      };
+    };
 
 const maxCameraOrbitIntrinsics = (element: ModelViewerElementBase) => {
   const orbitIntrinsics = cameraOrbitIntrinsics(element);
@@ -314,10 +316,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         {type: String, attribute: 'min-field-of-view', hasChanged: () => true})
     minFieldOfView: string = 'auto';
 
-    @style({
-      intrinsics: maxFieldOfViewIntrinsics,
-      updateHandler: $syncMaxFieldOfView
-    })
+    @style(
+        {intrinsics: fieldOfViewIntrinsics, updateHandler: $syncMaxFieldOfView})
     @property(
         {type: String, attribute: 'max-field-of-view', hasChanged: () => true})
     maxFieldOfView: string = 'auto';
@@ -717,13 +717,14 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       // compare the before and after to calculate the proper zoom.
       super[$onResize](event);
 
-      const newFramedFoV = scene.adjustedFoV(scene.framedFoVDeg);
-      const zoom = controls.getFieldOfView() / oldFramedFoV;
+      const fovRatio = scene.adjustedFoV(scene.framedFoVDeg) / oldFramedFoV;
+      const fov =
+          controls.getFieldOfView() * (isFinite(fovRatio) ? fovRatio : 1);
 
       controls.updateAspect(this[$scene].aspect);
 
       await this.requestUpdate('maxFieldOfView', this.maxFieldOfView);
-      this[$controls].setFieldOfView(newFramedFoV * zoom);
+      this[$controls].setFieldOfView(fov);
 
       this.jumpCameraToGoal();
     }

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -195,6 +195,7 @@ const TAU = 2.0 * Math.PI;
 
 export const $controls = Symbol('controls');
 export const $promptElement = Symbol('promptElement');
+export const $panElement = Symbol('panElement');
 export const $promptAnimatedContainer = Symbol('promptAnimatedContainer');
 
 const $deferInteractionPrompt = Symbol('deferInteractionPrompt');
@@ -357,6 +358,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     protected[$promptAnimatedContainer] =
         this.shadowRoot!.querySelector(
             '.interaction-prompt > .animated-container') as HTMLElement;
+    protected[$panElement] =
+        this.shadowRoot!.querySelector('.pan-target') as HTMLElement;
 
     protected[$focusedTime] = Infinity;
     protected[$lastPromptOffset] = 0;

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -257,6 +257,27 @@ canvas.show {
   transform-origin: bottom right;
 }
 
+.slot.pan-target {
+  display: block;
+  position: absolute;
+  width: 0;
+  height: 0;
+  left: 50%;
+  top: 50%;
+  transform: translate3d(-50%, -50%, 0);
+  background-color: transparent;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+#default-pan-target {
+  width: 6px;
+  height: 6px;
+  border-radius: 6px;
+  border: 1px solid white;
+  box-shadow: 0px 0px 2px 1px rgba(0, 0, 0, 0.8);
+}
+
 .slot.default {
   pointer-events: none;
 }
@@ -315,6 +336,13 @@ canvas.show {
           aria-label="View in your space">
         ${ARGlyph}
       </a>
+    </slot>
+  </div>
+
+  <div class="slot pan-target">
+    <slot name="pan-target">
+      <div id="default-pan-target">      
+      </div>
     </slot>
   </div>
 

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -15,10 +15,9 @@
 
 import {Camera, Vector3} from 'three';
 
-import {$controls, $promptAnimatedContainer, $promptElement, CameraChangeDetails, cameraOrbitIntrinsics, ControlsInterface, ControlsMixin, INTERACTION_PROMPT, SphericalPosition} from '../../features/controls.js';
+import {$controls, $promptAnimatedContainer, $promptElement, CameraChangeDetails, cameraOrbitIntrinsics, ControlsInterface, ControlsMixin, INTERACTION_PROMPT, OLD_DEFAULT_FOV_DEG, SphericalPosition} from '../../features/controls.js';
 import ModelViewerElementBase, {$canvas, $scene, $statusElement, $userInputElement, Vector3D} from '../../model-viewer-base.js';
 import {StyleEvaluator} from '../../styles/evaluators.js';
-import {DEFAULT_FOV_DEG} from '../../three-components/ModelScene.js';
 import {ChangeSource, SmoothControls} from '../../three-components/SmoothControls.js';
 import {Constructor, step, timePasses, waitForEvent} from '../../utilities.js';
 import {assetPath, dispatchSyntheticEvent, rafPasses, until} from '../helpers.js';
@@ -325,7 +324,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           await timePasses();
           settleControls(controls);
           expect(element.getFieldOfView())
-              .to.be.closeTo(DEFAULT_FOV_DEG, 0.001);
+              .to.be.closeTo(OLD_DEFAULT_FOV_DEG, 0.001);
         });
 
         test('jumps to maxCameraOrbit when outside', async () => {

--- a/packages/model-viewer/src/test/features/scene-graph/model-spec.ts
+++ b/packages/model-viewer/src/test/features/scene-graph/model-spec.ts
@@ -22,8 +22,8 @@ import {$correlatedObjects} from '../../../features/scene-graph/three-dom-elemen
 import {$scene} from '../../../model-viewer-base.js';
 import {ModelViewerElement} from '../../../model-viewer.js';
 import {CorrelatedSceneGraph} from '../../../three-components/gltf-instance/correlated-scene-graph.js';
-import {timePasses, waitForEvent} from '../../../utilities.js';
-import {assetPath, loadThreeGLTF} from '../../helpers.js';
+import {waitForEvent} from '../../../utilities.js';
+import {assetPath, loadThreeGLTF, rafPasses} from '../../helpers.js';
 
 
 
@@ -319,6 +319,8 @@ suite('scene-graph/model', () => {
         test('materialFromPoint returns material', async () => {
           await loadModel(ASTRONAUT_GLB_PATH);
 
+          await rafPasses();
+
           const material = element.materialFromPoint(
               element[$scene].width / 2, element[$scene].height / 2)!;
 
@@ -329,7 +331,7 @@ suite('scene-graph/model', () => {
             'materialFromPoint returns null when intersect fails', async () => {
               await loadModel(ASTRONAUT_GLB_PATH);
 
-              await timePasses(1000);
+              await rafPasses();
 
               const material = element.materialFromPoint(
                   element[$scene].width, element[$scene].height)!;

--- a/packages/model-viewer/src/test/three-components/ModelScene-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ModelScene-spec.ts
@@ -16,7 +16,7 @@
 import {Matrix4, Mesh, SphereBufferGeometry, Vector3} from 'three';
 
 import ModelViewerElementBase, {$canvas} from '../../model-viewer-base.js';
-import {DEFAULT_FOV_DEG, ModelScene} from '../../three-components/ModelScene.js';
+import {ModelScene} from '../../three-components/ModelScene.js';
 import {assetPath} from '../helpers.js';
 
 
@@ -103,13 +103,15 @@ suite('ModelScene', () => {
     test('idealCameraDistance is set correctly', async () => {
       await scene.setObject(dummyMesh);
 
-      const halfFov = (DEFAULT_FOV_DEG / 2) * Math.PI / 180;
+      scene.framedFoVDeg = 35;
+      const halfFov = (scene.framedFoVDeg / 2) * Math.PI / 180;
       const expectedDistance = dummyRadius / Math.sin(halfFov);
       expect(scene.idealCameraDistance())
           .to.be.closeTo(expectedDistance, 0.0001);
     });
 
     test('idealAspect is set correctly', async () => {
+      scene.framedFoVDeg = 35;
       await scene.setObject(dummyMesh);
 
       expect(scene.idealAspect).to.be.closeTo(1, 0.0001);

--- a/packages/model-viewer/src/test/three-components/SmoothControls-spec.ts
+++ b/packages/model-viewer/src/test/three-components/SmoothControls-spec.ts
@@ -15,6 +15,9 @@
 
 import {PerspectiveCamera, Vector3} from 'three';
 
+import {$controls} from '../../features/controls.js';
+import {$userInputElement} from '../../model-viewer-base.js';
+import {ModelViewerElement} from '../../model-viewer.js';
 import {ChangeSource, DEFAULT_OPTIONS, KeyCode, SmoothControls} from '../../three-components/SmoothControls.js';
 import {waitForEvent} from '../../utilities.js';
 import {dispatchSyntheticEvent} from '../helpers.js';
@@ -40,23 +43,25 @@ export const settleControls = (controls: SmoothControls) =>
 suite('SmoothControls', () => {
   let controls: SmoothControls;
   let camera: PerspectiveCamera;
+  let modelViewer: ModelViewerElement;
   let element: HTMLDivElement;
 
   setup(() => {
-    element = document.createElement<'div'>('div');
-    camera = new PerspectiveCamera();
-    controls = new SmoothControls(camera, element);
+    modelViewer = new ModelViewerElement();
+    element = modelViewer[$userInputElement];
+    controls = (modelViewer as any)[$controls];
+    camera = controls.camera;
 
-    element.style.height = '100px';
+    modelViewer.style.height = '100px';
     element.tabIndex = 0;
 
-    document.body.insertBefore(element, document.body.firstChild);
+    document.body.insertBefore(modelViewer, document.body.firstChild);
 
     controls.enableInteraction();
   });
 
   teardown(() => {
-    document.body.removeChild(element);
+    document.body.removeChild(modelViewer);
 
     controls.disableInteraction();
   });

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -688,7 +688,8 @@ export class ARRenderer extends EventDispatcher {
 
   private moveScene(delta: number) {
     const scene = this.presentedScene!;
-    const {position, yaw, boundingRadius} = scene;
+    const {position, yaw} = scene;
+    const boundingRadius = scene.boundingSphere.radius;
     const goal = this.goalPosition;
     const oldScale = scene.scale.x;
     const box = this.placementBox!;

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -46,8 +46,6 @@ export const IlluminationRole: {[index: string]: IlluminationRole} = {
   Secondary: 'secondary'
 };
 
-export const DEFAULT_FOV_DEG = 45;
-
 const view = new Vector3();
 const target = new Vector3();
 const normalWorld = new Vector3();
@@ -87,7 +85,7 @@ export class ModelScene extends Scene {
   public boundingSphere = new Sphere();
   public size = new Vector3();
   public idealAspect = 0;
-  public framedFoVDeg = DEFAULT_FOV_DEG;
+  public framedFoVDeg = 0;
 
   public shadow: Shadow|null = null;
   public shadowIntensity = 0;

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {AnimationAction, AnimationClip, AnimationMixer, Box3, Camera, Event as ThreeEvent, LoopPingPong, LoopRepeat, Matrix3, Object3D, PerspectiveCamera, Raycaster, Scene, Vector2, Vector3, WebGLRenderer} from 'three';
+import {AnimationAction, AnimationClip, AnimationMixer, Box3, Camera, Event as ThreeEvent, LoopPingPong, LoopRepeat, Matrix3, Object3D, PerspectiveCamera, Raycaster, Scene, Sphere, Vector2, Vector3, WebGLRenderer} from 'three';
 import {CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 
 import ModelViewerElementBase, {$renderer, RendererInterface} from '../model-viewer-base.js';
@@ -84,10 +84,10 @@ export class ModelScene extends Scene {
   public modelContainer = new Object3D();
   public animationNames: Array<string> = [];
   public boundingBox = new Box3();
+  public boundingSphere = new Sphere();
   public size = new Vector3();
   public idealAspect = 0;
   public framedFoVDeg = DEFAULT_FOV_DEG;
-  public boundingRadius = 0;
 
   public shadow: Shadow|null = null;
   public shadowIntensity = 0;
@@ -197,7 +197,7 @@ export class ModelScene extends Scene {
     if (this.externalRenderer != null) {
       const framingInfo = await this.externalRenderer.load(progressCallback);
 
-      this.boundingRadius = framingInfo.framedRadius;
+      this.boundingSphere.radius = framingInfo.framedRadius;
       this.idealAspect = framingInfo.fieldOfViewAspect;
 
       this.dispatchEvent({type: 'model-load', url: this.url});
@@ -335,7 +335,7 @@ export class ModelScene extends Scene {
   }
 
   /**
-   * Calculates the boundingRadius and idealAspect that allows the 3D
+   * Calculates the boundingSphere and idealAspect that allows the 3D
    * object to be framed tightly in a 2D window of any aspect ratio without
    * clipping at any camera orbit. The camera's center target point can be
    * optionally specified. If no center is specified, it defaults to the center
@@ -344,17 +344,19 @@ export class ModelScene extends Scene {
    */
   async updateFraming() {
     this.target.remove(this.modelContainer);
+    const {center} = this.boundingSphere;
 
-    let center = this.boundingBox.getCenter(new Vector3());
     if (this.tightBounds === true) {
       await this.element.requestUpdate('cameraTarget');
-      center = this.getTarget();
+      center.copy(this.getTarget());
+    } else {
+      this.boundingBox.getCenter(center);
     }
 
     const radiusSquared = (value: number, vertex: Vector3): number => {
       return Math.max(value, center!.distanceToSquared(vertex));
     };
-    this.boundingRadius =
+    this.boundingSphere.radius =
         Math.sqrt(reduceVertices(this.modelContainer, radiusSquared, 0));
 
     const horizontalTanFov = (value: number, vertex: Vector3): number => {
@@ -372,7 +374,7 @@ export class ModelScene extends Scene {
 
   idealCameraDistance(): number {
     const halfFovRad = (this.framedFoVDeg / 2) * Math.PI / 180;
-    return this.boundingRadius / Math.sin(halfFovRad);
+    return this.boundingSphere.radius / Math.sin(halfFovRad);
   }
 
   /**
@@ -444,7 +446,7 @@ export class ModelScene extends Scene {
     const goal = this.goalTarget;
     const target = this.target.position;
     if (!goal.equals(target)) {
-      const normalization = this.boundingRadius / 10;
+      const normalization = this.boundingSphere.radius / 10;
       let {x, y, z} = target;
       x = this.targetDamperX.update(x, goal.x, delta, normalization);
       y = this.targetDamperY.update(y, goal.y, delta, normalization);
@@ -540,11 +542,12 @@ export class ModelScene extends Scene {
 
     if (name != null) {
       animationClip = this.animationsByName.get(name);
-      
+
       if (animationClip == null) {
         const parsedAnimationIndex = parseInt(name);
 
-        if (!isNaN(parsedAnimationIndex) && parsedAnimationIndex >= 0 && parsedAnimationIndex < animations.length) {
+        if (!isNaN(parsedAnimationIndex) && parsedAnimationIndex >= 0 &&
+            parsedAnimationIndex < animations.length) {
           animationClip = animations[parsedAnimationIndex];
         }
       }

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -430,6 +430,14 @@
         ]
       },
       {
+        "name": "enable-pan",
+        "htmlName": "enablePan",
+        "description": "Enable panning interactions using two-finger touch, or dragging with right-click or modifier keys. Pan is limited to the bounding sphere of the model. Tapping on the model focuses on that point, while tapping off the model zooms back to the original framing. When panning, the center point is shown visually (and can be suppressed/changed using the <a href=\"#entrydocs-stagingandcameras-slots-panTarget\">pan-target</a> slot) and when the pan gesture ends, the camera is focused on that model point (if there was a surface under the dot), so that the camera doesn't orbit around a random point in space. Note this attribute also changes the camera defaults: field-of-view will default to 30 degrees (minimum 12 degrees) and the minimum radius is twice the bounding radius to keep the camera from entering the object.",
+        "links": [
+          "<a href=\"../examples/stagingandcameras/#panning\">Related example</a>"
+        ]
+      },
+      {
         "name": "touch-action",
         "htmlName": "touch-action",
         "description": "Akin to the CSS touch-action property (which does not work due to some iOS bugs), the default 'pan-y' allows touch users to vertically scroll the <span class=\"attribute\">&lt;model-viewer&gt;</span> element, but can interact if their gesture starts horizontal. Legacy behavior can be achieved with 'none', where all scrolling is prevented, while 'pan-x' is the opposite of 'pan-y'. The normal CSS default 'auto' is not allowed here, as this can be achieved by not including the <span class='attribute'>camera-controls</span> attribute.",
@@ -699,6 +707,11 @@
         "name": "interaction-prompt",
         "htmlName": "interactionPrompt",
         "description": "By placing a child element under <span class=\"attribute\">&lt;model-viewer&gt;</span> with <span class=\"attribute\">slot=\"interaction-prompt\"</span>, this element will replace the default hand icon which wiggles back and forth with the model until the user interacts."
+      },
+      {
+        "name": "pan-target",
+        "htmlName": "panTarget",
+        "description": "By placing a child element under <span class=\"attribute\">&lt;model-viewer&gt;</span> with <span class=\"attribute\">slot=\"pan-target\"</span>, this element will replace the small default circle that appears when the user is panning to indicate the camera's target."
       }
     ]
   },

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -331,12 +331,15 @@
       src="../../assets/SketchfabModels/ThorAndTheMidgardSerpent.glb"
       alt="Thor and the Midgard Serpent"
       camera-controls
+      enable-pan
       touch-action="none"
       camera-orbit="-8.142746deg 68.967deg 0.6179899m"
       camera-target="-0.003m 0.0722m 0.0391m"
+      field-of-view="45deg"
       min-field-of-view="45deg"
+      max-field-of-view="45deg"
       interpolation-decay="200"
-      min-camera-orbit="auto auto 10%"
+      min-camera-orbit="auto auto 5%"
       touch-action="none"
       poster="../../assets/SketchfabModels/ThorAndTheMidgardSerpent.webp"
       ar
@@ -438,147 +441,6 @@
       transform: translate3d(-50%, -50%, 0);
     }
 </style>
-
-<!-- nearly identical to the "Staging & Cameras/Panning" example -->
-<script type="module">
-  const modelViewer = document.querySelector("#hotspot-camera-view-demo");
-  const tapDistance = 2;
-  let panning = false;
-  let panX, panY;
-  let startX, startY;
-  let lastX, lastY;
-  let metersPerPixel;
-
-  const startPan = () => {
-    const orbit = modelViewer.getCameraOrbit();
-    const {theta, phi, radius} = orbit;
-    const psi = theta - modelViewer.turntableRotation;
-    metersPerPixel = 0.75 * radius / modelViewer.getBoundingClientRect().height;
-    panX = [-Math.cos(psi), 0, Math.sin(psi)];
-    panY = [
-      -Math.cos(phi) * Math.sin(psi),
-      Math.sin(phi),
-      -Math.cos(phi) * Math.cos(psi)
-    ];
-    modelViewer.interactionPrompt = 'none';
-  };
-
-  const stopPan = (event) => {
-    panning = false;
-  }
-
-  const movePan = (thisX, thisY) => {
-    const dx = (thisX - lastX) * metersPerPixel;
-    const dy = (thisY - lastY) * metersPerPixel;
-    lastX = thisX;
-    lastY = thisY;
-
-    const target = modelViewer.getCameraTarget();
-    target.x += dx * panX[0] + dy * panY[0];
-    target.y += dx * panX[1] + dy * panY[1];
-    target.z += dx * panX[2] + dy * panY[2];
-    modelViewer.cameraTarget = `${target.x}m ${target.y}m ${target.z}m`;
-
-    // This pauses turntable rotation
-    modelViewer.dispatchEvent(new CustomEvent(
-          'camera-change', {detail: {source: 'user-interaction'}}));
-  };
-
-  const recenter = (pointer) => {
-    panning = false;
-    if (Math.abs(pointer.clientX - startX) > tapDistance ||
-        Math.abs(pointer.clientY - startY) > tapDistance)
-      return;
-    const hit = modelViewer.positionAndNormalFromPoint(pointer.clientX, pointer.clientY);
-    if(hit != null) {
-      modelViewer.cameraTarget = hit.position.toString();
-    }
-    else {
-      modelViewer.cameraTarget = 'auto auto auto';
-      modelViewer.cameraOrbit = 'auto auto auto';
-    }
-  };
-
-  modelViewer.addEventListener('mousedown', (event) => {
-    startX = event.clientX;
-    startY = event.clientY;
-    panning = event.button === 2 || event.ctrlKey || event.metaKey ||
-        event.shiftKey;
-    if (!panning)
-      return;
-
-    lastX = startX;
-    lastY = startY;
-    startPan();
-    event.stopPropagation();
-  }, true);
-
-  modelViewer.addEventListener('touchstart', (event) => {
-    const {targetTouches, touches} = event;
-    startX = targetTouches[0].clientX;
-    startY = targetTouches[0].clientY;
-    panning = targetTouches.length === 2 && targetTouches.length === touches.length;
-    if (!panning)
-      return;
-
-    lastX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
-    lastY = 0.5 * (targetTouches[0].clientY + targetTouches[1].clientY);
-    startPan();
-  }, true);
-
-  self.addEventListener('mousemove', (event) => {
-    if (!panning)
-      return;
-
-    movePan(event.clientX, event.clientY);
-    event.stopPropagation();
-  }, true);
-
-  modelViewer.addEventListener('touchmove', (event) => {
-    if (!panning || event.targetTouches.length !== 2)
-      return;
-
-    const {targetTouches} = event;
-    const thisX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
-    const thisY = 0.5 * (targetTouches[0].clientY + targetTouches[1].clientY);
-    movePan(thisX, thisY);
-  }, true);
-
-  let lastMousedown = {time: new Date().getTime()};
-  let lastTouchstart = {time: new Date().getTime()};
-  function doubletap(timer) {
-    var now = new Date().getTime();
-    var timesince = now - timer.time;
-    timer.time = new Date().getTime();
-    if((timesince < 400) && (timesince > 0))
-      return true;
-    else
-      return false;
-  }
-
-  self.addEventListener('mouseup', (event) => {
-    stopPan(event);
-  }, true);
-
-  modelViewer.addEventListener('oncontextmenu', (event) => {
-      return false;
-  });
-
-  self.addEventListener('mousedown', (event) => {
-    if(doubletap(lastMousedown))
-        recenter(event);
-  }, true);
-  
-  modelViewer.addEventListener('touchstart', (event) => {
-    if (doubletap(lastTouchstart) && event.targetTouches.length === 0) {
-      recenter(event.changedTouches[0]);
-
-      if (event.cancelable) {
-        event.preventDefault();
-      }
-    }
-  }, true);
-</script>
             </template>
           </example-snippet>
         </div>

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -185,130 +185,13 @@
       <div class="content">
         <div class="wrapper">
           <div class="heading">
-            <h2 class="demo-title">Add other interactions like pan</h2>
-            <h4>Event listeners can cooperate with camera-controls</h4>
-            <p>By using capture on your event listeners you can make sure the
-            events are also passed in as usual to the built in camera controls.
-            This can be selectively disabled by calling stopPropagation() on the
-            event.</p>
-            <p>This is one of many possible implementations of panning around a
-            model, including the ability to set the target by clicking. It is left
-            as an example here as there are too many possible variations to make a
-            reasonable API around. It also tends to be confusing to users in cases
-            where it is not necessary.</p>
+            <h2 class="demo-title">Pan and focus</h2>
+            <p>Enables two-finger pan on touch or using right-click or any modifier key with mouse drag. 
+              Clicking on the model focuses on that point, while clicking off the model returns to the default center.</p>
           </div>
           <example-snippet stamp-to="panning" highlight-as="html">
             <template>
-<model-viewer id="pan-demo" auto-rotate camera-controls oncontextmenu="return false;" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum"></model-viewer>
-<script type="module">
-  const modelViewer = document.querySelector('#pan-demo');
-  const tapDistance = 2;
-  let panning = false;
-  let panX, panY;
-  let startX, startY;
-  let lastX, lastY;
-  let metersPerPixel;
-
-  const startPan = () => {
-    const orbit = modelViewer.getCameraOrbit();
-    const {theta, phi, radius} = orbit;
-    const psi = theta - modelViewer.turntableRotation;
-    metersPerPixel = 0.75 * radius / modelViewer.getBoundingClientRect().height;
-    panX = [-Math.cos(psi), 0, Math.sin(psi)];
-    panY = [
-      -Math.cos(phi) * Math.sin(psi),
-      Math.sin(phi),
-      -Math.cos(phi) * Math.cos(psi)
-    ];
-    modelViewer.interactionPrompt = 'none';
-  };
-
-  const movePan = (thisX, thisY) => {
-    const dx = (thisX - lastX) * metersPerPixel;
-    const dy = (thisY - lastY) * metersPerPixel;
-    lastX = thisX;
-    lastY = thisY;
-
-    const target = modelViewer.getCameraTarget();
-    target.x += dx * panX[0] + dy * panY[0];
-    target.y += dx * panX[1] + dy * panY[1];
-    target.z += dx * panX[2] + dy * panY[2];
-    modelViewer.cameraTarget = `${target.x}m ${target.y}m ${target.z}m`;
-
-    // This pauses turntable rotation
-    modelViewer.dispatchEvent(new CustomEvent(
-          'camera-change', {detail: {source: 'user-interaction'}}));
-  };
-
-  const recenter = (pointer) => {
-    panning = false;
-    if (Math.abs(pointer.clientX - startX) > tapDistance ||
-        Math.abs(pointer.clientY - startY) > tapDistance)
-      return;
-    const hit = modelViewer.positionAndNormalFromPoint(pointer.clientX, pointer.clientY);
-    modelViewer.cameraTarget =
-        hit == null ? 'auto auto auto' : hit.position.toString();
-  };
-
-  modelViewer.addEventListener('mousedown', (event) => {
-    startX = event.clientX;
-    startY = event.clientY;
-    panning = event.button === 2 || event.ctrlKey || event.metaKey ||
-        event.shiftKey;
-    if (!panning)
-      return;
-
-    lastX = startX;
-    lastY = startY;
-    startPan();
-    event.stopPropagation();
-  }, true);
-
-  modelViewer.addEventListener('touchstart', (event) => {
-    const {targetTouches, touches} = event;
-    startX = targetTouches[0].clientX;
-    startY = targetTouches[0].clientY;
-    panning = targetTouches.length === 2 && targetTouches.length === touches.length;
-    if (!panning)
-      return;
-
-    lastX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
-    lastY = 0.5 * (targetTouches[0].clientY + targetTouches[1].clientY);
-    startPan();
-  }, true);
-
-  self.addEventListener('mousemove', (event) => {
-    if (!panning)
-      return;
-
-    movePan(event.clientX, event.clientY);
-    event.stopPropagation();
-  }, true);
-
-  modelViewer.addEventListener('touchmove', (event) => {
-    if (!panning || event.targetTouches.length !== 2)
-      return;
-
-    const {targetTouches} = event;
-    const thisX = 0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
-    const thisY = 0.5 * (targetTouches[0].clientY + targetTouches[1].clientY);
-    movePan(thisX, thisY);
-  }, true);
-
-  self.addEventListener('mouseup', (event) => {
-    recenter(event);
-  }, true);
-  
-  modelViewer.addEventListener('touchend', (event) => {
-    if (event.targetTouches.length === 0) {
-      recenter(event.changedTouches[0]);
-
-      if (event.cancelable) {
-        event.preventDefault();
-      }
-    }
-  }, true);
-</script>
+<model-viewer id="pan-demo" enable-pan auto-rotate camera-controls src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum"></model-viewer>
             </template>
           </example-snippet>
         </div>
@@ -321,6 +204,11 @@
         <div class="wrapper">
           <div class="heading">
             <h2 class="demo-title">Add other interactions like rotating the skybox</h2>
+            <h4>Event listeners can cooperate with camera-controls</h4>
+            <p>By using capture on your event listeners you can make sure the
+              events are also passed in as usual to the built in camera controls.
+              This can be selectively disabled by calling stopPropagation() on the
+              event.</p>
             <p>Using shift-drag or two-finger drag on mobile, one can rotate the
             skybox to see how the environment would cast light onto the object
             from different angles.</p>

--- a/packages/space-opera/src/types.ts
+++ b/packages/space-opera/src/types.ts
@@ -133,7 +133,7 @@ export const INITIAL_STATE: State = {
       hotspots: [],
       relativeFilePaths:
           {posterName: 'poster.webp', environmentName: 'neutral'},
-      extraAttributes: {bounds: 'tight'},
+      extraAttributes: {bounds: 'tight', 'enable-pan': ''},
     },
   },
 };


### PR DESCRIPTION
Adds `enable-pan` as an attribute so that no extra JS is needed to enable panning interactions. Pan is limited to the bounding sphere of the model. Tapping on the model focuses on that point, while tapping off the model zooms back to the original framing. When panning, the center point is shown visually (and can be suppressed/changed using the `pan-target` slot) and when the pan gesture ends, the camera is focused on that model point (if there was a surface under the dot), so that the camera doesn't orbit around a random point in space. 