### PR TITLE
Baked shadows

### DIFF
--- a/packages/model-viewer/src/features/environment.ts
+++ b/packages/model-viewer/src/features/environment.ts
@@ -38,6 +38,7 @@ export declare interface EnvironmentInterface {
   shadowIntensity: number;
   shadowSoftness: number;
   exposure: number;
+  hasBakedShadow(): boolean;
 }
 
 export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
@@ -103,6 +104,10 @@ export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
           this[$shouldAttemptPreload]()) {
         this[$updateEnvironment]();
       }
+    }
+
+    hasBakedShadow(): boolean {
+      return this[$scene].bakedShadows.length > 0;
     }
 
     [$onModelLoad]() {

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -26,8 +26,7 @@ import {Hotspot} from './Hotspot.js';
 import {reduceVertices} from './ModelUtils.js';
 import {Shadow} from './Shadow.js';
 
-const MAX_SHADOW_THICKNESS = 1e-4;
-const MIN_SHADOW_SIZE = 1e-2;
+const MIN_SHADOW_RATIO = 100;
 
 export interface ModelLoadEvent extends ThreeEvent {
   url: string;
@@ -334,7 +333,7 @@ export class ModelScene extends Scene {
       const size = boundingBox.getSize(vector3);
       const minDim = Math.min(size.x, size.y, size.z);
       const maxDim = Math.max(size.x, size.y, size.z);
-      if (minDim > MAX_SHADOW_THICKNESS || maxDim < MIN_SHADOW_SIZE) {
+      if (maxDim < MIN_SHADOW_RATIO * minDim) {
         return;
       }
       this.bakedShadows.push(mesh);

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -338,6 +338,7 @@ export class ModelScene extends Scene {
         return;
       }
       this.bakedShadows.push(mesh);
+      mesh.userData.shadow = true;
     });
   }
 
@@ -726,12 +727,8 @@ export class ModelScene extends Scene {
     this.raycaster.setFromCamera(ndcPosition, this.getCamera());
     const hits = this.raycaster.intersectObject(object, true);
 
-    if (hits.length === 0) {
-      return null;
-    }
-
-    const hit = hits[0];
-    if (hit.face == null) {
+    const hit = hits.find((hit) => !hit.object.userData.shadow);
+    if (hit == null || hit.face == null) {
       return null;
     }
 

--- a/packages/model-viewer/src/three-components/ModelUtils.ts
+++ b/packages/model-viewer/src/three-components/ModelUtils.ts
@@ -63,7 +63,7 @@ export const reduceVertices = <T>(
     T => {
       let value = initialValue;
       const vertex = new Vector3();
-      model.traverse((object: any) => {
+      model.traverseVisible((object: any) => {
         let i, l;
 
         object.updateWorldMatrix(false, false);

--- a/packages/model-viewer/src/three-components/Shadow.ts
+++ b/packages/model-viewer/src/three-components/Shadow.ts
@@ -91,6 +91,7 @@ export class Shadow extends Object3D {
       side: BackSide,
     });
     this.floor = new Mesh(plane, shadowMaterial);
+    this.floor.userData.shadow = true;
     camera.add(this.floor);
 
     // the plane onto which to blur the texture

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -560,7 +560,7 @@ export class SmoothControls extends EventDispatcher {
         this.userAdjustOrbit(0, 0, deltaZoom);
       }
 
-      if (this.enablePan && this.panMetersPerPixel > 0) {
+      if (this.panMetersPerPixel > 0) {
         const thisX =
             0.5 * (targetTouches[0].clientX + targetTouches[1].clientX);
         const thisY =
@@ -646,6 +646,9 @@ export class SmoothControls extends EventDispatcher {
   }
 
   private recenter(pointer: Pointer) {
+    if (!this.enablePan) {
+      return;
+    }
     const {scene} = this;
     (scene.element as any)[$panElement].style.opacity = 0;
     if (Math.abs(pointer.clientX - this.startPointerPosition.clientX) <

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -823,6 +823,13 @@
         }
       }
     ],
+    "Methods": [
+      {
+        "name": "hasBakedShadow()",
+        "htmlName": "hasBakedShadow",
+        "description": "Returns true if a baked-in shadow plane appears to be part of this model. These planes are removed from framing calculations and are only rendered if shadow-intensity is zero, to avoid multiple shadows interacting."
+      }
+    ],
     "Events": [
       {
         "name": "environment-change",

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -427,14 +427,14 @@ modelViewerTexture.addEventListener("load", () => {
   </div>
 </model-viewer>
 <script type="module">
-const modelViewerTexture = document.querySelector("model-viewer#helmet");
+const modelViewerTexture1 = document.querySelector("model-viewer#helmet");
 
-modelViewerTexture.addEventListener("load", () => {
+modelViewerTexture1.addEventListener("load", () => {
 
-  const material = modelViewerTexture.model.materials[0];
+  const material = modelViewerTexture1.model.materials[0];
 
   const createAndApplyTexture = async (channel, event) => {
-    const texture = await modelViewerTexture.createTexture(event.target.value);
+    const texture = await modelViewerTexture1.createTexture(event.target.value);
     if (channel.includes('base') || channel.includes('metallic')) {
       material.pbrMetallicRoughness[channel].setTexture(texture);
     } else {
@@ -481,7 +481,7 @@ modelViewerTexture.addEventListener("load", () => {
           </div>
           <example-snippet stamp-to="pickMaterialExample" highlight-as="html">
             <template>
-<model-viewer id="pickMaterial" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer" scale="0.001 0.001 0.001" alt="A Material Picking Example">
+<model-viewer id="pickMaterial" shadow-intensity="1" camera-controls src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer" scale="0.001 0.001 0.001" alt="A Material Picking Example">
 </model-viewer>
 <script type="module">
 const modelViewer = document.querySelector("model-viewer#pickMaterial");

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -191,7 +191,7 @@
           </div>
           <example-snippet stamp-to="panning" highlight-as="html">
             <template>
-<model-viewer id="pan-demo" enable-pan auto-rotate camera-controls src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum"></model-viewer>
+<model-viewer id="pan-demo" enable-pan auto-rotate shadow-intensity="1" camera-controls src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum"></model-viewer>
             </template>
           </example-snippet>
         </div>


### PR DESCRIPTION
Identifies pre-baked shadows in the model (unlit, transparent, axis-aligned planes) and removes them from framing calculations. Also disables them if `shadow-intensity` is non-zero so that only one type of shadow is shown. Added `hasBakedShadow()` method to query the model. 

Also fixed some bugs from the last PR: tap-recentering was enabled always instead of only when `enable-pan` was specified. Fixed `positionAndNormalFromPoint` to ignore hits on shadows. 