### PR TITLE
Override MWC tab to expose min-width

### DIFF
--- a/packages/space-opera/src/components/shared/tabs/styles.css.ts
+++ b/packages/space-opera/src/components/shared/tabs/styles.css.ts
@@ -35,6 +35,7 @@ export const styles: CSSResult = css`:host {
   --mdc-tab-color-default: var(--me-theme-tab-default-color);
   --mdc-tab-text-label-color-default: var(--me-theme-tab-default-color);
   --mdc-tab-stacked-height: 100px;
+  --mdc-tab-min-width: 48px;
   background: var(--me-theme-container-background-color);
   display: flex;
   flex-direction: column;
@@ -65,4 +66,10 @@ export const styles: CSSResult = css`:host {
 ::slotted(span) {
   display: contents;
 }
+`;
+
+export const tabStyles: CSSResult = css`
+  .mdc-tab {
+    min-width: var(--mdc-tab-min-width, 48px);
+  }
 `;

--- a/packages/space-opera/src/components/shared/tabs/tab.ts
+++ b/packages/space-opera/src/components/shared/tabs/tab.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2022 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { customElement } from 'lit/decorators.js';
+
+import { TabBase } from '@material/mwc-tab/mwc-tab-base';
+import { styles as baseStyles } from '@material/mwc-tab/mwc-tab.css';
+import { tabStyles } from './styles.css';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'me-tab': Tab;
+  }
+}
+
+@customElement('me-tab')
+export class Tab extends TabBase {
+  // MWC tab did not allow us to modify min-width, so we have to override the
+  // styles ourselves. M2 MWC has sent out its final release  as they are now
+  // focusing on M3 making this safe to override according to:
+  // https://lit-and-friends.slack.com/archives/CC0Q3PRCL/p1651599492903519
+  static override styles = [baseStyles, tabStyles];
+}

--- a/packages/space-opera/src/components/shared/tabs/tabs.ts
+++ b/packages/space-opera/src/components/shared/tabs/tabs.ts
@@ -15,13 +15,13 @@
  *
  */
 
-import '@material/mwc-tab';
 import '@material/mwc-tab-bar';
 
 import {html, LitElement} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 
 import {styles} from './styles.css.js';
+import './tab';
 
 /**
  * A tabbed panel.
@@ -40,10 +40,10 @@ export class Tabs extends LitElement {
   renderPanelIcon(panel: Element) {
     if (panel instanceof TabbedPanel) {
       return html`
-      <mwc-tab
+      <me-tab
         icon='${panel.icon}'
         label='${panel.label}'
-      ></mwc-tab>`;
+      ></me-tab>`;
     }
     return html``;
   }


### PR DESCRIPTION
Overrides `mwc-tab` and creates `me-tab` and exposes the min-width property to fix space opera's seemingly missing 5th, inspect, tab

Workaround for:
material-components/material-web#2609