### PR TITLE
Add Material docs

### DIFF
--- a/packages/model-viewer/src/features/scene-graph/api.ts
+++ b/packages/model-viewer/src/features/scene-graph/api.ts
@@ -205,8 +205,9 @@ export declare interface TextureInfo {
   readonly texture: Texture|null;
 
   /**
-   * Sets a texture on the texture info, or removes the texture if argument is
-   * null.
+   * Sets the texture, or removes it if argument is null. Note you cannot build
+   * your own Texture object, but must either use one from another TextureInfo,
+   * or create one with the createTexture method.
    */
   setTexture(texture: Texture|null): void;
 }

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -1,6 +1,7 @@
 [
   {
     "Title": "Loading",
+    "htmlName": "loading",
     "Attributes": [
       {
         "name": "src",
@@ -293,6 +294,7 @@
   },
   {
     "Title": "Augmented Reality",
+    "htmlName": "augmentedreality",
     "Attributes": [
       {
         "name": "ar",
@@ -448,6 +450,7 @@
   },
   {
     "Title": "Staging & Cameras",
+    "htmlName": "stagingandcameras",
     "Attributes": [
       {
         "name": "camera-controls",
@@ -761,6 +764,7 @@
   },
   {
     "Title": "Annotations",
+    "htmlName": "annotations",
     "CSS": [
       {
         "name": "--min-hotspot-opacity",
@@ -808,7 +812,8 @@
     ]
   },
   {
-    "Title": "Lighting & Env",
+    "Title": "Lighting & Skybox",
+    "htmlName": "lightingandenv",
     "Attributes": [
       {
         "name": "skybox-image",
@@ -884,6 +889,7 @@
   },
   {
     "Title": "Animation",
+    "htmlName": "animation",
     "Attributes": [
       {
         "name": "animation-name",
@@ -984,7 +990,8 @@
     ]
   },
   {
-    "Title": "Scene Graph",
+    "Title": "Materials & Scene",
+    "htmlName": "scenegraph",
     "Attributes": [
       {
         "name": "variant-name",

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -1038,10 +1038,15 @@
       {
         "name": "model",
         "htmlName": "model",
-        "description": "This object contains all the methods for the scene-graph API. See examples for usage.",
+        "description": "This object contains all the methods for the materials API. See examples for usage.",
         "links": [
-          "<a href=\"../examples/scenegraph/\">Related examples</a>"
+          "<a href=\"../examples/scenegraph/#pickMaterialExample\">API definition</a>"
         ]
+      },
+      {
+        "name": "originalGltfJson",
+        "htmlName": "originalGltfJson",
+        "description": "Returns a readonly copy of the GLTF JSON object as loaded. Changing this object has no affect on the scene and changes made through the materials API are not reflected here. This object is useful for reverting individual changes made through the materials API."
       }
     ],
     "Methods": [
@@ -1058,7 +1063,15 @@
         "htmlName": "materialFromPoint",
         "description": "Returns a material whose mesh primitive intersects with a ray created from the input pixel coordinates relative to the screen. Returns the material whose mesh is nearest the camera.",
         "links": [
-          "<a href=\"../examples/scenegraph/#pickMaterialExample\">Related examples</a>"
+          "<a href=\"../examples/scenegraph/#pickMaterialExample\">Material picking example</a>"
+        ]
+      },
+      {
+        "name": "createTexture(uri, type?)",
+        "htmlName": "createTexture",
+        "description": "Async method that returns a Texture object for use with the <code>setTexture</code> method on <code>TextureInfo</code> objects in the Materials API. The uri is required, but the type defaults to 'image/png', which only designates the export format for saving a GLB. The mimetypes 'image/jpeg' and 'image/webp' are also supported.",
+        "links": [
+          "<a href=\"../examples/scenegraph/#createTexturesExample\">Create texture example</a>"
         ]
       }
     ],

--- a/packages/modelviewer.dev/data/examples.json
+++ b/packages/modelviewer.dev/data/examples.json
@@ -258,10 +258,6 @@
       {
         "htmlId": "exporter",
         "name": "Exporter"
-      },
-      {
-        "htmlId": "exporterWithOptions",
-        "name": "Exporter w/ Options"
       }
     ]
   }

--- a/packages/modelviewer.dev/data/examples.json
+++ b/packages/modelviewer.dev/data/examples.json
@@ -224,7 +224,7 @@
     ]
   },
   {
-    "name": "Scene Graph",
+    "name": "Materials & Scene",
     "htmlName": "scenegraph",
     "examples": [
       {

--- a/packages/modelviewer.dev/data/examples.json
+++ b/packages/modelviewer.dev/data/examples.json
@@ -253,7 +253,7 @@
       },
       {
         "htmlId": "pickMaterialExample",
-        "name": "Pick a material"
+        "name": "Materials API"
       },
       {
         "htmlId": "exporter",

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -17,7 +17,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>&lt;model-viewer&gt; Scene Graph Worklet</title>
+  <title>&lt;model-viewer&gt; Materials & Scene Examples</title>
   <meta charset="utf-8">
   <meta name="description" content="&lt;model-viewer&gt; scene graph examples">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -476,8 +476,12 @@ modelViewerTexture1.addEventListener("load", () => {
       <div class="content">
         <div class="wrapper">
           <div class="heading">
-            <h2 class="demo-title">Pick a Material</h2>
-            <p>Demonstrates selecting a material with pointer input and changing its color. Note this also works in the WebXR AR mode. Also demonstrates the use of the scale attribute since this GLB was erroneously modeled in mm instead of meters.</p>
+            <h2 class="demo-title">Materials API</h2>
+            <p>The complete Materials interface is documented below, which is all accessible through the <a href="../../docs/index.html#entrydocs-scenegraph-properties-model">model property</a>.
+            The Materials API is designed to follow the <a href="https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material">glTF structure</a>, just as though you are navigating their JSON object. 
+            Only the materials and their children are exposed rather than the whole scene graph to keep the scope small for this high-level web component.
+            Not every glTF parameter is exposed, but more may be added in the future. Additionally, several methods have been added for useful operations.</p>
+            <p>This example demonstrates selecting a material with pointer input and changing its color. Note this also works in the WebXR AR mode. It also demonstrates the use of the scale attribute since this GLB was erroneously modeled in mm instead of meters.</p>
           </div>
           <example-snippet stamp-to="pickMaterialExample" highlight-as="html">
             <template>
@@ -487,20 +491,143 @@ modelViewerTexture1.addEventListener("load", () => {
 const modelViewer = document.querySelector("model-viewer#pickMaterial");
 
 modelViewer.addEventListener("load", () => {
-
-  const changeColor = async (event) => {
-    let material = modelViewer.materialFromPoint(event.clientX, event.clientY);
-
-    if(material != null) {
+  const changeColor = (event) => {
+    const material = modelViewer.materialFromPoint(event.clientX, event.clientY);
+    if (material != null) {
       material.pbrMetallicRoughness.
         setBaseColorFactor([Math.random(), Math.random(), Math.random()]);
     }
-  }
+  };
 
   modelViewer.addEventListener("click", changeColor);
-
 });
+</script>
+<script>
+/**
+ * This is not an actual script, but an API declaration made prettier with JS syntax highlighting.
+*/
 
+interface Model {
+  /**
+    * An ordered set of unique Materials found in this model. The Materials
+    * correspond to the listing of materials in the glTF, with the possible
+    * addition of a default material at the end.
+    */
+  readonly materials: Material[];
+
+  // Returns the first material to whose name matches 'name'.
+  getMaterialByName(name: string): Material|null;
+}
+
+interface Material {
+  name: string;
+
+  // Returns the glTF index of this material.
+  readonly index: number;
+  readonly normalTexture: TextureInfo|null;
+  readonly occlusionTexture: TextureInfo|null;
+  readonly emissiveTexture: TextureInfo|null;
+  readonly emissiveFactor: RGB;
+  readonly pbrMetallicRoughness: PBRMetallicRoughness;
+
+  setEmissiveFactor(rgb: RGB): void;
+  setAlphaCutoff(cutoff: number): void;
+  getAlphaCutoff(): number;
+  setDoubleSided(doubleSided: boolean): void;
+  getDoubleSided(): boolean;
+  setAlphaMode(alphaMode: AlphaMode): void;
+  getAlphaMode(): AlphaMode;
+}
+
+interface PBRMetallicRoughness {
+  readonly baseColorFactor: RGBA;
+  readonly metallicFactor: number;
+  readonly roughnessFactor: number;
+  readonly baseColorTexture: TextureInfo|null;
+  readonly metallicRoughnessTexture: TextureInfo|null;
+  
+  setBaseColorFactor(rgba: RGBA): void;
+  setMetallicFactor(value: number): void;
+  setRoughnessFactor(value: number): void;
+}
+
+interface TextureInfo {
+  readonly texture: Texture|null;
+
+  /**
+   * Sets the texture, or removes it if argument is null. Note you cannot build
+   * your own Texture object, but must either use one from another TextureInfo,
+   * or create one with the createTexture method.
+   */
+  setTexture(texture: Texture|null): void;
+}
+
+interface Texture {
+  readonly name: string;
+  readonly sampler: Sampler;
+  readonly source: Image;
+}
+
+interface Sampler {
+  readonly name: string;
+  readonly minFilter: MinFilter;
+  readonly magFilter: MagFilter;
+  readonly wrapS: WrapMode;
+  readonly wrapT: WrapMode;
+
+  setMinFilter(filter: MinFilter): void;
+  setMagFilter(filter: MagFilter): void;
+  setWrapS(mode: WrapMode): void;
+  setWrapT(mode: WrapMode): void;
+}
+
+interface Image {
+  readonly name: string;
+
+  /**
+    * The type is 'external' if the image has a configured URI. Otherwise, it is
+    * considered to be 'embedded'. Note: this distinction is only implied by the
+    * glTF spec, and is made explicit here for convenience.
+    */
+  readonly type: 'embedded'|'external';
+
+  // The URI of the image, if it is external.
+  readonly uri?: string;
+
+  // The bufferView of the image, if it is embedded.
+  readonly bufferView?: number
+
+  /**
+    * A method to create an object URL of this image at the desired
+    * resolution. Especially useful for KTX2 textures which are GPU compressed,
+    * and so are unreadable on the CPU without a method like this.
+    */
+  createThumbnail(width: number, height: number): Promise<string>;
+}
+
+type RGBA = [number, number, number, number];
+type RGB = [number, number, number];
+type AlphaMode = 'OPAQUE'|'MASK'|'BLEND';
+
+enum WrapMode {
+  ClampToEdge = 33071,
+  MirroredRepeat = 33648,
+  Repeat = 10497,
+}
+
+enum MinFilter {
+  Nearest = 9728,
+  Linear = 9729,
+  NearestMipmapNearest = 9984,
+  LinearMipmapNearest = 9985,
+  NearestMipmapLinear = 9986,
+  LinearMipmapLinear = 9987,
+}
+
+enum MaxFilter {
+  Nearest = 9728,
+  Linear = 9729,
+}
 </script>
 </template>
           </example-snippet>

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -668,47 +668,6 @@ enum MaxFilter {
       </div>
     </div>
 
-    <div class="sample">
-      <div id="exporterWithOptions" class="demo"></div>
-      <div class="content">
-        <div class="wrapper">
-          <div class="heading">
-            <h2 class="demo-title">Exporter with options</h2>
-          </div>
-          <example-snippet stamp-to="exporterWithOptions" highlight-as="html">
-            <template>
-<model-viewer id="animated-model" src="../../shared-assets/models/Horse.glb" autoplay camera-controls alt="A 3D model of a horse galloping">
-  <div class="controls">
-    <button onclick="exportScene(true)">Export GLB</button>
-    <button onclick="exportScene(false)">Export GLTF</button>
-  </div>
-</model-viewer>
-<script>
-  async function exportScene(binary){
-    let options = {
-      binary: binary,
-      trs: true,
-      onlyVisible: true,
-      maxTextureSize: 256,
-      forcePowerOfTwoTextures: true,
-      includeCustomExtensions: false,
-      embedImages: true
-    };
-    let modelViewer = document.getElementById("animated-model");
-    const glTF = await modelViewer.exportScene(options);
-    var file = new File([glTF], binary ? "export.glb" : "export.gltf");
-    var link = document.createElement("a");
-    link.download =file.name;
-    link.href = URL.createObjectURL(file);
-    link.click();
-  }
-</script>
-            </template>
-          </example-snippet>
-        </div>
-      </div>
-    </div>
-
     <div class="footer">
       <ul>
         <li class="attribution">

--- a/packages/modelviewer.dev/src/docs-and-examples/create-html.ts
+++ b/packages/modelviewer.dev/src/docs-and-examples/create-html.ts
@@ -23,13 +23,15 @@ interface Entry {
 }
 
 interface Category {
-  Title: string, Attributes: Entry[], CSS: Entry[], Parts: Entry[],
-      Properties: Entry[], 'Static Properties': Entry[], Methods: Entry[],
-      'Static Methods': Entry[], Events: Entry[], Slots: Entry[],
+  Title: string, htmlName: string, Attributes: Entry[], CSS: Entry[],
+      Parts: Entry[], Properties: Entry[], 'Static Properties': Entry[],
+      Methods: Entry[], 'Static Methods': Entry[], Events: Entry[],
+      Slots: Entry[],
 }
 
 const CategoryConstant: Category = {
   Title: '',
+  htmlName: '',
   Attributes: [],
   CSS: [],
   Parts: [],
@@ -151,9 +153,9 @@ function createSidebarName(name: string): string {
 
 function createSidebar(category: Category) {
   const container = document.getElementById('sidebar-category-container');
-  const lowerCaseTitle = getLowerCaseTitle(category.Title);
+  const lowerCaseTitle = category.htmlName;
   let subcategories = Object.keys(category);
-  subcategories = subcategories.filter(k => k !== 'Title');
+  subcategories = subcategories.filter(k => k !== 'Title' && k !== 'htmlName');
 
   // Link category href (Loading) to first subcategory (Loading, Attributes)
   let lowerKey = '';
@@ -198,13 +200,11 @@ function createSidebar(category: Category) {
   }
 }
 
-function createTitle(title: string) {
-  const lowerCaseTitle = getLowerCaseTitle(title);
-  const titleContainer =
-      document.getElementById(lowerCaseTitle.concat('-docs'));
+function createTitle(title: string, htmlName: string) {
+  const titleContainer = document.getElementById(htmlName.concat('-docs'));
   titleContainer!.innerHTML += `
 <div class="header">
-  <h1 id=${lowerCaseTitle}>${title}</h1>
+  <h1 id=${htmlName}>${title}</h1>
 </div>`;
 }
 
@@ -217,10 +217,6 @@ export function getLowerCaseKey(key: string): string {
     default:
       return key.toLowerCase();
   }
-}
-
-function getLowerCaseTitle(title: string): string {
-  return title.replace('&', 'and').replace(/\s/g, '').toLowerCase();
 }
 
 function createDefaultTable(entry: Entry): string {
@@ -283,17 +279,15 @@ function createSubcategory(
     category: string,
     subcategory: string,
     pluralLowerCaseSubcategory: string) {
-  const lowerCaseCategory = getLowerCaseTitle(category);
-
-  const element = document.getElementById(lowerCaseCategory.concat('-docs'));
+  const element = document.getElementById(category.concat('-docs'));
   const subcategoryContainerId =
-      'docs-'.concat(lowerCaseCategory, '-', pluralLowerCaseSubcategory);
+      'docs-'.concat(category, '-', pluralLowerCaseSubcategory);
 
   const subcategoryContainer = `
 <div class=${pluralLowerCaseSubcategory.concat('-container')}>
   <div class='inner-content'>
     <div id=${subcategoryContainerId}>
-      <h3 id=${lowerCaseCategory.concat('-', pluralLowerCaseSubcategory)}>
+      <h3 id=${category.concat('-', pluralLowerCaseSubcategory)}>
         ${subcategory}
       </h3>
     </div>
@@ -305,11 +299,11 @@ function createSubcategory(
       document.getElementById(subcategoryContainerId);
   for (const entry of subcategoryArray) {
     innerSubcategoryContainer!.innerHTML +=
-        createEntry(entry, lowerCaseCategory, pluralLowerCaseSubcategory);
+        createEntry(entry, category, pluralLowerCaseSubcategory);
 
     if ('links' in entry) {
-      const linksId = 'links'.concat(
-          entry.htmlName, pluralLowerCaseSubcategory, lowerCaseCategory);
+      const linksId =
+          'links'.concat(entry.htmlName, pluralLowerCaseSubcategory, category);
       const linksDiv = document.getElementById(linksId);
       for (const link of entry.links) {
         linksDiv!.innerHTML += `<div>${link}</div>`;
@@ -337,15 +331,13 @@ function createToggle() {
 
 export function convertJSONToHTML(json: any[]) {
   createToggle();
-  let header = '';
   for (const category of json) {
+    const {Title, htmlName} = category;
+    createTitle(Title, htmlName);
     for (const key in category) {
-      if (key === 'Title') {
-        header = category[key];
-        createTitle(category[key]);
-      } else {
+      if (key !== 'Title' && key !== 'htmlName') {
         const lowerCaseKey = getLowerCaseKey(key);
-        createSubcategory(category[key], header, key, lowerCaseKey);
+        createSubcategory(category[key], htmlName, key, lowerCaseKey);
       }
     }
     createSidebar(category);


### PR DESCRIPTION
None of this functionality is new, but I'm finally adding our Materials API to our public docs, and in so doing, marking it as public API and not experimental/internal. I've also renamed this section of our docs from Scene-Graph to Materials because this is what we are actually exposing. In fact we've made a conscious decision to *not* expose the whole glTF scene graph, as this would make our API too large to properly maintain and would blur the distinction between model-viewer and three.js. 

Some extra methods exist on `model` that are not yet documented as we are not sure they are API-stable yet, so they are not officially public. I've also removed the glTF export example, as I'm not confident the options parameter we inherit from three.js is API-stable. 