### PR TITLE
remove tap-zoom-in

### DIFF
--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -669,8 +669,6 @@ export class SmoothControls extends EventDispatcher {
     } else {
       scene.target.worldToLocal(hit.position);
       scene.setTarget(hit.position.x, hit.position.y, hit.position.z);
-      // Zoom in on the tapped point.
-      this.userAdjustOrbit(0, 0, -5 * ZOOM_SENSITIVITY);
     }
   }
 


### PR DESCRIPTION
Fixes #3334 

By popular demand, `enable-pan` will no longer zoom in on a tap: it will only shift the camera target. Tapping on the background will still zoom back out. 