### PR TITLE
fix disable-zoom for touch

### DIFF
--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -784,6 +784,11 @@ export class SmoothControls extends EventDispatcher {
     if (this.pointers.length === 1) {
       this.touchMode = this.touchModeRotate;
     } else {
+      if (this._disableZoom) {
+        this.touchMode = null;
+        this.element.removeEventListener('touchmove', this.disableScroll);
+        return;
+      }
       this.touchMode = (this.touchDecided && this.touchMode === null) ?
           null :
           this.touchModeZoom;


### PR DESCRIPTION
Fixed another small regression, where two-finger pinch was not scaling the page under `disable-zoom` like it ought to.