### PR TITLE
fixed context menu pointer cancel

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -190,10 +190,6 @@ export const cameraTargetIntrinsics = (element: ModelViewerElementBase) => {
   };
 };
 
-const disableContextMenu = (event: MouseEvent) => {
-  event.preventDefault();
-};
-
 const HALF_PI = Math.PI / 2.0;
 const THIRD_PI = Math.PI / 3.0;
 const QUARTER_PI = HALF_PI / 2.0;
@@ -491,11 +487,6 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       if (changedProperties.has('enablePan')) {
         controls.enablePan = this.enablePan;
-        if (this.enablePan) {
-          this.addEventListener('contextmenu', disableContextMenu);
-        } else {
-          this.removeEventListener('contextmenu', disableContextMenu);
-        }
       }
 
       if (changedProperties.has('bounds')) {


### PR DESCRIPTION
Upon switching to pointer events, I noticed that the context menu would cause our pointerUp method to never be called. Turns out this is a known bug in most browsers: https://github.com/w3c/pointerevents/issues/408

So, I'm now calling it manually to keep our state in a good place. So much for the reliability of `pointercancel`...