### PR TITLE
Remove visibilitychange event listener if interaction is cancelled

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -622,6 +622,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
             fingerElement.style.opacity = '0';
           }
           dispatchTouches('pointercancel');
+          document.removeEventListener('visibilitychange', onVisibilityChange);
           return;
         }
 


### PR DESCRIPTION
Remove `visibilitychange` listener when we cancel the `interact` animations because of user interactions.