### PR TITLE
Check that BrowserStack is at fault for Firefox test failures

### DIFF
--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -553,7 +553,7 @@ modelViewer.addEventListener("load", () => {
 <model-viewer id="animated-model" src="../../shared-assets/models/Horse.glb" autoplay camera-controls alt="A 3D model of a horse galloping">
   <div class="controls">
     <button onclick="exportScene(true)">Export GLB</button>
-    <button onclick="exportScene(false)">Export GLTF</button>
+    <button onclick="exportScene(false)">Export GLTF </button>
   </div>
 </model-viewer>
 <script>


### PR DESCRIPTION
Firefox 98 and 99 are timing out 100% on my PRs from last week. This is a trivial change on top of the master branch which passed all the tests when it was originally merged. If this fails, we know the problem isn't with our code. 