### PR TITLE
fix pan-y for Android 12

### DIFF
--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -725,6 +725,9 @@ export class SmoothControls extends EventDispatcher {
     const numTouches = this.pointers.length;
     const dx = (event.clientX - pointer.clientX) / numTouches;
     const dy = (event.clientY - pointer.clientY) / numTouches;
+    if (dx === 0 && dy === 0) {
+      return;
+    }
     pointer.clientX = event.clientX;
     pointer.clientY = event.clientY;
 


### PR DESCRIPTION
Apparently Chrome on Android 12 will emit a pointermove event even if the pointer didn't move. Go figure.