### PR TITLE
fixed cache

### DIFF
--- a/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
+++ b/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
@@ -212,7 +212,8 @@ export class CachingGLTFLoader<T extends GLTFInstanceConstructor =
                                     .then((preparedGLTF) => {
                                       progressCallback(0.9);
                                       return new GLTFInstance(preparedGLTF);
-                                    }).catch((reason => {
+                                    })
+                                    .catch((reason => {
                                       console.error(reason);
                                       return new GLTFInstance();
                                     }));
@@ -245,20 +246,9 @@ export class CachingGLTFLoader<T extends GLTFInstanceConstructor =
 
     // Patch dispose so that we can properly account for instance use
     // in the caching layer:
-    clone.dispose = (() => {
-      const originalDispose = clone.dispose;
-      let disposed = false;
-
-      return () => {
-        if (disposed) {
-          return;
-        }
-
-        disposed = true;
-        originalDispose.apply(clone);
-        this[$evictionPolicy].release(url);
-      };
-    })();
+    clone.dispose = () => {
+      this[$evictionPolicy].release(url);
+    };
 
     return clone;
   }

--- a/packages/modelviewer.dev/src/docs-and-examples/sidebar.ts
+++ b/packages/modelviewer.dev/src/docs-and-examples/sidebar.ts
@@ -279,11 +279,14 @@ function handleExamples(entries: IntersectionObserverEntry[], _observer: any) {
   for (const entry of everyEntry) {
     const id = entry.target.getAttribute('id')!;
     const sidebarName = `container-${id}-sidebar`;
+    const sidebarElement = document.querySelector(`h4[id=${sidebarName}`);
+    if (sidebarElement == null) {
+      return;
+    }
     if (id === maxName) {
-      document.querySelector(`h4[id=${sidebarName}`)!.classList.add('active');
+      sidebarElement.classList.add('active');
     } else {
-      document.querySelector(`h4[id=${sidebarName}`)!.classList.remove(
-          'active');
+      sidebarElement.classList.remove('active');
     }
   }
 }


### PR DESCRIPTION
Fixes #3414

This bug was exposed by #3399, but the error appears to be long-standing: I don't think our `modelCacheSize` was ever working correctly. The idea is to cache X models in GPU memory to facilitate rapid switching. It appears we were accidentally disposing of them all and three.js was happily re-uploading them. However, once I disposed of the source data, that was no longer possible, hence the black textures. 

Hopefully this doesn't start causing out-of-memory problems for our users; it was always intended to work this way, but we effectively had `modelCacheSize = 0` enforced on everyone, which should really only be used by folks switching between very memory-intense models. In any case, that will be the solution for anyone encountering a regression here, unless I've introduced another bug...