### PR TITLE
3561 - fix - returning non-basic mesh material from marking as baked …

### DIFF
--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -340,7 +340,7 @@ export class ModelScene extends Scene {
         return;
       }
       const material = mesh.material as Material;
-      if (!material.transparent) {
+      if (!(material as any).isMeshBasicMaterial || !material.transparent) {
         return;
       }
       boundingBox.setFromObject(mesh);


### PR DESCRIPTION
…shadow

### Reference Issue
Fixes issue #3561 

### Tests
01 07 2022 13:54:45.366:WARN [karma]: No captured browser, open http://localhost:9876/
01 07 2022 13:54:45.372:INFO [karma-server]: Karma v6.3.19 server started at http://localhost:9876/
01 07 2022 13:54:45.372:INFO [launcher]: Launching browsers ChromeHeadlessNoSandbox with concurrency 10
01 07 2022 13:54:45.377:INFO [launcher]: Starting browser ChromeHeadless
01 07 2022 13:54:46.065:INFO [Chrome Headless 103.0.5060.66 (Windows 10)]: Connected on socket udzElri9nOhYg4wxAAAB with id 66963962

START:
  utils
    deserializeUrl
      ✔ returns a string given a string
      ✔ returns null given a null-ish value
      ✔ yields a url on the same origin for relative paths
    resolveDpr
      when <meta name="viewport"> is present
        ✔ resolves the device pixel ratio
      when <meta name="viewport"> is not present
        ✖ caps the device pixel ratio to 1 (skipped)
    step
      ✔ returns 0 for values below edge
      ✔ returns 1 for values above edge
    clamp
      ✔ numbers below lower limit adjusted to lower limit
      ✔ numbers above upper limit adjusted to upper limit
      ✔ numbers within lower and upper limits unchanged
  parsers
    parseExpressions
      ✔ parses single numbers
      ✔ parses number tuples
      ✔ parses exponential numbers
      ✔ parses hex colors
      ✔ parses functions
      ✔ parses nested functions
      ✔ parses calc algebra
      failure cases
        mismatched parens
          ✔ trailing paren is gracefully dropped
    ASTWalker
      ✔ only walks configured node types
  conversions
    degreesToRadians
      ✔ converts a number expressed in degrees to radians
      ✔ passes through numbers expressed in radians
      ✔ passes through numbers without a unit
    radiansToDegrees
      ✔ converts a number expressed in radians to degrees
      ✔ passes through numbers expressed in degrees
      ✔ treats numbers without a unit as radians
    lengthToBaseMeters
      ✔ passes through numbers expressed in base meters
      ✔ converts numbers expressed in centimeters to base meters
      ✔ converts numbers expressed in millimeters to base meters
    normalizeUnit
      ✔ normalizes angles to radians
      ✔ normalizes lengths to base meters
  deserializers
    enumerationDeserializer
      ✔ yields the members of the enumeration in the input string
      ✔ filters out non-members of the enumeration
      ✔ yields an empty set from null input
  evaluators
    EnvEvaluator
      ✔ is never constant
      ✔ with no arguments, evaluates to zero
      window-scroll-y
        ✔ evaluates to current top-level scroll position
    PercentageEvaluator
      ✔ multiplies the percentage by the basis
    CalcEvaluator
      ✔ is constant if its operands are all numbers
      ✔ is constant if nested functions are constant
      ✔ is not constant if any nested function is not constant
      ✔ with no arguments, evaluates to zero
      ✔ evaluates basic addition
      ✔ evaluates basic subtraction
      ✔ evaluates basic multiplication
      ✔ evaluates basic division
      ✔ evaluates complex algebraic expressions
      ✔ evaluates algebra with nested functions
    OperatorEvaluator
      ✔ evaluates zero for an unknown operator
      ✔ evaluates zero for operands with mismatching unit types
      ✔ normalizes to base meters for length operands
      ✔ normalizes to radians for angular operands
    VectorEvaluator
      with SphericalIntrinsics
        ✔ evaluates to defaults (e.g., auto) for omitted expressions
        ✔ substitutes the keyword auto for the related intrinsic value
        ✔ treats missing values as equivalent to auto
        ✔ scales the basis by an input percentage
        ✔ evaluates spherical values from basic expressions
        ✔ applies a percentage at any expression depth to the basis
        ✔ evaluates spherical values from complex expressions
  StyleEffector
    ✔ never invokes its callback for constant styles
    ✔ invokes its callback for styles that depend on scroll
  decorators
    @style
      ✔ invokes the update handler with the parsed default value
      ✔ invokes the update handler once with a parsed updated value
  ModelViewerElementBase
    ✔ is not registered as a custom element by default
    when registered
      ✔ can be directly instantiated
      ✔ can be instantiated with document.createElement
      compatibility
        when WebGL is not supported
          ✔ does not explode when created and appended to the document
      with alt text
        ✔ gives the input a related aria-label
        that is removed
          ✔ reverts input to default aria-label
      with a valid src
        ✔ eventually dispatches a load event
        that changes before the model loads
          ✔ it loads the second value on microtask timing
          ✔ it loads the second value on task timing
01 07 2022 13:54:48.827:WARN [web-server]: 404: /does-not-exist.glb
ERROR: Error: fetch for "http://localhost:9876/does-not-exist.glb" responded with 404: Not Found
Error: fetch for "http://localhost:9876/does-not-exist.glb" responded with 404: Not Found
    at http://localhost:9876/base/node_modules/three/build/three.module.js:39338:12
      with an invalid src
        ✔ eventually dispatches an error event
LOG: 'THREE.WebGLRenderer: Context Lost.'
      when losing the GL context
        ✔ dispatches a related error event
      capturing screenshots
        toDataURL
          ✔ produces a URL-compatible string
        toBlob
          ✔ produces a blob
          ✔ can convert blob to object URL
          ✔ has size
          ✔ uses fallbacks on unsupported browsers
          ✔ blobs on supported and unsupported browsers are equivalent
          ✖ idealAspect gives the proper blob dimensions (skipped)
      orchestrates rendering
        ✔ sets a model within viewport to be visible
        ✖ only models visible in the viewport (skipped)
  ModelViewerElement
    ✔ can be directly instantiated
    ✔ can be instantiated with document.createElement
    compatibility
      when WebGL is not supported
        ✔ does not explode when created and appended to the document
    Render Functionality Test
      ✔ Metal roughness sphere with generated lighting
      ✔ Metal roughness sphere with HDR lighting
      ✔ Metal roughness sphere with LDR lighting
  ModelScene
    setModelSource
      ✔ fires a model-load event when loaded
    with a model
      setShadowIntensity
        ✔ can increase intensity and reset it to zero
        ✔ shadow is only created when intensity is greater than zero
    setSize
      ✔ updates visual and buffer size
      ✔ model is not scaled
      ✔ idealCameraDistance is set correctly
      ✔ idealAspect is set correctly
      ✔ cannot set the canvas smaller than 1x1
  Renderer with two scenes
    ✔ pre-renders eager, invisible scenes
    and an externally-rendered scene
      ✔ load sets framing
      ✔ camera-orbit updates camera in external render method
      ✔ resize forwards pixel dimensions
    with two loaded scenes
      ✔ renders only dirty scenes
      ✔ renders only visible scenes
      ✔ uses the proper canvas when unregsitering scenes
      when resizing
        ✔ updates effective DPR
  ARRenderer
    ✔ supports presenting to AR only on Android
    ✔ is not presenting if present has not been invoked
    when presenting a scene
      ✔ presents the model at its natural scale
      presentation ends
        ✔ restores the model to its natural scale
        ✔ restores original camera
        ✔ restores scene size
      after initial placement
        ✔ places the model oriented to the camera
  GLTFInstance
    with a prepared GLTF
      ✔ exposes the same scene as the GLTF
      when cloned
        ✔ creates a unique scene
    preparing the GLTF
      ✔ creates a prepared GLTF
  ModelViewerGLTFInstance
    with a prepared GLTF
      when cloned
        ✔ clones materials in a mesh
        ✔ only clones a discrete material once
    preparing the GLTF
      ✔ sets meshes to cast shadows
      ✔ disables frustum culling on meshes
  correlated-scene-graph
    CorrelatedSceneGraph
      ✔ maps Three.js materials to glTF elements
      ✔ maps Three.js textures to glTF elements
      ✔ has a mapping for each node in scene
      ✔ has a mapping for each material & texture
      when correlating a cloned glTF
        ✔ creates a GLTFLoader "default" material
        ✔ Only one default material after cloning
  utilities
    GLTFTreeVisitor
      ✔ visits materials in tree order
      sparse traversal
        ✔ visits materials in tree order
  SmoothControls
    when updated
      ✔ repositions the camera within the configured radius options
      when orbit is changed
        radius
          ✔ changes the absolute distance to the target
        azimuth
          ✔ wraps and takes the shortest path
          ✔ adjustOrbit does not move the goal theta more than pi past the current theta
      keyboard input
        global keyboard input
          ✔ does not change orbital position of camera
        local keyboard input
          ✔ changes orbital position of camera
      customizing options
        azimuth
          ✔ prevents camera azimuth from exceeding options
        pole
          ✔ prevents camera polar angle from exceeding options
        radius
          ✔ prevents camera distance from exceeding options
        field of view
          ✔ prevents field of view from exceeding options
        interaction policy
          allow-when-focused
            ✔ does not zoom when scrolling while blurred
            ✔ does not orbit when pointing while blurred
            ✔ does zoom when scrolling while focused
          always-allow
            ✔ orbits when pointing, even while blurred
            ✔ zooms when scrolling, even while blurred
          events
            ✔ dispatches "change" on user interaction
            ✔ dispatches "change" on direct orbit change
            ✔ sends "user-interaction" multiple times
            ✔ does not send "user-interaction" after setOrbit
            simultaneous user and imperative interaction
              ✔ reports source as user interaction
  Damper
    ✔ converges to goal with large time step without overshoot
    ✔ stays at initial value for negative time step
    ✔ converges to goal when normalization is zero
    ✔ negative normalization is the same as positive
  TextureUtils
    load
      ✔ loads a valid texture from URL
      ✔ loads a valid HDR texture from URL
      ✔ throws on invalid URL
01 07 2022 13:54:57.945:WARN [web-server]: 404: /nope.png
      ✔ throws if texture not found
    generating an environment map and skybox
      ✔ returns an environmentMap and skybox texture from url
      ✔ returns an environmentMap and skybox texture from an HDR url
      ✔ returns an environmentMap and skybox texture from two urls
      ✔ throws if given an invalid url
    dynamically generating environment maps
      ✔ creates a cubemap render target with PMREM
  CachingGLTFLoader
    when loading a glTF
      ✔ synchronously populates the cache
      ✔ yields a promise that resolves a group
      before glTF is loaded
        ✔ reports that it has not finished loading
      after glTF is loaded
        ✔ reports that it has finished loading
      with items outside of the eviction threshold
        ✔ deletinates them when they are fully released
  ModelUtils
    cloneGltf
      ✔ reduceVertices matches boundingBox
  Hotspot
    with only a name
      ✔ has a DOM element
    with assigned nodes
      with a configured visibilityAttribute
        when shown
          ✔ adds a corresponding data-* attribute to assigned nodes
          and then hidden
            ✔ removes the corresponding data-* attribute
      when shown
        ✔ dispatches a "visibility-change" on assigned nodes
        and then hidden
          ✔ dispatches a "visibility-change" on assigned nodes
  animation
    interpolate
      ✔ interpolates from start to end values
    sequence
      ✔ interpolates across a sequence of timing functions
      ✔ allows for timing functions to be relatively weighted
    timeline
      ✔ creates a timing function sequence from keyframes
  CacheEvictionPolicy
    ✔ reports zero retainers for uncached items
    ✔ accounts for total retainers of cached items
    ✔ ignores non-retained cached items within the threshold
    ✔ deletes non-retained cached items outside the threshold
    ✔ deletes non-retained cached items least-recently-used first
  ModelViewerElementBase with FocusVisiblePolyfillMixin
    ✔ can be directly instantiated
    ✔ can be instantiated with document.createElement
    compatibility
      when WebGL is not supported
        ✔ does not explode when created and appended to the document
    when polyfill is present
      ✔ typically does not show the focus ring when focused
  ProgressTracker
    ✔ starts out with zero ongoing activities
    an activity
      ✔ increases the ongoing activities count
      with partial progress
        ✔ causes the ProgressTracker to dispatch a progress event
        ✔ only allows progress to advance
        a late-added activity
          ✔ is added to the current stack of activities
          ✔ defers marking all activities completed
      completed
        ✔ ProgressTracker dispatches a final progress event
        ✔ ProgressTracker resets ongoing activity count
      with another activity
        ✔ increases the ongoing activity count
        ✔ each activity progresses independently
        all activities completed
          ✔ ProgressTracker resets ongoing activity count
          ✔ ProgressTracker dispatches a final progress event after the last activity is completed
  ModelViewerElementBase with AnimationMixin
    ✔ can be directly instantiated
    ✔ can be instantiated with document.createElement
    compatibility
      when WebGL is not supported
        ✔ does not explode when created and appended to the document
    a model with animations
      ✔ remains in a paused state
      when play is invoked with no options
        ✔ animations play
        ✔ has a duration greater than 0
        when pause is invoked after a delay
          ✔ animations pause
          ✔ has a current time close to the delay
          ✔ changing currentTime triggers render
          when play is invoked again
            ✔ animations play
            ✔ has a duration greater than 0
            ✔ has a current time close to the delay
      when play is invoked with options
        ✔ plays forward, backward, and stops
      when configured to autoplay
        ✔ plays an animation
        ✔ has a duration greater than 0
        ✔ plays the first animation by default
        with a specified animation-name
          ✔ plays the specified animation
        with an invalid animation-name
          ✔ plays the first animation
        with a specified index as animation-name
          ✔ plays the specified animation
        with an invalid index as animation-name
          ✔ plays the first animation
        a model with duplicate animation names
          ✔ plays the specified animation
          when playing a duplicate animation by name
            ✔ fails to play the specified animation and plays the last animation with that name instead
        a model without animations
          ✔ does not play an animation
          ✔ has a duration of 0
          with a specified animation-name
            ✔ does not play an animation
WARN: 'Cannot play animation (model does not have any animations)'
          with a specified animation by index
            ✔ does not play an animation
  ModelViewerElementBase with AnnotationMixin
    ✔ can be directly instantiated
    ✔ can be instantiated with document.createElement
    compatibility
      when WebGL is not supported
        ✔ does not explode when created and appended to the document
    a model-viewer element with a hotspot
      ✔ creates a corresponding slot
      adding a second hotspot with the same name
        ✔ does not change the slot
        ✔ does not change the data
        ✔ updateHotspot does change the data
        ✔ and removing it does not remove the slot
        ✔ but removing both does remove the slot
        with a camera
          ✔ the hotspot is hidden
          ✔ the hotspot is visible after turning
    a model-viewer element with a loaded cube
      ✔ gets expected hit result
      ✔ gets expected hit result when turned
  ModelViewerElementBase with StagingMixin
    ✔ can be directly instantiated
    ✔ can be instantiated with document.createElement
    compatibility
      when WebGL is not supported
        ✔ does not explode when created and appended to the document
    with a visible loaded model
      ✔ can manually rotate turntable
      auto-rotate
        ✔ causes the model to rotate after a delay
        ✖ retains turntable rotation when auto-rotate is toggled (skipped)
        ✖ pauses rotate after user interaction (skipped)
        when the model is not visible
          ✔ does not cause the model to rotate over time
        with zero auto-rotate-delay
          ✔ causes the model to rotate ASAP
  ModelViewerElementBase with ControlsMixin
    when registered
      ✔ can be directly instantiated
      ✔ can be instantiated with document.createElement
      compatibility
        when WebGL is not supported
          ✔ does not explode when created and appended to the document
      camera-orbit
        ✔ defaults radius to ideal camera distance
        ✔ can independently adjust azimuth
        ✔ can independently adjust inclination
        ✔ can independently adjust radius
        ✔ can independently adjust target
        ✔ causes the camera to look at the target
        ✔ defaults FOV correctly
        ✔ defaults FOV limits correctly
        ✔ can independently adjust FOV
        ✔ changes FOV basis when aspect ratio changes
        ✔ causes camera-change event to fire
        ✔ sets an appropriate event source
        when target is modified
          ✔ camera looks at the configured target
          ✔ causes camera-change event to fire
        getCameraOrbit
          ✔ starts at the initially configured orbit
          ✔ updates with current orbit after interaction
          ✔ jumpCameraToGoal updates instantly
        min/max extents
          ✔ defaults maxFieldOfView correctly
          ✔ jumps to maxCameraOrbit when outside
          ✔ jumps to minCameraOrbit when outside
          ✔ jumps to maxFieldOfView when outside
          ✔ jumps to minFieldOfView when outside
          when configured before model loads
            ✔ respects user-configured min/maxFieldOfView
      camera-controls
        ✔ creates SmoothControls if enabled
        ✔ requires focus to interact if policy is set to allow-when-focused
        ✔ does not require focus to interact if policy is set to always-allow
        ✔ sets max radius to at least the camera framed distance
        ✔ with a large radius, sets far plane to contain the model
        ✔ with zero radius, sets far plane to contain the model
        ✔ disables interaction if disabled after enabled
        when user is interacting
          ✔ sets an appropriate camera-change event source
        interaction-prompt
          ✔ can be configured to never appear
          ✔ can be configured to raise automatically
          ✔ does not appear when camera-controls is disabled
          after it has been dismissed
            ✔ can be reset and displayed again
          when configured to be basic
            ✔ does not have a css animation
        synthetic interaction
          ✔ one finger rotates
          ✔ return one finger to starting point returns camera to starting point
          ✔ two fingers pan
          ✔ return two fingers to starting point returns target to starting point
          ✔ user interaction cancels synthetic interaction
WARN: 'interact() failed because an existing interaction is running.'
          ✔ second interaction does not interupt the first
        a11y
          ✔ announces camera orientation when orbiting horizontally
          ✔ announces camera orientation when orbiting vertically
          when configured for focus-based interaction prompting
            ✔ has initial aria-label set to alt before interaction
            ✖ prompts user to interact when focused (skipped)
            ✖ does not prompt users to interact before a model is loaded (skipped)
            ✔ does not prompt if user already interacted
  ModelViewerElementBase with EnvironmentMixin
    ✔ can be directly instantiated
    ✔ can be instantiated with document.createElement
    ✔ only generates an environment when in the render tree
    compatibility
      when WebGL is not supported
        ✔ does not explode when created and appended to the document
    with no skybox-image property
      and a src property
        ✔ applies a generated environment map on model
        ✔ changes the environment exactly once
    exposure
      ✔ changes the tone mapping exposure of the renderer
    shadow-intensity
      ✔ changes the opacity of the static shadow
    environment-image
      ✔ applies environment-image environment map on model
      and environment-image subsequently removed
        ✔ reapplies generated environment map on model
    with skybox-image property
      ✔ displays background with skybox-image
      ✔ applies skybox-image environment map on model
      with an environment-image
        ✔ prefers environment-image as environment map
        and environment-image subsequently removed
          ✔ uses skybox-image as environment map
        and skybox-image subsequently removed
          ✔ continues using environment-image as environment map
          ✔ removes the background
      and skybox-image subsequently removed
        ✔ removes the background
        ✔ reapplies generated environment map on model
  ModelViewerElementBase with LoadingMixin
    when registered
      ✔ can be directly instantiated
      ✔ can be instantiated with document.createElement
      compatibility
        when WebGL is not supported
          ✔ does not explode when created and appended to the document
      loading
        ✔ creates a poster element that captures interactions
        ✔ does not load when hidden from render tree
        load
          when a model src changes after loading
            ✔ only dispatches load once per src change
            ✔ getDimensions() returns correct size
            ✔ generates 3DModel schema
        loading
          src changes quickly
            ✔ eventually notifies that current src is preloaded
          reveal
            auto
              ✔ hides poster when element loads
            interaction
              ✔ retains poster after loading
              when focused
                ✔ can hide the poster with keyboard interaction
            manual
              ✔ does not hide poster until dismissed
        configuring poster via attribute
          removing the attribute
            ✔ sets poster to null
        with loaded model src
          ✔ can be hidden imperatively
          when poster is hidden
            ✔ allows the input to be interactive
            ✔ when src is reset, poster is dismissable
  ModelViewerElementBase with SceneGraphMixin
    ✔ can be directly instantiated
    ✔ can be instantiated with document.createElement
    compatibility
      when WebGL is not supported
        ✔ does not explode when created and appended to the document
WARN: 'THREE.GLTFExporter: parse() expects options as the fourth argument now.'
    scene export
      ✔ When loading a new JPEG texture from an ObjectURL, the GLB does not export PNG
WARN: 'THREE.GLTFExporter: parse() expects options as the fourth argument now.'
      with a loaded model
        ✔ exports the loaded model to GLTF
WARN: 'THREE.GLTFExporter: parse() expects options as the fourth argument now.'
        ✔ exports the loaded model to GLB
        ✔ has variants
        ✔ Setting variantName to null results in primitive
           reverting to default/initial material
WARN: 'THREE.GLTFExporter: parse() expects options as the fourth argument now.'
        ✔ exports and re-imports the model with variants
      with a loaded model containing a mesh with multiple primitives
        ✔ has variants
        ✔ Setting variantName to null results in primitive
           reverting to default/initial material
WARN: 'THREE.GLTFExporter: parse() expects options as the fourth argument now.'
        ✔ exports and re-imports the model with variants
    with a loaded scene graph
      ✔ allows the scene graph to be manipulated
      ✔ image.setURI sets the appropriate texture
      when the model changes
        ✔ updates when the model changes
        ✔ allows the scene graph to be manipulated
      Scene-graph gltf-to-three mappings
        ✔ has a mapping for each primitive mesh
  scene-graph/model
    Model
      ✔ creates a "default" material, when none is specified
      ✖ exposes a list of materials in the scene (skipped)
      Model Variants
        ✔ Switch variant and lazy load
        ✔ Switch back to default variant does not change correlations
        ✔ Switching variant when model has no variants has not effect
      Model e2e test
        ✔ getMaterialByName returns material when name exists
        ✔ getMaterialByName returns null when name does not exists
        Create Variant
          ✔ createMaterialInstanceForVariant() adds new primitive variants mapping
            only to primitives that use the source material
          ✔ Create variant and switch to it
          ✔ New variant is available to model-viewer
          ✔ createMaterialInstanceForVariant() fails when there is a variant name
            collision
          ✔ createVariant() creates a variant
WARN: 'Variant 'Purple Yellow'' already exists'
          ✔ createVariant() is a noop if the variant exists
          ✔ setMaterialToVariant() adds variants mapping
          only to primitives that use the source material
          ✔ updateVariantName() updates the variant name
          ✔ deleteVariant() removes variant from primitives, materials and available variants.
          ✔ hasVariant() positive and negative test
        Intersecting
          ✔ materialFromPoint returns material
          ✔ materialFromPoint returns null when intersect fails
  ModelViewerElementBase with ARMixin
    when registered
      ✔ can be directly instantiated
      ✔ can be instantiated with document.createElement
      compatibility
        when WebGL is not supported
          ✔ does not explode when created and appended to the document
LOG: 'Attempting to present in AR with Scene Viewer...'
      AR intents
        openSceneViewer
          ✔ preserves query parameters in model URLs
LOG: 'Attempting to present in AR with Scene Viewer...'
          ✔ keeps title and link when supplied
LOG: 'Attempting to present in AR with Scene Viewer...'
          ✔ sets sound and link to absolute URLs
LOG: 'Attempting to present in AR with Quick Look...'
        openQuickLook
          ✔ sets hash for fixed scale
LOG: 'Attempting to present in AR with Quick Look...'
          ✔ keeps original hash too
LOG: 'Attempting to present in AR with Quick Look...'
          ✔ replicate src hash to usdz blob url
LOG: 'Attempting to present in AR with Quick Look...'
          ✔ replicate src hash to usdz blob and set hash for fixed scale
      with webxr
        ✔ shows the AR button if on a WebXR platform
      ios-src
        on browsers that do not support AR
          ✔ hides the AR button
          with an ios-src
            ✔ still hides the AR button
  scene-graph/texture
    Texture
      ✔ Create a texture
      ✔ Set a texture
      ✔ Verify legacy correlatedObjects are updated.
      ✔ Set a texture and then setURI
  scene-graph/material
    Test Texture Slots
      ✔ Set a new base map
      ✔ Set a new metallicRoughness map
      ✔ Set a new normal map
      ✔ Set a new occlusion map
      ✔ Set a new emissive map
    Material properties
      ✔ test alpha cutoff expect disabled by default
      ✔ test alpha cutoff expect valid value as default
      ✔ test alpha cutoff test setting and getting
      ✔ test double sided expect default is false
      ✔ test double sided expect default is true
      ✔ test double sided setting and getting
      ✔ test alpha-mode, setting and getting
      ✔ test alpha-mode, expect default of opaque
      ✔ test alpha-mode, expect default of blend
      ✔ test alpha-mode, expect default of mask
    Material lazy loading
      ✔ Accessing the name getter does not cause throw error.
      ✔ Accessing a getter of an unloaded material throws an error.
      ✔ Accessing a getter of a loaded material has valid data.
  scene-graph/texture-info
    texture-info
      ✔ empty slot is null
      ✔ non-empty slot is not null
      ✔ call setTexture
  scene-graph/model/mesh-primitives
    Primitive with default material
      ✔ has a default material
    Static Primitive Without Variant
      ✔ Should not have any primitives with variant info
    Static Primitive With Variant
      ✔ Primitive count matches glTF file
      ✔ Primitives should have expected variant names
      ✔ Should not have any primitives without variant info
      ✔ Switching to incorrect variant name
      ✔ Switching to current variant
      ✔ Switching to variant and then switch back
      ✔ Primitive switches to initial material
    Mesh with multiple primitives each with variants
      ✔ Primitive count matches glTF file
      ✔ Primitives should have expected variant names
      ✔ Switching to incorrect variant name
      ✔ Switching to variant and then switch back
      ✔ Primitive switches to initial material
    Skinned Primitive Without Variant
      ✔ Primitive count matches glTF file

Finished in 36.93 secs / 18.137 secs @ 13:55:24 GMT+0200 (Central European Summer Time)

SUMMARY:
✔ 410 tests completed
ℹ 8 tests skipped