### PR TITLE
added render-scale event

### DIFF
--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -145,7 +145,7 @@
         "htmlName": "minimumRenderScale",
         "description": "This static, writable property sets <span class='attribute'>&lt;model-viewer&gt;</span>'s minimum rendering scale factor as it dynamically changes resolution to maintain framerate. Monitor its behavior with the <a href=\"./#entrydocs-loading-events-renderScale\">render-scale</a> event. Turn off this effect by setting to 1.",
         "links": [
-          "<a href=\"../examples/loading/#renderScale\">Dynamic Scaling</a>"
+          "<a href=\"../examples/loading/#renderScale\">Dynamic Scaling Example</a>"
         ],
         "default": {
           "default": "0.5",

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -143,9 +143,9 @@
       {
         "name": "minimumRenderScale",
         "htmlName": "minimumRenderScale",
-        "description": "This static, writable property sets <span class='attribute'>&lt;model-viewer&gt;</span>'s minimum rendering scale factor as it dynamically changes resolution to maintain framerate. Turn off this effect by setting to 1.",
+        "description": "This static, writable property sets <span class='attribute'>&lt;model-viewer&gt;</span>'s minimum rendering scale factor as it dynamically changes resolution to maintain framerate. Monitor its behavior with the <a href=\"./#entrydocs-loading-events-renderScale\">render-scale</a> event. Turn off this effect by setting to 1.",
         "links": [
-          "<a href=\"../examples/loading/#dracoSupport\">Static property usage example</a>"
+          "<a href=\"../examples/loading/#renderScale\">Dynamic Scaling</a>"
         ],
         "default": {
           "default": "0.5",
@@ -233,6 +233,14 @@
         "name": "progress",
         "htmlName": "progress",
         "description": "This event fires while a model, environment, and/or skybox is loading, during both download and processing. The progress of all of these concurrent tasks will be given by a value between 0 and 1: event.detail.totalProgress."
+      },
+      {
+        "name": "render-scale",
+        "htmlName": "renderScale",
+        "description": "This event fires when the element is attached to the DOM and whenever the rendered DPR (device pixel ratio) changes, which is generally due to our renderer scaling its resolution to maintain frame rate. The event.detail contains the reportedDpr (window.devicePixelRatio), our renderedDpr (<= reportedDpr), minimumDpr (based on <a href=\"./#entrydocs-loading-staticProperties-minimumRenderScale\">minimumRenderScale</a>), reason ('GPU throttling' or 'No meta viewport tag'), and pixelWidth/pixelHeight (rendered resolution of the element). Everything except the size is identical for all elements on the page since the renderer is shared.",
+        "links": [
+          "<a href=\"../examples/loading/#renderScale\">Dynamic Scaling Example</a>"
+        ]
       }
     ],
     "Parts": [

--- a/packages/modelviewer.dev/data/examples.json
+++ b/packages/modelviewer.dev/data/examples.json
@@ -48,8 +48,8 @@
         "name": "USDZ Model"
       },
       {
-        "htmlId": "noModel",
-        "name": "No Model"
+        "htmlId": "renderScale",
+        "name": "Dynamic Scaling"
       },
       {
         "htmlId": "cyclingModels",

--- a/packages/modelviewer.dev/examples/loading/index.html
+++ b/packages/modelviewer.dev/examples/loading/index.html
@@ -393,17 +393,55 @@ self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimize
     </div>
 
     <div class="sample">
-      <div id="noModel" class="demo"></div>
+      <div id="renderScale" class="demo"></div>
       <div class="content">
         <div class="wrapper">
           <div class="heading">
-            <h2 class="demo-title">With no model</h2>
-            <h4>There's nothing to show, but also no error.</h4>
+            <h2 class="demo-title">Dynamic scaling</h2>
+            <h4>Our renderer automatically scales resolution to maintain frame rate. This behavior can be monitored and controlled.</h4>
           </div>
-          <example-snippet stamp-to="noModel" highlight-as="html">
+          <example-snippet stamp-to="renderScale" highlight-as="html">
             <template>
-<model-viewer alt="An invalid model" src="i-do-not-exist.glb">
+<model-viewer id="scale" alt="A 3D model of a toy car" camera-controls auto-rotate src="../../shared-assets/models/glTF-Sample-Models/2.0/ToyCar/glTF-Binary/ToyCar.glb" ar ar-modes="webxr scene-viewer quick-look">
+  Reported DPR: <span id="reportedDpr"></span><br/>
+  Rendered DPR: <span id="renderedDpr"></span><br/>
+  Minimum DPR: <span id="minimumDpr"></span><br/>
+  Rendered width (pixels): <span id="pixelWidth"></span><br/>
+  Rendered height (pixels): <span id="pixelHeight"></span><br/>
+  Reason for scaling: <span id="reason"></span><br/>
+  Minimum scale: <span id="min-scale-value">0.5</span><br/>
+  <input id="min-scale" type="range" min="0.25" max="1" step="0.01" value="0.5" />
 </model-viewer>
+
+<script>
+  const reportedDpr = document.querySelector('#reportedDpr');
+  const renderedDpr = document.querySelector('#renderedDpr');
+  const minimumDpr = document.querySelector('#minimumDpr');
+  const pixelWidth = document.querySelector('#pixelWidth');
+  const pixelHeight = document.querySelector('#pixelHeight');
+  const reason = document.querySelector('#reason');
+
+  // This must be registered before the element loads to catch the initial event.
+  document.querySelector('#scale').addEventListener('render-scale', (event) => {
+    reportedDpr.textContent = event.detail.reportedDpr;
+    renderedDpr.textContent = event.detail.renderedDpr;
+    minimumDpr.textContent = event.detail.minimumDpr;
+    pixelWidth.textContent = event.detail.pixelWidth;
+    pixelHeight.textContent = event.detail.pixelHeight;
+    reason.textContent = event.detail.reason;
+  });
+
+  window.addEventListener('DOMContentLoaded', () => {
+    const minScale = document.querySelector('#min-scale-value');
+    // The static API must be queried after the element loads.
+    const ModelViewerStatic = customElements.get('model-viewer');
+
+    document.querySelector('#min-scale').addEventListener('input', (event) => {
+      ModelViewerStatic.minimumRenderScale = event.target.value;
+      minScale.textContent = event.target.value;
+    });
+  }, {once: true});
+</script>
             </template>
           </example-snippet>
         </div>

--- a/packages/modelviewer.dev/examples/loading/index.html
+++ b/packages/modelviewer.dev/examples/loading/index.html
@@ -399,6 +399,15 @@ self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimize
           <div class="heading">
             <h2 class="demo-title">Dynamic scaling</h2>
             <h4>Our renderer automatically scales resolution to maintain frame rate. This behavior can be monitored and controlled.</h4>
+            <h4>To see throttling happen, you'll have to tax your GPU. This model is intentionally complex (including transparency and clear coat)
+              so that it will throttle on a fairly broad range of devices. Note that expanding your window and zooming in will tend to tax the GPU
+              more since more pixels are being shaded. Also note that the render returns to full scale any time the scene stops moving. If you use
+              very complex 3D models, you may want to disable auto-rotate for this reason. 
+            </h4>
+            <h4>Our renderer tries to keep the frame rate between 38 and 60 frames per second. It's a pretty safe bet that if you are at the reportedDpr,
+              you are smoothly running at 60 fps, and if you are at the minimumDpr you are likely well below 38 fps. This event only fires in 3D mode;
+              The AR modes also do dynamic render scaling, but do not report their status. 
+            </h4>
           </div>
           <example-snippet stamp-to="renderScale" highlight-as="html">
             <template>
@@ -433,7 +442,7 @@ self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimize
 
   window.addEventListener('DOMContentLoaded', () => {
     const minScale = document.querySelector('#min-scale-value');
-    // The static API must be queried after the element loads.
+    // The static API must be queried after the element loads. Note that static properties affect all the <model-vieweer> elements on the page.
     const ModelViewerStatic = customElements.get('model-viewer');
 
     document.querySelector('#min-scale').addEventListener('input', (event) => {


### PR DESCRIPTION
You can now monitor our dynamic render scaling to know what kind of rendering performance your users are seeing. I've added an example that shows how the process works with a complicated and slow-to-render model that will tend to trigger GPU throttling on many less powerful devices. This also demonstrates how to control the behavior with `minimumRenderScale` and allows you to see what tradeoffs that creates. 