### PR TITLE
don't hit invisible geometry

### DIFF
--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -774,7 +774,8 @@ export class ModelScene extends Scene {
     this.raycaster.setFromCamera(ndcPosition, this.getCamera());
     const hits = this.raycaster.intersectObject(object, true);
 
-    const hit = hits.find((hit) => !hit.object.userData.shadow);
+    const hit =
+        hits.find((hit) => hit.object.visible && !hit.object.userData.shadow);
     if (hit == null || hit.face == null) {
       return null;
     }


### PR DESCRIPTION
Fixes #3531 

It wasn't even hitting the shadow, but the blur plane. Honestly raycaster should probably skip `!visible` objects anyway, but at least it's easy to work around.