### PR TITLE
Removing trailing comma from docs

### DIFF
--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -263,7 +263,7 @@
         "name": "default-progress-bar",
         "htmlName": "defaultProgressBar",
         "description": "Scope your CSS to <code>model-viewer::part(default-progress-bar)</code> to change the styling of our default progress bar without replacing it wholesale with a slot. Most common would be probably changing the background-color, height, width, and margins (avoid the transform property as that is how the progress is updated)."
-      },
+      }
     ],
     "Slots": [
       {


### PR DESCRIPTION
Docs page went down due to a trailing comma. Fix pointed out by @alanb-sony 

### Reference Issue
<!-- Fixes #3694 -->
