### PR TITLE
updated FoV in thor example

### DIFF
--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -336,7 +336,7 @@
       camera-orbit="-8.142746deg 68.967deg 0.6179899m"
       camera-target="-0.003m 0.0722m 0.0391m"
       field-of-view="45deg"
-      min-field-of-view="45deg"
+      min-field-of-view="25deg"
       max-field-of-view="45deg"
       interpolation-decay="200"
       min-camera-orbit="auto auto 5%"
@@ -413,6 +413,7 @@
     let dataset = annotation.dataset;
     modelViewer1.cameraTarget = dataset.target;
     modelViewer1.cameraOrbit = dataset.orbit;
+    modelViewer1.fieldOfView = '45deg';
   }
 
   modelViewer1.querySelectorAll('button').forEach((hotspot) => {


### PR DESCRIPTION
Fixes #3281 

Okay, on closer inspection, I think the only reason this example was zooming too fast is that it was set to have no FoV range (max = min = 45deg). We base the zoom on changing the FoV, so if that fails, we have a fallback that's getting used for radius. With these small tweaks to the example it now feels just fine to me. 

The bigger question: right now a single zoom "click" is set to change the zoom by a fixed amount of `log(FoV)`, which means if the FoV range decreases, it takes fewer "clicks" to cross that range (because it tries to change FoV and radius in proportion to their extents). Should we instead target a fixed number of "clicks" traversing the range of the zoom limits? If so, how many? Will it be weird that small zoom ranges have less zoom sensitivity? 

Would love some feedback here, @hybridherbst.