### PR TITLE
reactivate AR tests

### DIFF
--- a/packages/model-viewer/karma.conf.js
+++ b/packages/model-viewer/karma.conf.js
@@ -40,7 +40,6 @@ module.exports = function(config) {
     ],
     autoWatchBatchDelay: 1000,
     restartOnFileChange: true,
-    hostname: 'bs-local.com',
 
     browserDisconnectTimeout: 300000,
     browserNoActivityTimeout: 360000,

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -202,7 +202,7 @@ suite('ModelViewerElementBase with ARMixin', () => {
       // possibly due to not serving over HTTPS (which disables WebXR)? However,
       // Browserstack is unstable without this hostname.
       test('shows the AR button if on a WebXR platform', () => {
-        expect(element.canActivateAR).to.be.equal(false);  // IS_ANDROID
+        expect(element.canActivateAR).to.be.equal(IS_ANDROID);
       });
     });
 
@@ -225,41 +225,16 @@ suite('ModelViewerElementBase with ARMixin', () => {
         }
       });
 
-      if (IS_IOS) {
-        suite('on iOS Safari', () => {
-          test('hides the AR button', () => {
-            expect(element.canActivateAR).to.be.equal(false);
-          });
-
-          suite('with an ios-src', () => {
-            setup(async () => {
-              element.iosSrc = assetPath('models/Astronaut.usdz');
-              await timePasses();
-            });
-
-            test('shows the AR button', () => {
-              expect(element.canActivateAR).to.be.equal(true);
-            });
-          });
+      suite('with an ios-src', () => {
+        setup(async () => {
+          element.iosSrc = assetPath('models/Astronaut.usdz');
+          await timePasses();
         });
-      } else if (!IS_ANDROID) {
-        suite('on browsers that do not support AR', () => {
-          test('hides the AR button', () => {
-            expect(element.canActivateAR).to.be.equal(false);
-          });
 
-          suite('with an ios-src', () => {
-            setup(async () => {
-              element.iosSrc = assetPath('models/Astronaut.usdz');
-              await timePasses();
-            });
-
-            test('still hides the AR button', () => {
-              expect(element.canActivateAR).to.be.equal(false);
-            });
-          });
+        test('shows the AR button', () => {
+          expect(element.canActivateAR).to.be.equal(IS_ANDROID || IS_IOS);
         });
-      }
+      });
     });
   });
 });

--- a/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ARRenderer-spec.ts
@@ -15,6 +15,7 @@
 
 import {Matrix4, PerspectiveCamera, Vector2, Vector3} from 'three';
 
+import {IS_ANDROID} from '../../constants.js';
 import {ControlsInterface, ControlsMixin} from '../../features/controls.js';
 import ModelViewerElementBase, {$scene} from '../../model-viewer-base.js';
 import {ARRenderer} from '../../three-components/ARRenderer.js';
@@ -212,8 +213,7 @@ suite('ARRenderer', () => {
   // possibly due to not serving over HTTPS (which disables WebXR)? However,
   // Browserstack is unstable without this hostname.
   test('supports presenting to AR only on Android', async () => {
-    expect(await arRenderer.supportsPresentation())
-        .to.be.equal(false);  // IS_ANDROID
+    expect(await arRenderer.supportsPresentation()).to.be.equal(IS_ANDROID);
   });
 
   test('is not presenting if present has not been invoked', () => {


### PR DESCRIPTION
Reverting the hostname: 'bs-local' in karma.conf because it made the tests not run locally and caused WebXR sessions to appear erroneously unsupported. 