### PR TITLE
fixed reverse play

### DIFF
--- a/packages/model-viewer/src/features/animation.ts
+++ b/packages/model-viewer/src/features/animation.ts
@@ -66,7 +66,6 @@ export const AnimationMixin = <T extends Constructor<ModelViewerElementBase>>(
       });
       this[$scene].subscribeMixerEvent('finished', () => {
         this[$paused] = true;
-        this[$changeAnimation]();
         this.dispatchEvent(new CustomEvent('finished'));
       });
     }

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -608,9 +608,14 @@ export class ModelScene extends Scene {
 
       if ((this.element as any).paused) {
         this.mixer.stopAllAction();
-      } else if (
-          lastAnimationAction != null && action !== lastAnimationAction) {
-        action.crossFadeFrom(lastAnimationAction, crossfadeTime, false);
+      } else {
+        action.paused = false;
+        if (lastAnimationAction != null && action !== lastAnimationAction) {
+          action.crossFadeFrom(lastAnimationAction, crossfadeTime, false);
+        } else if (this.animationTimeScale > 0) {
+          // This is a workaround for what I believe is a three.js bug.
+          this.animationTime = 0;
+        }
       }
 
       action.setLoop(loopMode, repetitionCount);

--- a/packages/modelviewer.dev/examples/animation/index.html
+++ b/packages/modelviewer.dev/examples/animation/index.html
@@ -90,17 +90,18 @@
           </div>
           <example-snippet stamp-to="controlSpeed" highlight-as="html">
             <template>
-<model-viewer id="change-speed-demo" camera-controls autoplay animation-name="Dance" ar shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animate 3D model of a robot"></model-viewer>
-<script>
-(() => {
+<model-viewer id="change-speed-demo" camera-controls animation-name="Dance" ar shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animate 3D model of a robot"></model-viewer>
+<script type="module">
   const modelViewer = document.querySelector('#change-speed-demo');
-  const speeds = [1, 2, 0.5, -1, 0];
+  const speeds = [1, 2, 0.5, -1];
 
   let i = 0;
-  self.setInterval(() => {
+  const play = () => {
     modelViewer.timeScale = speeds[i++%speeds.length];
-  }, 3000.0);
-})();
+    modelViewer.play({repetitions: 1});
+  };
+  modelViewer.addEventListener('load', play);
+  modelViewer.addEventListener('finished', play);
 </script>
             </template>
           </example-snippet>


### PR DESCRIPTION
Fixes #3223 

This was painful to debug; I think there's a three.js bug in here somewhere, but our own animation code is also a little convoluted. This workaround seems to fix it, but I should probably go in and refactor this sometime. I also changed our example to repro the bug and serve as a manual regression test.