### PR TITLE
added missing .js for fidelity comparisons

### DIFF
--- a/packages/render-fidelity-tools/src/components/image-comparison-app.ts
+++ b/packages/render-fidelity-tools/src/components/image-comparison-app.ts
@@ -17,7 +17,7 @@ import './analysis-view.js';
 import './rendering-scenario.js';
 
 import {html, LitElement} from 'lit';
-import {property} from 'lit/decorators';
+import {property} from 'lit/decorators.js';
 
 import {ImageComparisonConfig} from '../common.js';
 

--- a/packages/render-fidelity-tools/src/components/images-4-up.ts
+++ b/packages/render-fidelity-tools/src/components/images-4-up.ts
@@ -17,10 +17,9 @@ import '../image-accessor.js';
 import './magnifying-glass.js';
 
 import {html, LitElement} from 'lit';
-import {property} from 'lit/decorators';
+import {property} from 'lit/decorators.js';
 
 import {Dimensions, Pixel, Rect} from '../common.js';
-
 import {ImageAccessor} from '../image-accessor.js';
 
 


### PR DESCRIPTION
Fixes the missing images in our glTF fidelity comparison page. 