### PR TITLE
Support extended AR QuickLook parameters when auto generating USDZ blob

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -373,6 +373,15 @@ configuration or device capabilities');
       const objectURL = generateUsdz ? await this.prepareUSDZ() : this.iosSrc!;
       const modelUrl = new URL(objectURL, self.location.toString());
 
+      if(generateUsdz){
+        const location = self.location.toString();
+        const locationUrl = new URL(location);
+        const srcUrl =  new URL(this.src!, locationUrl);
+        if(srcUrl.hash){
+          modelUrl.hash = srcUrl.hash;
+        }
+      }
+
       if (this.arScale === 'fixed') {
         if (modelUrl.hash) {
           modelUrl.hash += '&';

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -143,44 +143,38 @@ suite('ModelViewerElementBase with ARMixin', () => {
         test('replicate src hash to usdz blob url', async () => {
           element.src = assetPath('models/cube.gltf')+'#custom=path-to-banner.html';
           element.arModes = 'webxr scene-viewer quick-look';
-          
-          console.log('element.src:'+element.src);
-          console.log('element.arModes:'+element.arModes);
-          console.log('element.iosSrc:'+element.iosSrc);
-          console.log('intentUrls:'+intentUrls);
 
           await (element as any)[$openIOSARQuickLook]();
 
-          console.log('intentUrls:'+intentUrls);
-          console.log('intentUrls.length:'+intentUrls.length);
-          console.log('intentUrls[0]:'+intentUrls[0]);
-
           expect(intentUrls.length).to.be.equal(1);
 
           const url = new URL(intentUrls[0]);
 
+          expect(url.protocol).to.equal(
+              'blob:');
+
           expect(url.hash).to.equal(
               '#custom=path-to-banner.html');
- 
         });
 
-/*
-        test('replicate src hash to usdz blob url', async () => {
-          element.src = 'https://example.com/model.gltf#custom=path-to-banner.html';
-          console.log('element.src:'+element.src);
+        test('replicate src hash to usdz blob and set hash for fixed scale', async () => {
+          element.src = assetPath('models/cube.gltf')+'#custom=path-to-banner.html';
           element.arModes = 'webxr scene-viewer quick-look';
-          console.log('element.arModes:'+element.arModes);
+          element.arScale = 'fixed';
 
-          await(element as any)[$openIOSARQuickLook]();
+          await (element as any)[$openIOSARQuickLook]();
 
           expect(intentUrls.length).to.be.equal(1);
 
           const url = new URL(intentUrls[0]);
 
+          expect(url.protocol).to.equal(
+              'blob:');
+
           expect(url.hash).to.equal(
-              '#custom=path-to-banner.html');
+              '#custom=path-to-banner.html&allowsContentScaling=0');
         });
-*/
+
       });
     });
 

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -139,6 +139,21 @@ suite('ModelViewerElementBase with ARMixin', () => {
           expect(url.hash).to.equal(
               '#custom=path-to-banner.html&allowsContentScaling=0');
         });
+
+        test('replicate src hash to usdz blob url', () => {
+          element.src = 'https://example.com/model.gltf#custom=path-to-banner.html';
+          element.arModes = 'webxr scene-viewer quick-look';
+
+          (element as any)[$openIOSARQuickLook]();
+
+          expect(intentUrls.length).to.be.equal(1);
+
+          const url = new URL(intentUrls[0]);
+
+          expect(url.hash).to.equal(
+              '#custom=path-to-banner.html');
+        });
+        
       });
     });
 

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -140,11 +140,38 @@ suite('ModelViewerElementBase with ARMixin', () => {
               '#custom=path-to-banner.html&allowsContentScaling=0');
         });
 
-        test('replicate src hash to usdz blob url', () => {
-          element.src = 'https://example.com/model.gltf#custom=path-to-banner.html';
+        test('replicate src hash to usdz blob url', async () => {
+          element.src = assetPath('models/cube.gltf')+'#custom=path-to-banner.html';
           element.arModes = 'webxr scene-viewer quick-look';
+          
+          console.log('element.src:'+element.src);
+          console.log('element.arModes:'+element.arModes);
+          console.log('element.iosSrc:'+element.iosSrc);
+          console.log('intentUrls:'+intentUrls);
 
-          (element as any)[$openIOSARQuickLook]();
+          await (element as any)[$openIOSARQuickLook]();
+
+          console.log('intentUrls:'+intentUrls);
+          console.log('intentUrls.length:'+intentUrls.length);
+          console.log('intentUrls[0]:'+intentUrls[0]);
+
+          expect(intentUrls.length).to.be.equal(1);
+
+          const url = new URL(intentUrls[0]);
+
+          expect(url.hash).to.equal(
+              '#custom=path-to-banner.html');
+ 
+        });
+
+/*
+        test('replicate src hash to usdz blob url', async () => {
+          element.src = 'https://example.com/model.gltf#custom=path-to-banner.html';
+          console.log('element.src:'+element.src);
+          element.arModes = 'webxr scene-viewer quick-look';
+          console.log('element.arModes:'+element.arModes);
+
+          await(element as any)[$openIOSARQuickLook]();
 
           expect(intentUrls.length).to.be.equal(1);
 
@@ -153,7 +180,7 @@ suite('ModelViewerElementBase with ARMixin', () => {
           expect(url.hash).to.equal(
               '#custom=path-to-banner.html');
         });
-        
+*/
       });
     });
 


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
#3425

### Approach
This change allows extended AR QuickLook parameters (EG `custom`, `checkoutTitle`, `checkoutSubtitle`, etc) to be appended after the `src` path as `#` hash fragment when using auto USDZ generation and there is no `ios-src` property. 

Any / all defined `#` params get appended to USDZ blob without discrimination (AR QuickLook will ignore any invalid params).

### Usage
Define `src` as something like:
`https://example.com/model.gltf#custom=path-to-banner.html`
Omit `ios-src`
Include `"quick-look"` in `ar-modes` to trigger auto USDZ generation.
When opening AR on iOS, USDZ will be auto generated and displayed with custom banner in AR.

### Tests
Two tests created:
- replicate src hash to usdz blob url
- replicate src hash to usdz blob and set hash for fixed scale

### Demo
https://modelviewer-auto-usdz-params.glitch.me/

### Compatibility
Note that passing # params after blob url only works in Safari iOS 15.5 beta 4 onwards. Prior to that, passing # params after blob url were either ignored (https://bugs.webkit.org/show_bug.cgi?id=226265) or caused model to never load (https://bugs.webkit.org/show_bug.cgi?id=236069).
