### PR TITLE
apply ceil() to canvas (prevent potential resampling from fractional pixel dimensions)

### DIFF
--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -518,13 +518,10 @@ export default class ModelViewerElementBase extends ReactiveElement {
    * Called on initialization and when the resize observer fires.
    */
   [$updateSize]({width, height}: {width: any, height: any}) {
-    width = Math.floor(parseFloat(width));
-    height = Math.floor(parseFloat(height));
-
     this[$container].style.width = `${width}px`;
     this[$container].style.height = `${height}px`;
 
-    this[$onResize]({width, height});
+    this[$onResize]({width: parseFloat(width), height: parseFloat(height)});
   }
 
   [$tick](_time: number, _delta: number) {

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -518,10 +518,13 @@ export default class ModelViewerElementBase extends ReactiveElement {
    * Called on initialization and when the resize observer fires.
    */
   [$updateSize]({width, height}: {width: any, height: any}) {
+    width = Math.floor(parseFloat(width));
+    height = Math.floor(parseFloat(height));
+
     this[$container].style.width = `${width}px`;
     this[$container].style.height = `${height}px`;
 
-    this[$onResize]({width: parseFloat(width), height: parseFloat(height)});
+    this[$onResize]({width, height});
   }
 
   [$tick](_time: number, _delta: number) {

--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -40,6 +40,7 @@ const templateResult = html`
 
 .container {
   position: relative;
+  overflow: hidden;
 }
 
 .userInput {
@@ -47,7 +48,6 @@ const templateResult = html`
   height: 100%;
   display: block;
   position: relative;
-  overflow: hidden;
 }
 
 canvas {

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -472,9 +472,9 @@ export class Renderer extends EventDispatcher {
       // We avoid using the Three.js PixelRatio and handle it ourselves here so
       // that we can do proper rounding and avoid white boundary pixels.
       const width = Math.min(
-          Math.ceil(scene.width * scaleFactor * dpr), this.canvas3D.width);
+          Math.floor(scene.width * scaleFactor * dpr), this.canvas3D.width);
       const height = Math.min(
-          Math.ceil(scene.height * scaleFactor * dpr), this.canvas3D.height);
+          Math.floor(scene.height * scaleFactor * dpr), this.canvas3D.height);
 
       scene.renderShadow(this.threeRenderer);
 

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -204,13 +204,13 @@ export class Renderer extends EventDispatcher {
     this.dpr = dpr;
 
     if (this.canRender) {
-      this.threeRenderer.setSize(width * dpr, height * dpr, false);
+      this.threeRenderer.setSize(Math.floor(width * dpr), Math.floor(height * dpr), false);
     }
 
     // Expand the canvas size to make up for shrinking the viewport.
     const scale = this.scaleFactor;
-    const widthCSS = width / scale;
-    const heightCSS = height / scale;
+    const widthCSS = Math.floor(width / scale);
+    const heightCSS = Math.floor(height / scale);
     // The canvas element must by styled outside of three due to the offscreen
     // canvas not being directly stylable.
     this.canvas3D.style.width = `${widthCSS}px`;
@@ -221,8 +221,8 @@ export class Renderer extends EventDispatcher {
     // and only the portion that is shown is copied over.
     for (const scene of this.scenes) {
       const {canvas} = scene;
-      canvas.width = Math.round(width * dpr);
-      canvas.height = Math.round(height * dpr);
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
       canvas.style.width = `${widthCSS}px`;
       canvas.style.height = `${heightCSS}px`;
       scene.queueRender();
@@ -246,8 +246,8 @@ export class Renderer extends EventDispatcher {
     this.avgFrameDuration =
         (HIGH_FRAME_DURATION_MS + LOW_FRAME_DURATION_MS) / 2;
 
-    const width = this.width / scale;
-    const height = this.height / scale;
+    const width = Math.floor(this.width / scale);
+    const height = Math.floor(this.height / scale);
 
     this.canvas3D.style.width = `${width}px`;
     this.canvas3D.style.height = `${height}px`;

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -204,13 +204,13 @@ export class Renderer extends EventDispatcher {
     this.dpr = dpr;
 
     if (this.canRender) {
-      this.threeRenderer.setSize(Math.floor(width * dpr), Math.floor(height * dpr), false);
+      this.threeRenderer.setSize(Math.ceil(width * dpr), Math.ceil(height * dpr), false);
     }
 
     // Expand the canvas size to make up for shrinking the viewport.
     const scale = this.scaleFactor;
-    const widthCSS = Math.floor(width / scale);
-    const heightCSS = Math.floor(height / scale);
+    const widthCSS = Math.ceil(width / scale);
+    const heightCSS = Math.ceil(height / scale);
     // The canvas element must by styled outside of three due to the offscreen
     // canvas not being directly stylable.
     this.canvas3D.style.width = `${widthCSS}px`;
@@ -221,8 +221,8 @@ export class Renderer extends EventDispatcher {
     // and only the portion that is shown is copied over.
     for (const scene of this.scenes) {
       const {canvas} = scene;
-      canvas.width = Math.floor(width * dpr);
-      canvas.height = Math.floor(height * dpr);
+      canvas.width = Math.ceil(width * dpr);
+      canvas.height = Math.ceil(height * dpr);
       canvas.style.width = `${widthCSS}px`;
       canvas.style.height = `${heightCSS}px`;
       scene.queueRender();
@@ -246,8 +246,8 @@ export class Renderer extends EventDispatcher {
     this.avgFrameDuration =
         (HIGH_FRAME_DURATION_MS + LOW_FRAME_DURATION_MS) / 2;
 
-    const width = Math.floor(this.width / scale);
-    const height = Math.floor(this.height / scale);
+    const width = Math.ceil(this.width / scale);
+    const height = Math.ceil(this.height / scale);
 
     this.canvas3D.style.width = `${width}px`;
     this.canvas3D.style.height = `${height}px`;
@@ -283,8 +283,8 @@ export class Renderer extends EventDispatcher {
     const {canvas} = scene;
     const scale = this.scaleFactor;
 
-    canvas.width = Math.round(this.width * this.dpr);
-    canvas.height = Math.round(this.height * this.dpr);
+    canvas.width = Math.ceil(this.width * this.dpr);
+    canvas.height = Math.ceil(this.height * this.dpr);
 
     canvas.style.width = `${this.width / scale}px`;
     canvas.style.height = `${this.height / scale}px`;
@@ -472,9 +472,9 @@ export class Renderer extends EventDispatcher {
       // We avoid using the Three.js PixelRatio and handle it ourselves here so
       // that we can do proper rounding and avoid white boundary pixels.
       const width = Math.min(
-          Math.floor(scene.width * scaleFactor * dpr), this.canvas3D.width);
+          Math.ceil(scene.width * scaleFactor * dpr), this.canvas3D.width);
       const height = Math.min(
-          Math.floor(scene.height * scaleFactor * dpr), this.canvas3D.height);
+          Math.ceil(scene.height * scaleFactor * dpr), this.canvas3D.height);
 
       scene.renderShadow(this.threeRenderer);
 
@@ -482,7 +482,7 @@ export class Renderer extends EventDispatcher {
       // clearing the depth from a different buffer
       this.threeRenderer.setRenderTarget(null);
       this.threeRenderer.setViewport(
-          0, Math.floor(this.height * dpr) - height, width, height);
+          0, Math.ceil(this.height * dpr) - height, width, height);
       this.threeRenderer.render(scene, scene.camera);
 
       if (this.multipleScenesVisible) {


### PR DESCRIPTION
https://github.com/google/model-viewer/issues/3554

Fractional pixel dimensions (eg, 650.8) on canvas can cause "1px upsampling" (canvas is scaled larger by a single pixel), causing a slight "resampling blur" compared to native render size.

This can be fixed by removing the fractional parts of the dimensions.

After an initial solution using floor(), we are now switching to using ceil() to eliminate 1px gap issues.  (Concerns about three.js using floor() are moot; we just feed it integers anyway)

### Notes

- As we are already focused on canvas dimensions here, we are also attempting to resolve 1px gap issues (in addition to initial blurring issue).  This is accomplished by using ceil() and hiding overflow
- Only "final" values are adjusted (retain floating point until the last step)
- Tested on both DPR 1 & 2 screens, and at different browser zoom levels, with both my real-world use case and a test page with a variety of models displayed at different sizes (on Chrome, Firefox, and Safari)
- We don't need to apply ceil() to .container; in fact this is bad because it just creates another potential gap on ITS container
- I seemed to need overflow:hidden on .container, I noticed some 1px overlap weirdness without it (the canvas would overlap a 1px border on &lt;model-viewer>)... perhaps it works better because .container has width/height "set in stone" with inline styling values? (Always hard to say for certain when "how browsers round things" is part of the equation)  I then removed overflow:hidden from .userInput as redundant
- Ideas for further improvement: custom properties (aka CSS vars) might be useful for these dimensions, could be a bit more DRY