### PR TITLE
fixed ImageBitmap memory leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1929,9 +1929,9 @@
       }
     },
     "node_modules/async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "node_modules/asynckit": {
@@ -2167,12 +2167,12 @@
       "dev": true
     },
     "node_modules/clang-format": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.6.0.tgz",
-      "integrity": "sha512-W3/L7fWkA8DoLkz9UGjrRnNi+J5a5TuS2HDLqk6WsicpOzb66MBu4eY/EcXhicHriVnAXWQVyk5/VeHWY6w4ow==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.7.0.tgz",
+      "integrity": "sha512-BNuK+rXAK/Fk0rOQ1DW6bpSQUAZz6tpbZHTQn6m4PsgEkE1SNr6AQ/hhFK/b4KJrl4zjcl68molP+rEaKSZRAQ==",
       "dev": true,
       "dependencies": {
-        "async": "^1.5.2",
+        "async": "^3.2.3",
         "glob": "^7.0.0",
         "resolve": "^1.1.6"
       },
@@ -2687,15 +2687,19 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "dependencies": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -2896,9 +2900,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
-      "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
+      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -2912,7 +2916,7 @@
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.0",
@@ -3944,9 +3948,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3959,6 +3963,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -4090,9 +4106,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "dependencies": {
         "agent-base": "6",
@@ -4382,9 +4398,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -4891,14 +4907,14 @@
       }
     },
     "node_modules/libnpmaccess/node_modules/socks-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.0.tgz",
+      "integrity": "sha512-wWqJhjb32Q6GsrUqzuFkukxb/zzide5quXYcMVpIjxalDBBYy2nqKCFQ/9+Ie4dvOYSQdOk3hUlZSdzZOd3zMQ==",
       "dev": true,
       "dependencies": {
         "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
       },
       "engines": {
         "node": ">= 10"
@@ -4965,14 +4981,14 @@
       }
     },
     "node_modules/libnpmpublish/node_modules/socks-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.0.tgz",
+      "integrity": "sha512-wWqJhjb32Q6GsrUqzuFkukxb/zzide5quXYcMVpIjxalDBBYy2nqKCFQ/9+Ie4dvOYSQdOk3hUlZSdzZOd3zMQ==",
       "dev": true,
       "dependencies": {
         "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
       },
       "engines": {
         "node": ">= 10"
@@ -6285,14 +6301,14 @@
       }
     },
     "node_modules/pacote/node_modules/socks-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.0.tgz",
+      "integrity": "sha512-wWqJhjb32Q6GsrUqzuFkukxb/zzide5quXYcMVpIjxalDBBYy2nqKCFQ/9+Ie4dvOYSQdOk3hUlZSdzZOd3zMQ==",
       "dev": true,
       "dependencies": {
         "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
       },
       "engines": {
         "node": ">= 10"
@@ -6451,9 +6467,9 @@
       }
     },
     "node_modules/portfinder/node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -7200,27 +7216,18 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-      "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^7.4.0"
+        "lru-cache": "^6.0.0"
       },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
-        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
-      "integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/set-blocking": {
@@ -7906,9 +7913,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -7934,14 +7941,14 @@
       "dev": true
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -9928,9 +9935,9 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "asynckit": {
@@ -10121,12 +10128,12 @@
       "dev": true
     },
     "clang-format": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.6.0.tgz",
-      "integrity": "sha512-W3/L7fWkA8DoLkz9UGjrRnNi+J5a5TuS2HDLqk6WsicpOzb66MBu4eY/EcXhicHriVnAXWQVyk5/VeHWY6w4ow==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.7.0.tgz",
+      "integrity": "sha512-BNuK+rXAK/Fk0rOQ1DW6bpSQUAZz6tpbZHTQn6m4PsgEkE1SNr6AQ/hhFK/b4KJrl4zjcl68molP+rEaKSZRAQ==",
       "dev": true,
       "requires": {
-        "async": "^1.5.2",
+        "async": "^3.2.3",
         "glob": "^7.0.0",
         "resolve": "^1.1.6"
       }
@@ -10528,12 +10535,13 @@
       }
     },
     "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       }
     },
     "delayed-stream": {
@@ -10696,9 +10704,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
-      "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
+      "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -10712,7 +10720,7 @@
         "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
+        "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.0",
@@ -11492,9 +11500,9 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
@@ -11502,6 +11510,15 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "has-property-descriptors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -11597,9 +11614,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "requires": {
         "agent-base": "6",
@@ -11819,9 +11836,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -12212,14 +12229,14 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-          "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.0.tgz",
+          "integrity": "sha512-wWqJhjb32Q6GsrUqzuFkukxb/zzide5quXYcMVpIjxalDBBYy2nqKCFQ/9+Ie4dvOYSQdOk3hUlZSdzZOd3zMQ==",
           "dev": true,
           "requires": {
             "agent-base": "^6.0.2",
-            "debug": "^4.3.1",
-            "socks": "^2.6.1"
+            "debug": "^4.3.3",
+            "socks": "^2.6.2"
           }
         }
       }
@@ -12276,14 +12293,14 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-          "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.0.tgz",
+          "integrity": "sha512-wWqJhjb32Q6GsrUqzuFkukxb/zzide5quXYcMVpIjxalDBBYy2nqKCFQ/9+Ie4dvOYSQdOk3hUlZSdzZOd3zMQ==",
           "dev": true,
           "requires": {
             "agent-base": "^6.0.2",
-            "debug": "^4.3.1",
-            "socks": "^2.6.1"
+            "debug": "^4.3.3",
+            "socks": "^2.6.2"
           }
         }
       }
@@ -13306,14 +13323,14 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-          "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.0.tgz",
+          "integrity": "sha512-wWqJhjb32Q6GsrUqzuFkukxb/zzide5quXYcMVpIjxalDBBYy2nqKCFQ/9+Ie4dvOYSQdOk3hUlZSdzZOd3zMQ==",
           "dev": true,
           "requires": {
             "agent-base": "^6.0.2",
-            "debug": "^4.3.1",
-            "socks": "^2.6.1"
+            "debug": "^4.3.3",
+            "socks": "^2.6.2"
           }
         }
       }
@@ -13432,9 +13449,9 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "dev": true,
           "requires": {
             "lodash": "^4.17.14"
@@ -14000,20 +14017,12 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-      "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "requires": {
-        "lru-cache": "^7.4.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "7.8.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
-          "integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
-          "dev": true
-        }
+        "lru-cache": "^6.0.0"
       }
     },
     "set-blocking": {
@@ -14535,9 +14544,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-      "integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
       "dev": true,
       "optional": true
     },
@@ -14554,14 +14563,14 @@
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },

--- a/packages/model-viewer/package-lock.json
+++ b/packages/model-viewer/package-lock.json
@@ -21,7 +21,7 @@
 				"@types/chai": "^4.2.21",
 				"@types/mocha": "^8.2.3",
 				"@types/pngjs": "^6.0.1",
-				"@types/three": "^0.137.0",
+				"@types/three": "^0.139.0",
 				"@ungap/event-target": "^0.2.2",
 				"chai": "^4.3.4",
 				"focus-visible": "^5.2.0",
@@ -46,12 +46,13 @@
 			}
 		},
 		"node_modules/@ampproject/remapping": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -1621,10 +1622,32 @@
 				"node": ">=0.1.90"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-			"integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -1637,9 +1660,9 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-			"integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -1732,9 +1755,9 @@
 			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.1.tgz",
+			"integrity": "sha512-btX7kzGvp1JwShQI9V6IM841YKNPYjKCvUbNrQ2EcVYbULtUd/GH6wZ/qdqH13j9pOHBER+EZXNN2L8RSJhVRA==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -1838,9 +1861,9 @@
 			}
 		},
 		"node_modules/@types/babel__traverse": {
-			"version": "7.14.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
-			"integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
+			"version": "7.17.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+			"integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.3.0"
@@ -1879,9 +1902,9 @@
 			"dev": true
 		},
 		"node_modules/@types/chai": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
-			"integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
 			"dev": true
 		},
 		"node_modules/@types/command-line-args": {
@@ -2020,9 +2043,9 @@
 			}
 		},
 		"node_modules/@types/koa__cors": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.1.1.tgz",
-			"integrity": "sha512-O7MBkCocnLrpEvkMrYAp17arUDS+KuS5bXMG/Z4aPSbrO7vrYB6YrqcsTD3Dp2OnAL3j4WME2k/x2kOcyzwNUw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.3.0.tgz",
+			"integrity": "sha512-FUN8YxcBakIs+walVe3+HcNP+Bxd0SB8BJHBWkglZ5C1XQWljlKcEFDG/dPiCIqwVCUbc5X0nYDlH62uEhdHMA==",
 			"dev": true,
 			"dependencies": {
 				"@types/koa": "*"
@@ -2107,9 +2130,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
 			"dev": true
 		},
 		"node_modules/@types/path-is-inside": {
@@ -2159,9 +2182,9 @@
 			}
 		},
 		"node_modules/@types/three": {
-			"version": "0.137.0",
-			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.137.0.tgz",
-			"integrity": "sha512-Xc5EAlfYmgrCLI/VlSVqiRJAtzhWF0Rw2jSq48nqJy+Hcb5sfDOXyfZn1+RNcHyi9l8CeCAXCZygO8IyeOJVEA==",
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.139.0.tgz",
+			"integrity": "sha512-4V/jZhyq7Mv05coUzxL3bz8AuBOSi/1F0RY7ujisHTV0Amy/fnYJ+s7TSJ1/hXjZukSkpuFRgV+wvWUEMbsMbQ==",
 			"dev": true
 		},
 		"node_modules/@types/whatwg-url": {
@@ -2217,9 +2240,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2357,9 +2380,9 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"dev": true,
 			"dependencies": {
 				"lodash": "^4.17.14"
@@ -2559,9 +2582,9 @@
 			"dev": true
 		},
 		"node_modules/browserslist": {
-			"version": "4.20.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-			"integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+			"version": "4.20.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+			"integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2574,10 +2597,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001317",
-				"electron-to-chromium": "^1.4.84",
+				"caniuse-lite": "^1.0.30001332",
+				"electron-to-chromium": "^1.4.118",
 				"escalade": "^3.1.1",
-				"node-releases": "^2.0.2",
+				"node-releases": "^2.0.3",
 				"picocolors": "^1.0.0"
 			},
 			"bin": {
@@ -2604,28 +2627,37 @@
 			}
 		},
 		"node_modules/browserslist-useragent/node_modules/lru-cache": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
-			"integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			}
 		},
 		"node_modules/browserslist-useragent/node_modules/semver": {
-			"version": "7.3.6",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 			"dev": true,
 			"dependencies": {
-				"lru-cache": "^7.4.0"
+				"lru-cache": "^6.0.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+				"node": ">=10"
 			}
+		},
+		"node_modules/browserslist-useragent/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/browserstack": {
 			"version": "1.5.3",
@@ -2734,9 +2766,9 @@
 			}
 		},
 		"node_modules/camel-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/camelcase": {
@@ -2761,9 +2793,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001325",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-			"integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+			"version": "1.0.30001334",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2974,14 +3006,14 @@
 			}
 		},
 		"node_modules/command-line-usage": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.2.tgz",
-			"integrity": "sha512-I+0XN613reAhpBQ6icsPOTwu9cvhc9NtLtUcY2fGYuwm9JZiWBzFDA8w0PHqQjru7Xth7fM/y9TJ13+VKdjh7Q==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+			"integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
 			"dev": true,
 			"dependencies": {
-				"array-back": "^4.0.1",
+				"array-back": "^4.0.2",
 				"chalk": "^2.4.2",
-				"table-layout": "^1.0.1",
+				"table-layout": "^1.0.2",
 				"typical": "^5.2.0"
 			},
 			"engines": {
@@ -3148,9 +3180,9 @@
 			}
 		},
 		"node_modules/core-js-bundle": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.21.1.tgz",
-			"integrity": "sha512-4Gjo/bE+NxIBMsoFzuo4u8QjA531kKaorC7L1DiUlvM3ny4pj/0vIz9y1BZUWmFP6KHaEsUNFLWWLUa9EwN/2Q==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.22.3.tgz",
+			"integrity": "sha512-tgp03QRPXUr/540ZCAwYuEIk7Z7r+AObHPqgnMlctZiHRkwP9LlDSK8sf9sEAIOIFQ6oAwElhpJAPw1ym1UJNQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -3159,12 +3191,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.21.1.tgz",
-			"integrity": "sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+			"integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.19.1",
+				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
 			},
 			"funding": {
@@ -3253,9 +3285,9 @@
 			}
 		},
 		"node_modules/date-format": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.6.tgz",
-			"integrity": "sha512-B9vvg5rHuQ8cbUXE/RMWMyX2YA5TecT3jKF5fLtGNlzPlU7zblSPmAm2OImDbWL+LDOQ6pUm+4LOFz+ywS41Zw==",
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.9.tgz",
+			"integrity": "sha512-+8J+BOUpSrlKLQLeF8xJJVTxS8QfRSuJgwxSVvslzgO3E6khbI0F5mMEPf5mTYhCCm4h99knYP6H3W9n3BQFrg==",
 			"dev": true,
 			"engines": {
 				"node": ">=4.0"
@@ -3333,15 +3365,19 @@
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"dev": true,
 			"dependencies": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/delayed-stream": {
@@ -3416,9 +3452,9 @@
 			}
 		},
 		"node_modules/dot-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/duplexer": {
@@ -3466,9 +3502,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.106",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
-			"integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
+			"version": "1.4.124",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+			"integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -3496,9 +3532,9 @@
 			}
 		},
 		"node_modules/engine.io": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
-			"integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
+			"integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
 			"dev": true,
 			"dependencies": {
 				"@types/cookie": "^0.4.1",
@@ -3544,9 +3580,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
-			"integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
+			"version": "1.19.5",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
+			"integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
@@ -3560,7 +3596,7 @@
 				"is-callable": "^1.2.4",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
 				"is-weakref": "^1.0.2",
 				"object-inspect": "^1.12.0",
@@ -3977,9 +4013,9 @@
 			"dev": true
 		},
 		"node_modules/fs-extra": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-			"integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
@@ -4189,9 +4225,9 @@
 			}
 		},
 		"node_modules/has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -4204,6 +4240,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-symbols": {
@@ -4515,9 +4563,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -4979,9 +5027,9 @@
 			}
 		},
 		"node_modules/karma": {
-			"version": "6.3.17",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.17.tgz",
-			"integrity": "sha512-2TfjHwrRExC8yHoWlPBULyaLwAFmXmxQrcuFImt/JsAsSZu1uOWTZ1ZsWjqQtWpHLiatJOHL5jFjXSJIgCd01g==",
+			"version": "6.3.19",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.19.tgz",
+			"integrity": "sha512-NDhWckzES/Y9xMiddyU1RzaKL76/scCsu8Mp0vR0Z3lQRvC3p72+Ab4ppoxs36S9tyPNX5V48yvaV++RNEBPZw==",
 			"dev": true,
 			"dependencies": {
 				"@colors/colors": "1.5.0",
@@ -5003,7 +5051,7 @@
 				"qjobs": "^1.2.0",
 				"range-parser": "^1.2.1",
 				"rimraf": "^3.0.2",
-				"socket.io": "^4.2.0",
+				"socket.io": "^4.4.1",
 				"source-map": "^0.6.1",
 				"tmp": "^0.2.1",
 				"ua-parser-js": "^0.7.30",
@@ -5395,16 +5443,16 @@
 			}
 		},
 		"node_modules/log4js": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.4.tgz",
-			"integrity": "sha512-ncaWPsuw9Vl1CKA406hVnJLGQKy1OHx6buk8J4rE2lVW+NW5Y82G5/DIloO7NkqLOUtNPEANaWC1kZYVjXssPw==",
+			"version": "6.4.6",
+			"resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.6.tgz",
+			"integrity": "sha512-1XMtRBZszmVZqPAOOWczH+Q94AI42mtNWjvjA5RduKTSWjEc56uOBbyM1CJnfN4Ym0wSd8cQ43zOojlSHgRDAw==",
 			"dev": true,
 			"dependencies": {
-				"date-format": "^4.0.6",
+				"date-format": "^4.0.9",
 				"debug": "^4.3.4",
 				"flatted": "^3.2.5",
 				"rfdc": "^1.3.0",
-				"streamroller": "^3.0.6"
+				"streamroller": "^3.0.8"
 			},
 			"engines": {
 				"node": ">=8.0"
@@ -5429,9 +5477,9 @@
 			}
 		},
 		"node_modules/lower-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/lru-cache": {
@@ -5882,9 +5930,9 @@
 			}
 		},
 		"node_modules/no-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/node-fetch": {
@@ -5930,9 +5978,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-			"integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+			"integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
 			"dev": true
 		},
 		"node_modules/normalize-package-data": {
@@ -6152,9 +6200,9 @@
 			}
 		},
 		"node_modules/param-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/parse-json": {
@@ -6196,9 +6244,9 @@
 			}
 		},
 		"node_modules/pascal-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/path-exists": {
@@ -6776,9 +6824,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-			"integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+			"integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -6846,23 +6894,26 @@
 			}
 		},
 		"node_modules/rollup-plugin-terser/node_modules/source-map": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+			"version": "0.8.0-beta.0",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+			"integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
 			"dev": true,
+			"dependencies": {
+				"whatwg-url": "^7.0.0"
+			},
 			"engines": {
 				"node": ">= 8"
 			}
 		},
 		"node_modules/rollup-plugin-terser/node_modules/terser": {
-			"version": "5.12.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-			"integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+			"version": "5.13.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.13.0.tgz",
+			"integrity": "sha512-sgQ99P+fRBM1jAYzN9RTnD/xEWx/7LZgYTCRgmYriSq1wxxqiQPJgXkkLBBuwySDWJ2PP0PnVQyuf4xLUuH4Ng==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
-				"source-map": "~0.7.2",
+				"source-map": "~0.8.0-beta.0",
 				"source-map-support": "~0.5.20"
 			},
 			"bin": {
@@ -6986,16 +7037,16 @@
 			}
 		},
 		"node_modules/socket.io": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
-			"integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.0.tgz",
+			"integrity": "sha512-slTYqU2jCgMjXwresG8grhUi/cC6GjzmcfqArzaH3BN/9I/42eZk9yamNvZJdBfTubkjEdKAKs12NEztId+bUA==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
 				"debug": "~4.3.2",
-				"engine.io": "~6.1.0",
-				"socket.io-adapter": "~2.3.3",
+				"engine.io": "~6.2.0",
+				"socket.io-adapter": "~2.4.0",
 				"socket.io-parser": "~4.0.4"
 			},
 			"engines": {
@@ -7003,9 +7054,9 @@
 			}
 		},
 		"node_modules/socket.io-adapter": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
-			"integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+			"integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
 			"dev": true
 		},
 		"node_modules/socket.io-parser": {
@@ -7144,14 +7195,14 @@
 			}
 		},
 		"node_modules/streamroller": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.6.tgz",
-			"integrity": "sha512-Qz32plKq/MZywYyhEatxyYc8vs994Gz0Hu2MSYXXLD233UyPeIeRBZARIIGwFer4Mdb8r3Y2UqKkgyDghM6QCg==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.8.tgz",
+			"integrity": "sha512-VI+ni3czbFZrd1MrlybxykWZ8sMDCMtTU7YJyhgb9M5X6d1DDxLdJr+gSnmRpXPMnIWxWKMaAE8K0WumBp3lDg==",
 			"dev": true,
 			"dependencies": {
-				"date-format": "^4.0.6",
+				"date-format": "^4.0.9",
 				"debug": "^4.3.4",
-				"fs-extra": "^10.0.1"
+				"fs-extra": "^10.1.0"
 			},
 			"engines": {
 				"node": ">=8.0"
@@ -7595,14 +7646,14 @@
 			}
 		},
 		"node_modules/unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			},
 			"funding": {
@@ -8075,12 +8126,13 @@
 	},
 	"dependencies": {
 		"@ampproject/remapping": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
 		"@babel/code-frame": {
@@ -9169,10 +9221,26 @@
 			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
 			"dev": true
 		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"@jridgewell/resolve-uri": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-			"integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+			"dev": true
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
 			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
@@ -9182,9 +9250,9 @@
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-			"integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -9268,9 +9336,9 @@
 			}
 		},
 		"@rollup/plugin-node-resolve": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.1.tgz",
+			"integrity": "sha512-btX7kzGvp1JwShQI9V6IM841YKNPYjKCvUbNrQ2EcVYbULtUd/GH6wZ/qdqH13j9pOHBER+EZXNN2L8RSJhVRA==",
 			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -9358,9 +9426,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.14.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
-			"integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
+			"version": "7.17.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+			"integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -9398,9 +9466,9 @@
 			"dev": true
 		},
 		"@types/chai": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
-			"integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
 			"dev": true
 		},
 		"@types/command-line-args": {
@@ -9539,9 +9607,9 @@
 			}
 		},
 		"@types/koa__cors": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.1.1.tgz",
-			"integrity": "sha512-O7MBkCocnLrpEvkMrYAp17arUDS+KuS5bXMG/Z4aPSbrO7vrYB6YrqcsTD3Dp2OnAL3j4WME2k/x2kOcyzwNUw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.3.0.tgz",
+			"integrity": "sha512-FUN8YxcBakIs+walVe3+HcNP+Bxd0SB8BJHBWkglZ5C1XQWljlKcEFDG/dPiCIqwVCUbc5X0nYDlH62uEhdHMA==",
 			"dev": true,
 			"requires": {
 				"@types/koa": "*"
@@ -9626,9 +9694,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
 			"dev": true
 		},
 		"@types/path-is-inside": {
@@ -9678,9 +9746,9 @@
 			}
 		},
 		"@types/three": {
-			"version": "0.137.0",
-			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.137.0.tgz",
-			"integrity": "sha512-Xc5EAlfYmgrCLI/VlSVqiRJAtzhWF0Rw2jSq48nqJy+Hcb5sfDOXyfZn1+RNcHyi9l8CeCAXCZygO8IyeOJVEA==",
+			"version": "0.139.0",
+			"resolved": "https://registry.npmjs.org/@types/three/-/three-0.139.0.tgz",
+			"integrity": "sha512-4V/jZhyq7Mv05coUzxL3bz8AuBOSi/1F0RY7ujisHTV0Amy/fnYJ+s7TSJ1/hXjZukSkpuFRgV+wvWUEMbsMbQ==",
 			"dev": true
 		},
 		"@types/whatwg-url": {
@@ -9733,9 +9801,9 @@
 			}
 		},
 		"acorn": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
 			"dev": true
 		},
 		"agent-base": {
@@ -9836,9 +9904,9 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.14"
@@ -10009,15 +10077,15 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.20.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-			"integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+			"version": "4.20.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+			"integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001317",
-				"electron-to-chromium": "^1.4.84",
+				"caniuse-lite": "^1.0.30001332",
+				"electron-to-chromium": "^1.4.118",
 				"escalade": "^3.1.1",
-				"node-releases": "^2.0.2",
+				"node-releases": "^2.0.3",
 				"picocolors": "^1.0.0"
 			}
 		},
@@ -10035,19 +10103,28 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "7.8.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
-					"integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
-					"dev": true
-				},
-				"semver": {
-					"version": "7.3.6",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^7.4.0"
+						"yallist": "^4.0.0"
 					}
+				},
+				"semver": {
+					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
 				}
 			}
 		},
@@ -10139,9 +10216,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -10165,9 +10242,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001325",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-			"integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+			"version": "1.0.30001334",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
 			"dev": true
 		},
 		"caseless": {
@@ -10324,14 +10401,14 @@
 			}
 		},
 		"command-line-usage": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.2.tgz",
-			"integrity": "sha512-I+0XN613reAhpBQ6icsPOTwu9cvhc9NtLtUcY2fGYuwm9JZiWBzFDA8w0PHqQjru7Xth7fM/y9TJ13+VKdjh7Q==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+			"integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
 			"dev": true,
 			"requires": {
-				"array-back": "^4.0.1",
+				"array-back": "^4.0.2",
 				"chalk": "^2.4.2",
-				"table-layout": "^1.0.1",
+				"table-layout": "^1.0.2",
 				"typical": "^5.2.0"
 			},
 			"dependencies": {
@@ -10460,18 +10537,18 @@
 			}
 		},
 		"core-js-bundle": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.21.1.tgz",
-			"integrity": "sha512-4Gjo/bE+NxIBMsoFzuo4u8QjA531kKaorC7L1DiUlvM3ny4pj/0vIz9y1BZUWmFP6KHaEsUNFLWWLUa9EwN/2Q==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.22.3.tgz",
+			"integrity": "sha512-tgp03QRPXUr/540ZCAwYuEIk7Z7r+AObHPqgnMlctZiHRkwP9LlDSK8sf9sEAIOIFQ6oAwElhpJAPw1ym1UJNQ==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.21.1.tgz",
-			"integrity": "sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+			"integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.19.1",
+				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
@@ -10542,9 +10619,9 @@
 			}
 		},
 		"date-format": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.6.tgz",
-			"integrity": "sha512-B9vvg5rHuQ8cbUXE/RMWMyX2YA5TecT3jKF5fLtGNlzPlU7zblSPmAm2OImDbWL+LDOQ6pUm+4LOFz+ywS41Zw==",
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.9.tgz",
+			"integrity": "sha512-+8J+BOUpSrlKLQLeF8xJJVTxS8QfRSuJgwxSVvslzgO3E6khbI0F5mMEPf5mTYhCCm4h99knYP6H3W9n3BQFrg==",
 			"dev": true
 		},
 		"debounce": {
@@ -10596,12 +10673,13 @@
 			"dev": true
 		},
 		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"dev": true,
 			"requires": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			}
 		},
 		"delayed-stream": {
@@ -10663,9 +10741,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -10711,9 +10789,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.106",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
-			"integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
+			"version": "1.4.124",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+			"integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -10738,9 +10816,9 @@
 			}
 		},
 		"engine.io": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
-			"integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
+			"integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
 			"dev": true,
 			"requires": {
 				"@types/cookie": "^0.4.1",
@@ -10780,9 +10858,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
-			"integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
+			"version": "1.19.5",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
+			"integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
@@ -10796,7 +10874,7 @@
 				"is-callable": "^1.2.4",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
 				"is-weakref": "^1.0.2",
 				"object-inspect": "^1.12.0",
@@ -11137,9 +11215,9 @@
 			"dev": true
 		},
 		"fs-extra": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-			"integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.0",
@@ -11290,9 +11368,9 @@
 			}
 		},
 		"has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
 			"dev": true
 		},
 		"has-flag": {
@@ -11300,6 +11378,15 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
+		},
+		"has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.1"
+			}
 		},
 		"has-symbols": {
 			"version": "1.0.3",
@@ -11539,9 +11626,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -11871,9 +11958,9 @@
 			}
 		},
 		"karma": {
-			"version": "6.3.17",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.17.tgz",
-			"integrity": "sha512-2TfjHwrRExC8yHoWlPBULyaLwAFmXmxQrcuFImt/JsAsSZu1uOWTZ1ZsWjqQtWpHLiatJOHL5jFjXSJIgCd01g==",
+			"version": "6.3.19",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.19.tgz",
+			"integrity": "sha512-NDhWckzES/Y9xMiddyU1RzaKL76/scCsu8Mp0vR0Z3lQRvC3p72+Ab4ppoxs36S9tyPNX5V48yvaV++RNEBPZw==",
 			"dev": true,
 			"requires": {
 				"@colors/colors": "1.5.0",
@@ -11895,7 +11982,7 @@
 				"qjobs": "^1.2.0",
 				"range-parser": "^1.2.1",
 				"rimraf": "^3.0.2",
-				"socket.io": "^4.2.0",
+				"socket.io": "^4.4.1",
 				"source-map": "^0.6.1",
 				"tmp": "^0.2.1",
 				"ua-parser-js": "^0.7.30",
@@ -12230,16 +12317,16 @@
 			}
 		},
 		"log4js": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.4.tgz",
-			"integrity": "sha512-ncaWPsuw9Vl1CKA406hVnJLGQKy1OHx6buk8J4rE2lVW+NW5Y82G5/DIloO7NkqLOUtNPEANaWC1kZYVjXssPw==",
+			"version": "6.4.6",
+			"resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.6.tgz",
+			"integrity": "sha512-1XMtRBZszmVZqPAOOWczH+Q94AI42mtNWjvjA5RduKTSWjEc56uOBbyM1CJnfN4Ym0wSd8cQ43zOojlSHgRDAw==",
 			"dev": true,
 			"requires": {
-				"date-format": "^4.0.6",
+				"date-format": "^4.0.9",
 				"debug": "^4.3.4",
 				"flatted": "^3.2.5",
 				"rfdc": "^1.3.0",
-				"streamroller": "^3.0.6"
+				"streamroller": "^3.0.8"
 			}
 		},
 		"loupe": {
@@ -12261,9 +12348,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -12595,9 +12682,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -12636,9 +12723,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-			"integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+			"integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -12801,9 +12888,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -12841,9 +12928,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -13306,9 +13393,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-			"integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+			"integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -13361,20 +13448,23 @@
 					}
 				},
 				"source-map": {
-					"version": "0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-					"dev": true
+					"version": "0.8.0-beta.0",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+					"integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^7.0.0"
+					}
 				},
 				"terser": {
-					"version": "5.12.1",
-					"resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
-					"integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
+					"version": "5.13.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-5.13.0.tgz",
+					"integrity": "sha512-sgQ99P+fRBM1jAYzN9RTnD/xEWx/7LZgYTCRgmYriSq1wxxqiQPJgXkkLBBuwySDWJ2PP0PnVQyuf4xLUuH4Ng==",
 					"dev": true,
 					"requires": {
 						"acorn": "^8.5.0",
 						"commander": "^2.20.0",
-						"source-map": "~0.7.2",
+						"source-map": "~0.8.0-beta.0",
 						"source-map-support": "~0.5.20"
 					}
 				}
@@ -13481,23 +13571,23 @@
 			"dev": true
 		},
 		"socket.io": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
-			"integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.0.tgz",
+			"integrity": "sha512-slTYqU2jCgMjXwresG8grhUi/cC6GjzmcfqArzaH3BN/9I/42eZk9yamNvZJdBfTubkjEdKAKs12NEztId+bUA==",
 			"dev": true,
 			"requires": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
 				"debug": "~4.3.2",
-				"engine.io": "~6.1.0",
-				"socket.io-adapter": "~2.3.3",
+				"engine.io": "~6.2.0",
+				"socket.io-adapter": "~2.4.0",
 				"socket.io-parser": "~4.0.4"
 			}
 		},
 		"socket.io-adapter": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
-			"integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+			"integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
 			"dev": true
 		},
 		"socket.io-parser": {
@@ -13615,14 +13705,14 @@
 			}
 		},
 		"streamroller": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.6.tgz",
-			"integrity": "sha512-Qz32plKq/MZywYyhEatxyYc8vs994Gz0Hu2MSYXXLD233UyPeIeRBZARIIGwFer4Mdb8r3Y2UqKkgyDghM6QCg==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.8.tgz",
+			"integrity": "sha512-VI+ni3czbFZrd1MrlybxykWZ8sMDCMtTU7YJyhgb9M5X6d1DDxLdJr+gSnmRpXPMnIWxWKMaAE8K0WumBp3lDg==",
 			"dev": true,
 			"requires": {
-				"date-format": "^4.0.6",
+				"date-format": "^4.0.9",
 				"debug": "^4.3.4",
-				"fs-extra": "^10.0.1"
+				"fs-extra": "^10.1.0"
 			}
 		},
 		"string-width": {
@@ -13949,14 +14039,14 @@
 			"dev": true
 		},
 		"unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			}
 		},

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -81,7 +81,7 @@
     "@types/chai": "^4.2.21",
     "@types/mocha": "^8.2.3",
     "@types/pngjs": "^6.0.1",
-    "@types/three": "^0.137.0",
+    "@types/three": "^0.139.0",
     "@ungap/event-target": "^0.2.2",
     "chai": "^4.3.4",
     "focus-visible": "^5.2.0",

--- a/packages/model-viewer/src/test/model-viewer-spec.ts
+++ b/packages/model-viewer/src/test/model-viewer-spec.ts
@@ -42,7 +42,8 @@ const setupLighting =
 // TODO(sun765): this only test whether the screenshot
 // is colorless or not. Replace this with more robust
 // test in later pr.
-function testFidelity(screenshotContext: WebGLRenderingContext) {
+function testFidelity(screenshotContext: WebGLRenderingContext|
+                      WebGL2RenderingContext) {
   const width = screenshotContext.drawingBufferWidth;
   const height = screenshotContext.drawingBufferHeight;
 

--- a/packages/model-viewer/src/three-components/GLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/GLTFInstance.ts
@@ -141,13 +141,13 @@ export class GLTFInstance implements GLTF {
         materials.forEach(material => {
           // Explicitly dispose any textures assigned to this material
           for (const propertyName in material) {
-            const propertyValue = (material as any)[propertyName];
-            if (propertyValue instanceof Texture) {
-              const image = propertyValue.source.data;
+            const texture = (material as any)[propertyName];
+            if (texture instanceof Texture) {
+              const image = texture.source.data;
               if (image instanceof ImageBitmap) {
                 image.close();
               }
-              propertyValue.dispose();
+              texture.dispose();
             }
           }
           material.dispose();

--- a/packages/model-viewer/src/three-components/GLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/GLTFInstance.ts
@@ -143,6 +143,10 @@ export class GLTFInstance implements GLTF {
           for (const propertyName in material) {
             const propertyValue = (material as any)[propertyName];
             if (propertyValue instanceof Texture) {
+              const image = propertyValue.source.data;
+              if (image instanceof ImageBitmap) {
+                image.close();
+              }
               propertyValue.dispose();
             }
           }

--- a/packages/modelviewer.dev/package-lock.json
+++ b/packages/modelviewer.dev/package-lock.json
@@ -28,9 +28,9 @@
 			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.1.tgz",
+			"integrity": "sha512-btX7kzGvp1JwShQI9V6IM841YKNPYjKCvUbNrQ2EcVYbULtUd/GH6wZ/qdqH13j9pOHBER+EZXNN2L8RSJhVRA==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -84,9 +84,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
 			"dev": true
 		},
 		"node_modules/@types/prismjs": {
@@ -263,9 +263,9 @@
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
 		"node_modules/is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -281,11 +281,11 @@
 			"dev": true
 		},
 		"node_modules/js-beautify": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.2.tgz",
-			"integrity": "sha512-H85kX95a53os+q1OCqtYe8AXAmgy3BvtysA/V83S3fdhznm6WlUpGi14DqSPbKFsL3dXZFXYl7YQwW9U1+76ng==",
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.3.tgz",
+			"integrity": "sha512-f1ra8PHtOEu/70EBnmiUlV8nJePS58y9qKjl4JHfYWlFH6bo7ogZBz//FAZp7jDuXtYnGYKymZPlrg2I/9Zo4g==",
 			"dependencies": {
-				"config-chain": "^1.1.12",
+				"config-chain": "^1.1.13",
 				"editorconfig": "^0.15.3",
 				"glob": "^7.1.3",
 				"nopt": "^5.0.0"
@@ -390,9 +390,9 @@
 			}
 		},
 		"node_modules/prismjs": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-			"integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+			"integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -425,9 +425,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-			"integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+			"integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -514,9 +514,9 @@
 	},
 	"dependencies": {
 		"@rollup/plugin-node-resolve": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.1.tgz",
+			"integrity": "sha512-btX7kzGvp1JwShQI9V6IM841YKNPYjKCvUbNrQ2EcVYbULtUd/GH6wZ/qdqH13j9pOHBER+EZXNN2L8RSJhVRA==",
 			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -555,9 +555,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
 			"dev": true
 		},
 		"@types/prismjs": {
@@ -706,9 +706,9 @@
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
 		"is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -721,11 +721,11 @@
 			"dev": true
 		},
 		"js-beautify": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.2.tgz",
-			"integrity": "sha512-H85kX95a53os+q1OCqtYe8AXAmgy3BvtysA/V83S3fdhznm6WlUpGi14DqSPbKFsL3dXZFXYl7YQwW9U1+76ng==",
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.3.tgz",
+			"integrity": "sha512-f1ra8PHtOEu/70EBnmiUlV8nJePS58y9qKjl4JHfYWlFH6bo7ogZBz//FAZp7jDuXtYnGYKymZPlrg2I/9Zo4g==",
 			"requires": {
-				"config-chain": "^1.1.12",
+				"config-chain": "^1.1.13",
 				"editorconfig": "^0.15.3",
 				"glob": "^7.1.3",
 				"nopt": "^5.0.0"
@@ -804,9 +804,9 @@
 			"dev": true
 		},
 		"prismjs": {
-			"version": "1.27.0",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-			"integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+			"integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
 		},
 		"proto-list": {
 			"version": "1.2.4",
@@ -830,9 +830,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-			"integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+			"integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"

--- a/packages/render-fidelity-tools/package-lock.json
+++ b/packages/render-fidelity-tools/package-lock.json
@@ -45,9 +45,9 @@
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-			"integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.7.0.tgz",
+			"integrity": "sha512-7fPSS7yKOhTpgLMbw7lBLc1QJWvJBBAgyTX2PEhagWcKK8t0H8AKCoPMfnrHqIm5cRYH4QFPqD1/ruhuUE7YcQ==",
 			"dependencies": {
 				"@actions/http-client": "^1.0.11"
 			}
@@ -61,12 +61,13 @@
 			}
 		},
 		"node_modules/@ampproject/remapping": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -1019,10 +1020,32 @@
 				"kuler": "^2.0.0"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-			"integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -1035,9 +1058,9 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-			"integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -1317,9 +1340,9 @@
 			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.1.tgz",
+			"integrity": "sha512-btX7kzGvp1JwShQI9V6IM841YKNPYjKCvUbNrQ2EcVYbULtUd/GH6wZ/qdqH13j9pOHBER+EZXNN2L8RSJhVRA==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -1406,9 +1429,9 @@
 			}
 		},
 		"node_modules/@types/chai": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
-			"integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
 			"dev": true
 		},
 		"node_modules/@types/chai-subset": {
@@ -1560,9 +1583,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA=="
 		},
 		"node_modules/@types/pako": {
 			"version": "1.0.3",
@@ -1593,9 +1616,9 @@
 			}
 		},
 		"node_modules/@types/puppeteer": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.5.tgz",
-			"integrity": "sha512-lxCjpDEY+DZ66+W3x5Af4oHnEmUXt0HuaRzkBGE2UZiZEp/V1d3StpLPlmNVu/ea091bdNmVPl44lu8Wy/0ZCA==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.6.tgz",
+			"integrity": "sha512-98Kghehs7+/GD9b56qryhqdqVCXUTbetTv3PlvDnmFRTHQH0j9DIp1f7rkAW3BAj4U3yoeSEQnKgdW8bDq0Y0Q==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -1636,9 +1659,9 @@
 			"dev": true
 		},
 		"node_modules/@types/uglify-js": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
-			"integrity": "sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==",
+			"version": "3.13.2",
+			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.2.tgz",
+			"integrity": "sha512-/xFrPIo+4zOeNGtVMbf9rUm0N+i4pDf1ynExomqtokIJmVzR3962lJ1UE+MmexMkA0cmN9oTzg5Xcbwge0Ij2Q==",
 			"dev": true,
 			"dependencies": {
 				"source-map": "^0.6.1"
@@ -1690,9 +1713,9 @@
 			}
 		},
 		"node_modules/@types/yauzl": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-			"integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
 			"optional": true,
 			"dependencies": {
 				"@types/node": "*"
@@ -1832,9 +1855,9 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"dependencies": {
 				"lodash": "^4.17.14"
 			}
@@ -2421,9 +2444,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.20.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-			"integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+			"version": "4.20.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+			"integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2436,10 +2459,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001317",
-				"electron-to-chromium": "^1.4.84",
+				"caniuse-lite": "^1.0.30001332",
+				"electron-to-chromium": "^1.4.118",
 				"escalade": "^3.1.1",
-				"node-releases": "^2.0.2",
+				"node-releases": "^2.0.3",
 				"picocolors": "^1.0.0"
 			},
 			"bin": {
@@ -2552,9 +2575,9 @@
 			"dev": true
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001325",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-			"integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+			"version": "1.0.30001334",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2672,9 +2695,9 @@
 			"dev": true
 		},
 		"node_modules/color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
 			"dev": true,
 			"dependencies": {
 				"color-name": "^1.0.0",
@@ -2928,15 +2951,19 @@
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"dev": true,
 			"dependencies": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/detect-indent": {
@@ -3055,9 +3082,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.106",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
-			"integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
+			"version": "1.4.124",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+			"integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
 			"dev": true
 		},
 		"node_modules/emitter-component": {
@@ -3763,6 +3790,18 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/has-symbols": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -3972,9 +4011,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -4696,9 +4735,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-			"integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+			"integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
 			"dev": true
 		},
 		"node_modules/normalize-package-data": {
@@ -5922,9 +5961,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-			"integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+			"integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -5952,9 +5991,9 @@
 			}
 		},
 		"node_modules/rollup-plugin-external-globals/node_modules/@rollup/pluginutils": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.0.tgz",
-			"integrity": "sha512-2WUyJNRkyH5p487pGnn4tWAsxhEFKN/pT8CMgHshd5H+IXkOnKvKZwsz5ZWz+YCXkleZRAU5kwbfgF8CPfDRqA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
 			"dev": true,
 			"dependencies": {
 				"estree-walker": "^2.0.1",
@@ -6546,9 +6585,9 @@
 			"dev": true
 		},
 		"node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",
@@ -6967,9 +7006,9 @@
 			}
 		},
 		"node_modules/winston-transport/node_modules/fecha": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-			"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
 			"dev": true
 		},
 		"node_modules/winston-transport/node_modules/logform": {
@@ -7006,9 +7045,9 @@
 			"dev": true
 		},
 		"node_modules/winston/node_modules/fecha": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-			"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
 			"dev": true
 		},
 		"node_modules/winston/node_modules/is-stream": {
@@ -7141,9 +7180,9 @@
 	},
 	"dependencies": {
 		"@actions/core": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-			"integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.7.0.tgz",
+			"integrity": "sha512-7fPSS7yKOhTpgLMbw7lBLc1QJWvJBBAgyTX2PEhagWcKK8t0H8AKCoPMfnrHqIm5cRYH4QFPqD1/ruhuUE7YcQ==",
 			"requires": {
 				"@actions/http-client": "^1.0.11"
 			}
@@ -7157,12 +7196,13 @@
 			}
 		},
 		"@ampproject/remapping": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
 		"@babel/code-frame": {
@@ -7828,10 +7868,26 @@
 				"kuler": "^2.0.0"
 			}
 		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"@jridgewell/resolve-uri": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-			"integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+			"dev": true
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
 			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
@@ -7841,9 +7897,9 @@
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-			"integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -8117,9 +8173,9 @@
 			}
 		},
 		"@rollup/plugin-node-resolve": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.1.tgz",
+			"integrity": "sha512-btX7kzGvp1JwShQI9V6IM841YKNPYjKCvUbNrQ2EcVYbULtUd/GH6wZ/qdqH13j9pOHBER+EZXNN2L8RSJhVRA==",
 			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -8193,9 +8249,9 @@
 			}
 		},
 		"@types/chai": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
-			"integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
+			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
 			"dev": true
 		},
 		"@types/chai-subset": {
@@ -8346,9 +8402,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA=="
 		},
 		"@types/pako": {
 			"version": "1.0.3",
@@ -8379,9 +8435,9 @@
 			}
 		},
 		"@types/puppeteer": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.5.tgz",
-			"integrity": "sha512-lxCjpDEY+DZ66+W3x5Af4oHnEmUXt0HuaRzkBGE2UZiZEp/V1d3StpLPlmNVu/ea091bdNmVPl44lu8Wy/0ZCA==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.6.tgz",
+			"integrity": "sha512-98Kghehs7+/GD9b56qryhqdqVCXUTbetTv3PlvDnmFRTHQH0j9DIp1f7rkAW3BAj4U3yoeSEQnKgdW8bDq0Y0Q==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -8422,9 +8478,9 @@
 			"dev": true
 		},
 		"@types/uglify-js": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
-			"integrity": "sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==",
+			"version": "3.13.2",
+			"resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.2.tgz",
+			"integrity": "sha512-/xFrPIo+4zOeNGtVMbf9rUm0N+i4pDf1ynExomqtokIJmVzR3962lJ1UE+MmexMkA0cmN9oTzg5Xcbwge0Ij2Q==",
 			"dev": true,
 			"requires": {
 				"source-map": "^0.6.1"
@@ -8475,9 +8531,9 @@
 			}
 		},
 		"@types/yauzl": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
-			"integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
 			"optional": true,
 			"requires": {
 				"@types/node": "*"
@@ -8583,9 +8639,9 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"requires": {
 				"lodash": "^4.17.14"
 			}
@@ -9116,15 +9172,15 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.20.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-			"integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+			"version": "4.20.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+			"integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001317",
-				"electron-to-chromium": "^1.4.84",
+				"caniuse-lite": "^1.0.30001332",
+				"electron-to-chromium": "^1.4.118",
 				"escalade": "^3.1.1",
-				"node-releases": "^2.0.2",
+				"node-releases": "^2.0.3",
 				"picocolors": "^1.0.0"
 			}
 		},
@@ -9201,9 +9257,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001325",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-			"integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+			"version": "1.0.30001334",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
 			"dev": true
 		},
 		"capture-stack-trace": {
@@ -9295,9 +9351,9 @@
 			"dev": true
 		},
 		"color-string": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
-			"integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
 			"dev": true,
 			"requires": {
 				"color-name": "^1.0.0",
@@ -9498,12 +9554,13 @@
 			"dev": true
 		},
 		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"dev": true,
 			"requires": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			}
 		},
 		"detect-indent": {
@@ -9606,9 +9663,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.106",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
-			"integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
+			"version": "1.4.124",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+			"integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
 			"dev": true
 		},
 		"emitter-component": {
@@ -10180,6 +10237,15 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
+		"has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.1"
+			}
+		},
 		"has-symbols": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -10335,9 +10401,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -10916,9 +10982,9 @@
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-releases": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-			"integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+			"integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
 			"dev": true
 		},
 		"normalize-package-data": {
@@ -11915,9 +11981,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-			"integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+			"integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -11936,9 +12002,9 @@
 			},
 			"dependencies": {
 				"@rollup/pluginutils": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.0.tgz",
-					"integrity": "sha512-2WUyJNRkyH5p487pGnn4tWAsxhEFKN/pT8CMgHshd5H+IXkOnKvKZwsz5ZWz+YCXkleZRAU5kwbfgF8CPfDRqA==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+					"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
 					"dev": true,
 					"requires": {
 						"estree-walker": "^2.0.1",
@@ -12434,9 +12500,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"tunnel": {
 			"version": "0.0.6",
@@ -12765,9 +12831,9 @@
 					"dev": true
 				},
 				"fecha": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-					"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+					"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
 					"dev": true
 				},
 				"is-stream": {
@@ -12814,9 +12880,9 @@
 			},
 			"dependencies": {
 				"fecha": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
-					"integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==",
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+					"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
 					"dev": true
 				},
 				"logform": {

--- a/packages/space-opera/package-lock.json
+++ b/packages/space-opera/package-lock.json
@@ -56,12 +56,13 @@
 			}
 		},
 		"node_modules/@ampproject/remapping": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -1631,10 +1632,32 @@
 				"node": ">=0.1.90"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-			"integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -1647,9 +1670,9 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-			"integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -2659,9 +2682,9 @@
 			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.1.tgz",
+			"integrity": "sha512-btX7kzGvp1JwShQI9V6IM841YKNPYjKCvUbNrQ2EcVYbULtUd/GH6wZ/qdqH13j9pOHBER+EZXNN2L8RSJhVRA==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -2752,9 +2775,9 @@
 			}
 		},
 		"node_modules/@types/babel__traverse": {
-			"version": "7.14.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
-			"integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
+			"version": "7.17.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+			"integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.3.0"
@@ -2906,9 +2929,9 @@
 			"dev": true
 		},
 		"node_modules/@types/jasmine": {
-			"version": "3.10.5",
-			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.5.tgz",
-			"integrity": "sha512-RYxEJkk/RK1S6W0nMOx9Mxm5v2bKwAVjzTHiBcHkQskwKDqHKHjSU46jx/q9IffyuctNl8ebaAjb5/461faKqQ==",
+			"version": "3.10.6",
+			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.6.tgz",
+			"integrity": "sha512-twY9adK/vz72oWxCWxzXaxoDtF9TpfEEsxvbc1ibjF3gMD/RThSuSud/GKUTR3aJnfbivAbC/vLqhY+gdWCHfA==",
 			"dev": true
 		},
 		"node_modules/@types/keygrip": {
@@ -2934,9 +2957,9 @@
 			}
 		},
 		"node_modules/@types/koa__cors": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.1.1.tgz",
-			"integrity": "sha512-O7MBkCocnLrpEvkMrYAp17arUDS+KuS5bXMG/Z4aPSbrO7vrYB6YrqcsTD3Dp2OnAL3j4WME2k/x2kOcyzwNUw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.3.0.tgz",
+			"integrity": "sha512-FUN8YxcBakIs+walVe3+HcNP+Bxd0SB8BJHBWkglZ5C1XQWljlKcEFDG/dPiCIqwVCUbc5X0nYDlH62uEhdHMA==",
 			"dev": true,
 			"dependencies": {
 				"@types/koa": "*"
@@ -3015,9 +3038,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
 			"dev": true
 		},
 		"node_modules/@types/path-is-inside": {
@@ -3217,9 +3240,9 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"dev": true,
 			"dependencies": {
 				"lodash": "^4.17.14"
@@ -3439,9 +3462,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.20.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-			"integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+			"version": "4.20.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+			"integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3454,10 +3477,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001317",
-				"electron-to-chromium": "^1.4.84",
+				"caniuse-lite": "^1.0.30001332",
+				"electron-to-chromium": "^1.4.118",
 				"escalade": "^3.1.1",
-				"node-releases": "^2.0.2",
+				"node-releases": "^2.0.3",
 				"picocolors": "^1.0.0"
 			},
 			"bin": {
@@ -3484,28 +3507,37 @@
 			}
 		},
 		"node_modules/browserslist-useragent/node_modules/lru-cache": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
-			"integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=10"
 			}
 		},
 		"node_modules/browserslist-useragent/node_modules/semver": {
-			"version": "7.3.6",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 			"dev": true,
 			"dependencies": {
-				"lru-cache": "^7.4.0"
+				"lru-cache": "^6.0.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+				"node": ">=10"
 			}
+		},
+		"node_modules/browserslist-useragent/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/browserstack": {
 			"version": "1.5.3",
@@ -3638,9 +3670,9 @@
 			}
 		},
 		"node_modules/camel-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/camelcase": {
@@ -3665,9 +3697,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001325",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-			"integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+			"version": "1.0.30001334",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3851,14 +3883,14 @@
 			}
 		},
 		"node_modules/command-line-usage": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.2.tgz",
-			"integrity": "sha512-I+0XN613reAhpBQ6icsPOTwu9cvhc9NtLtUcY2fGYuwm9JZiWBzFDA8w0PHqQjru7Xth7fM/y9TJ13+VKdjh7Q==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+			"integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
 			"dev": true,
 			"dependencies": {
-				"array-back": "^4.0.1",
+				"array-back": "^4.0.2",
 				"chalk": "^2.4.2",
-				"table-layout": "^1.0.1",
+				"table-layout": "^1.0.2",
 				"typical": "^5.2.0"
 			},
 			"engines": {
@@ -4035,9 +4067,9 @@
 			}
 		},
 		"node_modules/core-js-bundle": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.21.1.tgz",
-			"integrity": "sha512-4Gjo/bE+NxIBMsoFzuo4u8QjA531kKaorC7L1DiUlvM3ny4pj/0vIz9y1BZUWmFP6KHaEsUNFLWWLUa9EwN/2Q==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.22.3.tgz",
+			"integrity": "sha512-tgp03QRPXUr/540ZCAwYuEIk7Z7r+AObHPqgnMlctZiHRkwP9LlDSK8sf9sEAIOIFQ6oAwElhpJAPw1ym1UJNQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -4046,12 +4078,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.21.1.tgz",
-			"integrity": "sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+			"integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.19.1",
+				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
 			},
 			"funding": {
@@ -4140,9 +4172,9 @@
 			}
 		},
 		"node_modules/date-format": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.6.tgz",
-			"integrity": "sha512-B9vvg5rHuQ8cbUXE/RMWMyX2YA5TecT3jKF5fLtGNlzPlU7zblSPmAm2OImDbWL+LDOQ6pUm+4LOFz+ywS41Zw==",
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.9.tgz",
+			"integrity": "sha512-+8J+BOUpSrlKLQLeF8xJJVTxS8QfRSuJgwxSVvslzgO3E6khbI0F5mMEPf5mTYhCCm4h99knYP6H3W9n3BQFrg==",
 			"dev": true,
 			"engines": {
 				"node": ">=4.0"
@@ -4196,15 +4228,19 @@
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"dev": true,
 			"dependencies": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/delayed-stream": {
@@ -4270,9 +4306,9 @@
 			}
 		},
 		"node_modules/dot-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/duplexer": {
@@ -4366,9 +4402,9 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.106",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
-			"integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
+			"version": "1.4.124",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+			"integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -4396,9 +4432,9 @@
 			}
 		},
 		"node_modules/engine.io": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
-			"integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
+			"integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
 			"dev": true,
 			"dependencies": {
 				"@types/cookie": "^0.4.1",
@@ -4444,9 +4480,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
-			"integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
+			"version": "1.19.5",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
+			"integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
@@ -4460,7 +4496,7 @@
 				"is-callable": "^1.2.4",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
 				"is-weakref": "^1.0.2",
 				"object-inspect": "^1.12.0",
@@ -4862,9 +4898,9 @@
 			"dev": true
 		},
 		"node_modules/fs-extra": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-			"integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
@@ -5021,9 +5057,9 @@
 			}
 		},
 		"node_modules/gltf-validator": {
-			"version": "2.0.0-dev.3.5",
-			"resolved": "https://registry.npmjs.org/gltf-validator/-/gltf-validator-2.0.0-dev.3.5.tgz",
-			"integrity": "sha512-0HM9OnPQ4zYic0Ru1oIZ56+kf7kpswPIZPvjthmFb9UO/5XbxPg+KpL2tr4mq+2pBJzXHs8+oQHl0APqbT/ugA==",
+			"version": "2.0.0-dev.3.6",
+			"resolved": "https://registry.npmjs.org/gltf-validator/-/gltf-validator-2.0.0-dev.3.6.tgz",
+			"integrity": "sha512-8vuuI8GnU15XoYks2lG5gDAA1FcOi62FRyYeHTSA4q81ZfWBE3NLJB5+JMvI6KpdrhQtQWk5Gyl022dbynct1w==",
 			"dev": true
 		},
 		"node_modules/graceful-fs": {
@@ -5068,9 +5104,9 @@
 			}
 		},
 		"node_modules/has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -5083,6 +5119,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-symbols": {
@@ -5436,9 +5484,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -5743,12 +5791,12 @@
 			"dev": true
 		},
 		"node_modules/js-beautify": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.2.tgz",
-			"integrity": "sha512-H85kX95a53os+q1OCqtYe8AXAmgy3BvtysA/V83S3fdhznm6WlUpGi14DqSPbKFsL3dXZFXYl7YQwW9U1+76ng==",
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.3.tgz",
+			"integrity": "sha512-f1ra8PHtOEu/70EBnmiUlV8nJePS58y9qKjl4JHfYWlFH6bo7ogZBz//FAZp7jDuXtYnGYKymZPlrg2I/9Zo4g==",
 			"dev": true,
 			"dependencies": {
-				"config-chain": "^1.1.12",
+				"config-chain": "^1.1.13",
 				"editorconfig": "^0.15.3",
 				"glob": "^7.1.3",
 				"nopt": "^5.0.0"
@@ -5868,9 +5916,9 @@
 			}
 		},
 		"node_modules/karma": {
-			"version": "6.3.17",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.17.tgz",
-			"integrity": "sha512-2TfjHwrRExC8yHoWlPBULyaLwAFmXmxQrcuFImt/JsAsSZu1uOWTZ1ZsWjqQtWpHLiatJOHL5jFjXSJIgCd01g==",
+			"version": "6.3.19",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.19.tgz",
+			"integrity": "sha512-NDhWckzES/Y9xMiddyU1RzaKL76/scCsu8Mp0vR0Z3lQRvC3p72+Ab4ppoxs36S9tyPNX5V48yvaV++RNEBPZw==",
 			"dev": true,
 			"dependencies": {
 				"@colors/colors": "1.5.0",
@@ -5892,7 +5940,7 @@
 				"qjobs": "^1.2.0",
 				"range-parser": "^1.2.1",
 				"rimraf": "^3.0.2",
-				"socket.io": "^4.2.0",
+				"socket.io": "^4.4.1",
 				"source-map": "^0.6.1",
 				"tmp": "^0.2.1",
 				"ua-parser-js": "^0.7.30",
@@ -6262,16 +6310,16 @@
 			"dev": true
 		},
 		"node_modules/log4js": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.4.tgz",
-			"integrity": "sha512-ncaWPsuw9Vl1CKA406hVnJLGQKy1OHx6buk8J4rE2lVW+NW5Y82G5/DIloO7NkqLOUtNPEANaWC1kZYVjXssPw==",
+			"version": "6.4.6",
+			"resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.6.tgz",
+			"integrity": "sha512-1XMtRBZszmVZqPAOOWczH+Q94AI42mtNWjvjA5RduKTSWjEc56uOBbyM1CJnfN4Ym0wSd8cQ43zOojlSHgRDAw==",
 			"dev": true,
 			"dependencies": {
-				"date-format": "^4.0.6",
+				"date-format": "^4.0.9",
 				"debug": "^4.3.4",
 				"flatted": "^3.2.5",
 				"rfdc": "^1.3.0",
-				"streamroller": "^3.0.6"
+				"streamroller": "^3.0.8"
 			},
 			"engines": {
 				"node": ">=8.0"
@@ -6287,9 +6335,9 @@
 			}
 		},
 		"node_modules/lower-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/lru-cache": {
@@ -6446,9 +6494,9 @@
 			}
 		},
 		"node_modules/no-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/node-fetch": {
@@ -6494,9 +6542,9 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-			"integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+			"integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
 			"dev": true
 		},
 		"node_modules/nopt": {
@@ -6737,9 +6785,9 @@
 			}
 		},
 		"node_modules/param-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/parse-json": {
@@ -6781,9 +6829,9 @@
 			}
 		},
 		"node_modules/pascal-case/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/path-exists": {
@@ -7142,9 +7190,9 @@
 			}
 		},
 		"node_modules/redux": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-			"integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+			"integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.9.2"
@@ -7465,9 +7513,9 @@
 			"dev": true
 		},
 		"node_modules/rollup": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-			"integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+			"integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -7611,16 +7659,16 @@
 			}
 		},
 		"node_modules/socket.io": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
-			"integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.0.tgz",
+			"integrity": "sha512-slTYqU2jCgMjXwresG8grhUi/cC6GjzmcfqArzaH3BN/9I/42eZk9yamNvZJdBfTubkjEdKAKs12NEztId+bUA==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
 				"debug": "~4.3.2",
-				"engine.io": "~6.1.0",
-				"socket.io-adapter": "~2.3.3",
+				"engine.io": "~6.2.0",
+				"socket.io-adapter": "~2.4.0",
 				"socket.io-parser": "~4.0.4"
 			},
 			"engines": {
@@ -7628,9 +7676,9 @@
 			}
 		},
 		"node_modules/socket.io-adapter": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
-			"integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+			"integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
 			"dev": true
 		},
 		"node_modules/socket.io-parser": {
@@ -7843,14 +7891,14 @@
 			}
 		},
 		"node_modules/streamroller": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.6.tgz",
-			"integrity": "sha512-Qz32plKq/MZywYyhEatxyYc8vs994Gz0Hu2MSYXXLD233UyPeIeRBZARIIGwFer4Mdb8r3Y2UqKkgyDghM6QCg==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.8.tgz",
+			"integrity": "sha512-VI+ni3czbFZrd1MrlybxykWZ8sMDCMtTU7YJyhgb9M5X6d1DDxLdJr+gSnmRpXPMnIWxWKMaAE8K0WumBp3lDg==",
 			"dev": true,
 			"dependencies": {
-				"date-format": "^4.0.6",
+				"date-format": "^4.0.9",
 				"debug": "^4.3.4",
-				"fs-extra": "^10.0.1"
+				"fs-extra": "^10.1.0"
 			},
 			"engines": {
 				"node": ">=8.0"
@@ -8292,14 +8340,14 @@
 			}
 		},
 		"node_modules/unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
 			"dev": true,
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			},
 			"funding": {
@@ -8757,12 +8805,13 @@
 	},
 	"dependencies": {
 		"@ampproject/remapping": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
 		"@babel/code-frame": {
@@ -9851,10 +9900,26 @@
 			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
 			"dev": true
 		},
+		"@jridgewell/gen-mapping": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"@jridgewell/resolve-uri": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-			"integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
+			"integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+			"dev": true
+		},
+		"@jridgewell/set-array": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+			"integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
 			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
@@ -9864,9 +9929,9 @@
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-			"integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -10852,9 +10917,9 @@
 			}
 		},
 		"@rollup/plugin-node-resolve": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
-			"integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
+			"version": "13.2.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.2.1.tgz",
+			"integrity": "sha512-btX7kzGvp1JwShQI9V6IM841YKNPYjKCvUbNrQ2EcVYbULtUd/GH6wZ/qdqH13j9pOHBER+EZXNN2L8RSJhVRA==",
 			"dev": true,
 			"requires": {
 				"@rollup/pluginutils": "^3.1.0",
@@ -10932,9 +10997,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.14.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
-			"integrity": "sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==",
+			"version": "7.17.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
+			"integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -11085,9 +11150,9 @@
 			"dev": true
 		},
 		"@types/jasmine": {
-			"version": "3.10.5",
-			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.5.tgz",
-			"integrity": "sha512-RYxEJkk/RK1S6W0nMOx9Mxm5v2bKwAVjzTHiBcHkQskwKDqHKHjSU46jx/q9IffyuctNl8ebaAjb5/461faKqQ==",
+			"version": "3.10.6",
+			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.6.tgz",
+			"integrity": "sha512-twY9adK/vz72oWxCWxzXaxoDtF9TpfEEsxvbc1ibjF3gMD/RThSuSud/GKUTR3aJnfbivAbC/vLqhY+gdWCHfA==",
 			"dev": true
 		},
 		"@types/keygrip": {
@@ -11113,9 +11178,9 @@
 			}
 		},
 		"@types/koa__cors": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.1.1.tgz",
-			"integrity": "sha512-O7MBkCocnLrpEvkMrYAp17arUDS+KuS5bXMG/Z4aPSbrO7vrYB6YrqcsTD3Dp2OnAL3j4WME2k/x2kOcyzwNUw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@types/koa__cors/-/koa__cors-3.3.0.tgz",
+			"integrity": "sha512-FUN8YxcBakIs+walVe3+HcNP+Bxd0SB8BJHBWkglZ5C1XQWljlKcEFDG/dPiCIqwVCUbc5X0nYDlH62uEhdHMA==",
 			"dev": true,
 			"requires": {
 				"@types/koa": "*"
@@ -11194,9 +11259,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+			"version": "17.0.29",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+			"integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA==",
 			"dev": true
 		},
 		"@types/path-is-inside": {
@@ -11368,9 +11433,9 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.14"
@@ -11547,15 +11612,15 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.20.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-			"integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+			"version": "4.20.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+			"integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001317",
-				"electron-to-chromium": "^1.4.84",
+				"caniuse-lite": "^1.0.30001332",
+				"electron-to-chromium": "^1.4.118",
 				"escalade": "^3.1.1",
-				"node-releases": "^2.0.2",
+				"node-releases": "^2.0.3",
 				"picocolors": "^1.0.0"
 			}
 		},
@@ -11573,19 +11638,28 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "7.8.0",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
-					"integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
-					"dev": true
-				},
-				"semver": {
-					"version": "7.3.6",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^7.4.0"
+						"yallist": "^4.0.0"
 					}
+				},
+				"semver": {
+					"version": "7.3.7",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
 				}
 			}
 		},
@@ -11687,9 +11761,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -11713,9 +11787,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001325",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-			"integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
+			"version": "1.0.30001334",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+			"integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
 			"dev": true
 		},
 		"caseless": {
@@ -11851,14 +11925,14 @@
 			}
 		},
 		"command-line-usage": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.2.tgz",
-			"integrity": "sha512-I+0XN613reAhpBQ6icsPOTwu9cvhc9NtLtUcY2fGYuwm9JZiWBzFDA8w0PHqQjru7Xth7fM/y9TJ13+VKdjh7Q==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+			"integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
 			"dev": true,
 			"requires": {
-				"array-back": "^4.0.1",
+				"array-back": "^4.0.2",
 				"chalk": "^2.4.2",
-				"table-layout": "^1.0.1",
+				"table-layout": "^1.0.2",
 				"typical": "^5.2.0"
 			},
 			"dependencies": {
@@ -11997,18 +12071,18 @@
 			}
 		},
 		"core-js-bundle": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.21.1.tgz",
-			"integrity": "sha512-4Gjo/bE+NxIBMsoFzuo4u8QjA531kKaorC7L1DiUlvM3ny4pj/0vIz9y1BZUWmFP6KHaEsUNFLWWLUa9EwN/2Q==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.22.3.tgz",
+			"integrity": "sha512-tgp03QRPXUr/540ZCAwYuEIk7Z7r+AObHPqgnMlctZiHRkwP9LlDSK8sf9sEAIOIFQ6oAwElhpJAPw1ym1UJNQ==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.21.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.21.1.tgz",
-			"integrity": "sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g==",
+			"version": "3.22.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+			"integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.19.1",
+				"browserslist": "^4.20.3",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
@@ -12079,9 +12153,9 @@
 			}
 		},
 		"date-format": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.6.tgz",
-			"integrity": "sha512-B9vvg5rHuQ8cbUXE/RMWMyX2YA5TecT3jKF5fLtGNlzPlU7zblSPmAm2OImDbWL+LDOQ6pUm+4LOFz+ywS41Zw==",
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.9.tgz",
+			"integrity": "sha512-+8J+BOUpSrlKLQLeF8xJJVTxS8QfRSuJgwxSVvslzgO3E6khbI0F5mMEPf5mTYhCCm4h99knYP6H3W9n3BQFrg==",
 			"dev": true
 		},
 		"debounce": {
@@ -12118,12 +12192,13 @@
 			"dev": true
 		},
 		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"dev": true,
 			"requires": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			}
 		},
 		"delayed-stream": {
@@ -12179,9 +12254,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -12269,9 +12344,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.106",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
-			"integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
+			"version": "1.4.124",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+			"integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -12296,9 +12371,9 @@
 			}
 		},
 		"engine.io": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.3.tgz",
-			"integrity": "sha512-rqs60YwkvWTLLnfazqgZqLa/aKo+9cueVfEi/dZ8PyGyaf8TLOxj++4QMIgeG3Gn0AhrWiFXvghsoY9L9h25GA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
+			"integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
 			"dev": true,
 			"requires": {
 				"@types/cookie": "^0.4.1",
@@ -12338,9 +12413,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
-			"integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
+			"version": "1.19.5",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
+			"integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
@@ -12354,7 +12429,7 @@
 				"is-callable": "^1.2.4",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
 				"is-weakref": "^1.0.2",
 				"object-inspect": "^1.12.0",
@@ -12683,9 +12758,9 @@
 			"dev": true
 		},
 		"fs-extra": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-			"integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.2.0",
@@ -12799,9 +12874,9 @@
 			"dev": true
 		},
 		"gltf-validator": {
-			"version": "2.0.0-dev.3.5",
-			"resolved": "https://registry.npmjs.org/gltf-validator/-/gltf-validator-2.0.0-dev.3.5.tgz",
-			"integrity": "sha512-0HM9OnPQ4zYic0Ru1oIZ56+kf7kpswPIZPvjthmFb9UO/5XbxPg+KpL2tr4mq+2pBJzXHs8+oQHl0APqbT/ugA==",
+			"version": "2.0.0-dev.3.6",
+			"resolved": "https://registry.npmjs.org/gltf-validator/-/gltf-validator-2.0.0-dev.3.6.tgz",
+			"integrity": "sha512-8vuuI8GnU15XoYks2lG5gDAA1FcOi62FRyYeHTSA4q81ZfWBE3NLJB5+JMvI6KpdrhQtQWk5Gyl022dbynct1w==",
 			"dev": true
 		},
 		"graceful-fs": {
@@ -12836,9 +12911,9 @@
 			}
 		},
 		"has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
 			"dev": true
 		},
 		"has-flag": {
@@ -12846,6 +12921,15 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
+		},
+		"has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.1"
+			}
 		},
 		"has-symbols": {
 			"version": "1.0.3",
@@ -13109,9 +13193,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -13323,12 +13407,12 @@
 			"dev": true
 		},
 		"js-beautify": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.2.tgz",
-			"integrity": "sha512-H85kX95a53os+q1OCqtYe8AXAmgy3BvtysA/V83S3fdhznm6WlUpGi14DqSPbKFsL3dXZFXYl7YQwW9U1+76ng==",
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.3.tgz",
+			"integrity": "sha512-f1ra8PHtOEu/70EBnmiUlV8nJePS58y9qKjl4JHfYWlFH6bo7ogZBz//FAZp7jDuXtYnGYKymZPlrg2I/9Zo4g==",
 			"dev": true,
 			"requires": {
-				"config-chain": "^1.1.12",
+				"config-chain": "^1.1.13",
 				"editorconfig": "^0.15.3",
 				"glob": "^7.1.3",
 				"nopt": "^5.0.0"
@@ -13423,9 +13507,9 @@
 			}
 		},
 		"karma": {
-			"version": "6.3.17",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.17.tgz",
-			"integrity": "sha512-2TfjHwrRExC8yHoWlPBULyaLwAFmXmxQrcuFImt/JsAsSZu1uOWTZ1ZsWjqQtWpHLiatJOHL5jFjXSJIgCd01g==",
+			"version": "6.3.19",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.19.tgz",
+			"integrity": "sha512-NDhWckzES/Y9xMiddyU1RzaKL76/scCsu8Mp0vR0Z3lQRvC3p72+Ab4ppoxs36S9tyPNX5V48yvaV++RNEBPZw==",
 			"dev": true,
 			"requires": {
 				"@colors/colors": "1.5.0",
@@ -13447,7 +13531,7 @@
 				"qjobs": "^1.2.0",
 				"range-parser": "^1.2.1",
 				"rimraf": "^3.0.2",
-				"socket.io": "^4.2.0",
+				"socket.io": "^4.4.1",
 				"source-map": "^0.6.1",
 				"tmp": "^0.2.1",
 				"ua-parser-js": "^0.7.30",
@@ -13764,16 +13848,16 @@
 			"dev": true
 		},
 		"log4js": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.4.tgz",
-			"integrity": "sha512-ncaWPsuw9Vl1CKA406hVnJLGQKy1OHx6buk8J4rE2lVW+NW5Y82G5/DIloO7NkqLOUtNPEANaWC1kZYVjXssPw==",
+			"version": "6.4.6",
+			"resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.6.tgz",
+			"integrity": "sha512-1XMtRBZszmVZqPAOOWczH+Q94AI42mtNWjvjA5RduKTSWjEc56uOBbyM1CJnfN4Ym0wSd8cQ43zOojlSHgRDAw==",
 			"dev": true,
 			"requires": {
-				"date-format": "^4.0.6",
+				"date-format": "^4.0.9",
 				"debug": "^4.3.4",
 				"flatted": "^3.2.5",
 				"rfdc": "^1.3.0",
-				"streamroller": "^3.0.6"
+				"streamroller": "^3.0.8"
 			}
 		},
 		"lower-case": {
@@ -13786,9 +13870,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -13920,9 +14004,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -13961,9 +14045,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-			"integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+			"integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
 			"dev": true
 		},
 		"nopt": {
@@ -14141,9 +14225,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -14181,9 +14265,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 					"dev": true
 				}
 			}
@@ -14469,9 +14553,9 @@
 			"dev": true
 		},
 		"redux": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-			"integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+			"integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2"
@@ -14744,9 +14828,9 @@
 			"dev": true
 		},
 		"rollup": {
-			"version": "2.70.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-			"integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+			"integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -14871,23 +14955,23 @@
 			}
 		},
 		"socket.io": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
-			"integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.0.tgz",
+			"integrity": "sha512-slTYqU2jCgMjXwresG8grhUi/cC6GjzmcfqArzaH3BN/9I/42eZk9yamNvZJdBfTubkjEdKAKs12NEztId+bUA==",
 			"dev": true,
 			"requires": {
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
 				"debug": "~4.3.2",
-				"engine.io": "~6.1.0",
-				"socket.io-adapter": "~2.3.3",
+				"engine.io": "~6.2.0",
+				"socket.io-adapter": "~2.4.0",
 				"socket.io-parser": "~4.0.4"
 			}
 		},
 		"socket.io-adapter": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
-			"integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+			"integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==",
 			"dev": true
 		},
 		"socket.io-parser": {
@@ -15056,14 +15140,14 @@
 			}
 		},
 		"streamroller": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.6.tgz",
-			"integrity": "sha512-Qz32plKq/MZywYyhEatxyYc8vs994Gz0Hu2MSYXXLD233UyPeIeRBZARIIGwFer4Mdb8r3Y2UqKkgyDghM6QCg==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.8.tgz",
+			"integrity": "sha512-VI+ni3czbFZrd1MrlybxykWZ8sMDCMtTU7YJyhgb9M5X6d1DDxLdJr+gSnmRpXPMnIWxWKMaAE8K0WumBp3lDg==",
 			"dev": true,
 			"requires": {
-				"date-format": "^4.0.6",
+				"date-format": "^4.0.9",
 				"debug": "^4.3.4",
-				"fs-extra": "^10.0.1"
+				"fs-extra": "^10.1.0"
 			}
 		},
 		"string_decoder": {
@@ -15394,14 +15478,14 @@
 			"dev": true
 		},
 		"unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			}
 		},


### PR DESCRIPTION
As helpfully noted by @deenns: https://github.com/mrdoob/three.js/issues/23953#issuecomment-1110742946, we had a memory leak due to GLTFLoader switching to `ImageBitmap` while we had not updated our `dispose()` method. That's done here, along with a package-lock update to pull in the latest three.js types. 