### PR TITLE
Set safe area to Top of exit-webxr-ar-button

### DIFF
--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -306,7 +306,7 @@ canvas.show {
   align-items: center;
   justify-content: center;
   position: absolute;
-  top: 16px;
+  top: env(safe-area-inset-top, 16px);
   right: 16px;
   width: 40px;
   height: 40px;


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
Fixes #3463
On devices with a punch hole in the upper right corner, such as Galaxy s10/ s10+, the close button in WebAR mode overlaps with it and is not very visible.

To solve this problem I added `safe-area-inset-top` to the top of `exit-webxr-ar-button`.
And it does not overlap with the punch hole as shown in the Galaxy s10 screen in the following picture.

<img src="https://user-images.githubusercontent.com/20057935/168457870-47ea6b41-2b47-4304-b09b-b2a622c55e96.jpeg" alt="model-viewer xr mode screen" width="400" />
