### PR TITLE
update baked shadow criteria

### DIFF
--- a/packages/model-viewer/src/features/environment.ts
+++ b/packages/model-viewer/src/features/environment.ts
@@ -107,7 +107,7 @@ export const EnvironmentMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     hasBakedShadow(): boolean {
-      return this[$scene].bakedShadows.length > 0;
+      return this[$scene].bakedShadows.size > 0;
     }
 
     [$onModelLoad]() {

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -273,6 +273,8 @@ export class ModelScene extends Scene {
     if (this.shadow != null) {
       this.shadow.setIntensity(0);
     }
+    this.bakedShadows.clear();
+
     const gltf = this._currentGLTF;
     // Remove all current children
     if (gltf != null) {


### PR DESCRIPTION
Fixes #3398 

In addition, we found some furniture models with baked shadows that don't use the unlit extension, so we're no longer checking that.