### PR TITLE
fix HDR race condition

### DIFF
--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -22,7 +22,7 @@ import {makeTemplate} from './template.js';
 import {$evictionPolicy, CachingGLTFLoader} from './three-components/CachingGLTFLoader.js';
 import {ModelScene} from './three-components/ModelScene.js';
 import {ContextLostEvent, Renderer} from './three-components/Renderer.js';
-import {debounce, timePasses} from './utilities.js';
+import {clamp, debounce, timePasses} from './utilities.js';
 import {dataUrlToBlob} from './utilities/data-conversion.js';
 import {ProgressTracker} from './utilities/progress-tracker.js';
 
@@ -177,7 +177,7 @@ export default class ModelViewerElementBase extends ReactiveElement {
   protected[$userInputElement]: HTMLDivElement;
   protected[$canvas]: HTMLCanvasElement;
   protected[$statusElement]: HTMLSpanElement;
-  protected[$status]: string;
+  protected[$status] = '';
   protected[$defaultAriaLabel]: string;
   protected[$clearModelTimeout]: number|null = null;
 
@@ -584,7 +584,9 @@ export default class ModelViewerElementBase extends ReactiveElement {
     const source = this.src;
     try {
       await this[$scene].setSource(
-          source, (progress: number) => updateSourceProgress(progress * 0.95));
+          source,
+          (progress: number) =>
+              updateSourceProgress(clamp(progress, 0, 1) * 0.95));
 
       const detail = {url: source};
       this.dispatchEvent(new CustomEvent('preload', {detail}));

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -684,6 +684,7 @@ suite('ModelViewerElementBase with ControlsMixin', () => {
           statusElement = element[$statusElement];
           element.alt = 'A 3D model of a cube';
           element.cameraOrbit = '0 90deg auto';
+          await element.updateComplete;
         });
 
         test('has initial aria-label set to alt before interaction', () => {


### PR DESCRIPTION
I finally found the source of our flakiest test on the CI: the HDR rendering test. It turns out the `load` event was firing after the HDR image loaded, but just before it was actually applied to the scene (the flakiness was likely from where in the animation loop it happened to be when it finished). And it never repro'd locally because the network was instant - I finally got a local repro by opening dev tools in a debug Karma window and throttling the network. 