### PR TITLE
make target change fire camera-change event

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -661,7 +661,10 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       this[$controls].update(time, delta);
-      this[$scene].updateTarget(delta);
+      if (this[$scene].updateTarget(delta)) {
+        // Update to $controls.isUserChange once customPrompt lands
+        this[$onChange]({type: 'change', source: ChangeSource.NONE})
+      }
     }
 
     [$deferInteractionPrompt]() {

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -214,6 +214,13 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
                      element[$scene].camera, element.getCameraTarget()))
               .to.be.equal(true);
         });
+
+        test('causes camera-change event to fire', async () => {
+          const cameraChangeDispatches = waitForEvent(element, 'camera-change');
+          element.cameraTarget = '3m 2m 1m';
+
+          await cameraChangeDispatches;
+        });
       });
 
       test('defaults FOV correctly', async () => {

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -486,7 +486,7 @@ export class ModelScene extends Scene {
    * This should be called every frame with the frame delta to cause the target
    * to transition to its set point.
    */
-  updateTarget(delta: number) {
+  updateTarget(delta: number): boolean {
     const goal = this.goalTarget;
     const target = this.target.position;
     if (!goal.equals(target)) {
@@ -498,6 +498,9 @@ export class ModelScene extends Scene {
       this.target.position.set(x, y, z);
       this.target.updateMatrixWorld();
       this.queueRender();
+      return true;
+    } else {
+      return false;
     }
   }
 

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -620,6 +620,8 @@ export class SmoothControls extends EventDispatcher {
     target.add(dxy.applyMatrix3(this.panProjection));
     scene.boundingSphere.clampPoint(target, target);
     scene.setTarget(target.x, target.y, target.z);
+
+    this.dispatchEvent({type: 'change', source: ChangeSource.USER_INTERACTION});
   }
 
   private recenter(pointer: PointerEvent) {


### PR DESCRIPTION
Fixes https://github.com/google/model-viewer/discussions/3386#discussioncomment-2618327

This is important now that we have pan causing tap-to-recenter. This change will allow that type of user-interaction to be listened for. 