### PR TITLE
Support cancelInteract(time)

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -597,8 +597,9 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         for (const [i, position] of positions.entries()) {
           const {style} = fingerElements[i];
           if (!keepFingersPosition) {
-            style.transform = `translateX(${width * position.x}px) translateY(${
-                height * position.y}px)`;
+            const tx = width * position.x;
+            const ty = height * position.y;
+            style.transform = `translateX(${tx}px) translateY(${ty}px)`;
           }
           if (type === 'pointerdown') {
             style.opacity = '1';

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -663,7 +663,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
     
     cancelInteract(): void {
-      if (this[$cancelInteract]) {
+      if (this[$cancelInteract] != null) {
         this[$cancelInteract]();
       }
     }

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -393,6 +393,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     protected[$jumpCamera] = false;
     protected[$initialized] = false;
     protected[$maintainThetaPhi] = false;
+    
+    protected[$onVisibilityChange]?: () => void;
 
     getCameraOrbit(): SphericalPosition {
       const {theta, phi, radius} = this[$lastSpherical];

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -623,6 +623,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         // cancel interaction if user interacts
         if (this[$controls].isUserChange) {
           this.cancelInteract();
+          dispatchTouches('pointercancel');
           return;
         }
 

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -663,8 +663,9 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
     
     cancelInteract(): void {
-      if (this[$cancelInteract] != null) {
-        this[$cancelInteract]();
+      const cancelInteract = this[$cancelInteract];
+      if (cancelInteract != null) {
+        cancelInteract();
       }
     }
 

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -708,19 +708,13 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           const target = element.getCameraTarget();
           const orbit = element.getCameraOrbit();
 
-          element.interact(50, finger);
-          element.cancelInteract();
           element.interact(50, finger, finger);
+          element.cancelInteract();
           await rafPasses();
           await rafPasses();
 
-          const newTarget = element.getCameraTarget();
-          expect(newTarget.x).to.be.lessThan(target.x, 'X');
-          expect(newTarget.y).to.be.lessThan(target.y, 'Y');
-
-          const newOrbit = element.getCameraOrbit();
-          expect(newOrbit.theta).to.be.closeTo(orbit.theta, 0.001, 'theta');
-          expect(newOrbit.phi).to.be.closeTo(orbit.phi, 0.001, 'phi');
+          expect(element.getCameraTarget()).to.deep.equal(target, 'cameraTarget');
+          expect(element.getCameraOrbit()).to.deep.equal(orbit, 'cameraOrbit');
         });
       });
 

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -703,21 +703,17 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
         });
 
         test('cancelInteract() cancels synthetic interaction', async () => {
-          element.enablePan = true;
-          await element.updateComplete;
-          const target = element.getCameraTarget();
           const orbit = element.getCameraOrbit();
 
-          element.interact(50, finger, finger);
+          element.interact(50, finger);
           element.cancelInteract();
           await rafPasses();
           await rafPasses();
 
-          const newTarget = element.getCameraTarget();
-          expect(newTarget).to.deep.equal(target, 'cameraTarget');
-          
           const newOrbit = element.getCameraOrbit();
-          expect(newOrbit).to.deep.equal(orbit, 'cameraOrbit');
+          expect(newOrbit.theta).to.eq(orbit.theta, 'theta');
+          expect(newOrbit.phi).to.eq(orbit.phi, 'phi');
+          expect(newOrbit.radius).to.eq(orbit.radius, 'radius');
         });
       });
 

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -682,23 +682,6 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
               .to.be.not.closeTo(orbit.radius, 0.001, 'radius');
         });
 
-        test('user cancelInteract cancels synthetic interaction', async () => {
-          const orbit = element.getCameraOrbit();
-          element.interact(50, finger);
-          await rafPasses();
-          await rafPasses();
-
-          element.cancelInteract();
-          await timePasses(50);
-          await rafPasses();
-
-          const newOrbit = element.getCameraOrbit();
-          expect(newOrbit.theta).to.be.not.closeTo(orbit.theta, 0.001, 'theta');
-          expect(newOrbit.phi).to.be.not.closeTo(orbit.phi, 0.001, 'phi');
-          expect(newOrbit.radius)
-              .to.be.not.closeTo(orbit.radius, 0.001, 'radius');
-        });
-
         test('second interaction does not interupt the first', async () => {
           element.enablePan = true;
           await element.updateComplete;
@@ -707,6 +690,27 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
 
           element.interact(50, finger, finger);
           element.interact(50, finger);
+          await rafPasses();
+          await rafPasses();
+
+          const newTarget = element.getCameraTarget();
+          expect(newTarget.x).to.be.lessThan(target.x, 'X');
+          expect(newTarget.y).to.be.lessThan(target.y, 'Y');
+
+          const newOrbit = element.getCameraOrbit();
+          expect(newOrbit.theta).to.be.closeTo(orbit.theta, 0.001, 'theta');
+          expect(newOrbit.phi).to.be.closeTo(orbit.phi, 0.001, 'phi');
+        });
+
+        test('cancelInteract() cancels synthetic interaction', async () => {
+          element.enablePan = true;
+          await element.updateComplete;
+          const target = element.getCameraTarget();
+          const orbit = element.getCameraOrbit();
+
+          element.interact(50, finger);
+          element.cancelInteract();
+          element.interact(50, finger, finger);
           await rafPasses();
           await rafPasses();
 

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -682,6 +682,23 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
               .to.be.not.closeTo(orbit.radius, 0.001, 'radius');
         });
 
+        test('user cancelInteract cancels synthetic interaction', async () => {
+          const orbit = element.getCameraOrbit();
+          element.interact(50, finger);
+          await rafPasses();
+          await rafPasses();
+
+          element.cancelInteract();
+          await timePasses(50);
+          await rafPasses();
+
+          const newOrbit = element.getCameraOrbit();
+          expect(newOrbit.theta).to.be.not.closeTo(orbit.theta, 0.001, 'theta');
+          expect(newOrbit.phi).to.be.not.closeTo(orbit.phi, 0.001, 'phi');
+          expect(newOrbit.radius)
+              .to.be.not.closeTo(orbit.radius, 0.001, 'radius');
+        });
+
         test('second interaction does not interupt the first', async () => {
           element.enablePan = true;
           await element.updateComplete;

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -713,8 +713,11 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           await rafPasses();
           await rafPasses();
 
-          expect(element.getCameraTarget()).to.deep.equal(target, 'cameraTarget');
-          expect(element.getCameraOrbit()).to.deep.equal(orbit, 'cameraOrbit');
+          const newTarget = element.getCameraTarget();
+          expect(newTarget).to.deep.equal(target, 'cameraTarget');
+          
+          const newOrbit = element.getCameraOrbit();
+          expect(newOrbit).to.deep.equal(orbit, 'cameraOrbit');
         });
       });
 

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -729,6 +729,14 @@
         "links": [
           "<a href=\"../examples/stagingandcameras/#customPrompt\"><span class='attribute'>customPrompt</span> example</a>"
         ]
+      },
+      {
+        "name": "cancelInteract()",
+        "htmlName": "cancelInteract",
+        "description": "Cancels the currently running interaction prompt.",
+        "links": [
+          "<a href=\"../examples/stagingandcameras/#customPrompt\"><span class='attribute'>customPrompt</span> example</a>"
+        ]
       }
     ],
     "Events": [

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -733,7 +733,7 @@
       {
         "name": "cancelInteract(time)",
         "htmlName": "cancelInteract",
-        "description": "Cancels the currently running interaction prompt. The optional time (number, from 0 to 1) can be used to move the currently interaction to a desired keyframe position.",
+        "description": "Cancels the currently running interaction prompt. The optional time (number, from 0 to 1) can be used to move the current interaction animation to a desired keyframe position.",
         "links": [
           "<a href=\"../examples/stagingandcameras/#customPrompt\"><span class='attribute'>customPrompt</span> example</a>"
         ]

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -731,9 +731,9 @@
         ]
       },
       {
-        "name": "cancelInteract()",
+        "name": "cancelInteract(time)",
         "htmlName": "cancelInteract",
-        "description": "Cancels the currently running interaction prompt.",
+        "description": "Cancels the currently running interaction prompt. The optional time (number, from 0 to 1) can be used to move the currently interaction to a desired keyframe position.",
         "links": [
           "<a href=\"../examples/stagingandcameras/#customPrompt\"><span class='attribute'>customPrompt</span> example</a>"
         ]

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -325,8 +325,9 @@
 <script>
   const modelViewerPrompt = document.querySelector("#prompt-demo");
   
-  const PROMT_MS = 3000;
-  const REPEAT_MS = 5000;
+  const PROMT_DURATION_MS = 3000;
+  const START_AFTER_MS = 1000;
+  const REPEAT_AFTER_MS = 5000;
 
   const finger0 = {
     x: {
@@ -370,33 +371,42 @@
     }
   };
 
-  let hasInteracted = false;
+  let timeoutId = null;
 
   const prompt = () => {
-    if (!hasInteracted) {
-      modelViewerPrompt.interact(PROMT_MS, finger0, finger1);
-      setTimeout(prompt, REPEAT_MS);
+    cancelPrompt();
+    modelViewerPrompt.interact(PROMT_DURATION_MS, finger0, finger1);
+    timeoutId = setTimeout(prompt, REPEAT_AFTER_MS);
+  };
+
+  const queuePrompt = () => {
+    cancelPrompt();
+    timeoutId = setTimeout(prompt, START_AFTER_MS);
+  };
+
+  const cancelPrompt = () => {
+    // Move model to initial value of previous interact.
+    modelViewerPrompt.cancelInteract(0);
+    if (timeoutId != null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
     }
   };
 
   modelViewerPrompt.addEventListener('poster-dismissed', () => {
-    prompt();
+    queuePrompt();
+    document.addEventListener('scroll', queuePrompt, {passive: true});
   }, {once: true});
 
   const interacted = (event) => {
     if (event.detail.source === 'user-interaction') {
-      hasInteracted = true;
+      cancelPrompt();
       modelViewerPrompt.removeEventListener('camera-change', interacted);
+      document.removeEventListener('scroll', queuePrompt, {passive: true});
     }
   };
 
   modelViewerPrompt.addEventListener('camera-change', interacted);
-
-  const cancelPrompt = (event) => {
-    modelViewerPrompt.cancelInteract();
-  };
-
-  document.addEventListener('scroll', cancelPrompt, {passive: true});
 </script>
             </template>
           </example-snippet>

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -391,6 +391,12 @@
   };
 
   modelViewerPrompt.addEventListener('camera-change', interacted);
+
+  const cancelPrompt = (event) => {
+    modelViewerPrompt.cancelInteract();
+  };
+
+  document.addEventListener('scroll', cancelPrompt, {passive: true});
 </script>
             </template>
           </example-snippet>

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -371,38 +371,34 @@
     }
   };
 
-  let timeoutId = null;
+  let promptTimeoutId = null;
 
   const prompt = () => {
-    cancelPrompt();
     modelViewerPrompt.interact(PROMT_DURATION_MS, finger0, finger1);
-    timeoutId = setTimeout(prompt, REPEAT_AFTER_MS);
+    promptAfter(REPEAT_AFTER_MS);
   };
 
-  const queuePrompt = () => {
-    cancelPrompt();
-    timeoutId = setTimeout(prompt, START_AFTER_MS);
-  };
+  const promptAfter = (ms) => {
+    promptTimeoutId && clearTimeout(promptTimeoutId);
+    promptTimeoutId = setTimeout(prompt, ms);
+  }
 
-  const cancelPrompt = () => {
-    // Move model to initial value of previous interact.
+  const startPrompt = () => {
+    // Move model to initial value (same as final value).
     modelViewerPrompt.cancelInteract(0);
-    if (timeoutId != null) {
-      clearTimeout(timeoutId);
-      timeoutId = null;
-    }
+    promptAfter(START_AFTER_MS);
   };
 
   modelViewerPrompt.addEventListener('poster-dismissed', () => {
-    queuePrompt();
-    document.addEventListener('scroll', queuePrompt, {passive: true});
+    startPrompt();
+    document.addEventListener('scroll', startPrompt, {passive: true});
   }, {once: true});
 
   const interacted = (event) => {
     if (event.detail.source === 'user-interaction') {
-      cancelPrompt();
+      promptTimeoutId && clearTimeout(promptTimeoutId);
       modelViewerPrompt.removeEventListener('camera-change', interacted);
-      document.removeEventListener('scroll', queuePrompt, {passive: true});
+      document.removeEventListener('scroll', startPrompt);
     }
   };
 


### PR DESCRIPTION
Fixes #3506

`cancelInteraction(time)` allows to cancel a currently running prompt interaction and optionally have it jump to a desired keyframe through the `time` input. `cancelInteraction()` will keep the model's rotation and position to the last rendered keyframe, whereas `cancelInteraction(0)` will update those to the initial value.

Updated example to showcase `cancelInteraction(0)` during scroll events.

https://user-images.githubusercontent.com/6173664/171739656-227fed14-7566-4368-8a2d-c12a552a1636.mov

 