### PR TITLE
Enable pan by default

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -235,6 +235,7 @@ export declare interface ControlsInterface {
   interpolationDecay: number;
   disableZoom: boolean;
   disablePan: boolean;
+  disableTap: boolean;
   getCameraOrbit(): SphericalPosition;
   getCameraTarget(): Vector3D;
   getFieldOfView(): number;
@@ -328,6 +329,9 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
     @property({type: Boolean, attribute: 'disable-pan'})
     disablePan: boolean = false;
+
+    @property({type: Boolean, attribute: 'disable-tap'})
+    disableTap: boolean = false;
 
     @property({type: Number, attribute: 'interpolation-decay'})
     interpolationDecay: number = DECAY_MILLISECONDS;
@@ -462,6 +466,10 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       if (changedProperties.has('disablePan')) {
         controls.enablePan = !this.disablePan;
+      }
+
+      if (changedProperties.has('disableTap')) {
+        controls.enableTap = !this.disableTap;
       }
 
       if (changedProperties.has('interactionPrompt') ||

--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -234,7 +234,7 @@ export declare interface ControlsInterface {
   touchAction: TouchAction;
   interpolationDecay: number;
   disableZoom: boolean;
-  enablePan: boolean;
+  disablePan: boolean;
   getCameraOrbit(): SphericalPosition;
   getCameraTarget(): Vector3D;
   getFieldOfView(): number;
@@ -326,8 +326,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     @property({type: Boolean, attribute: 'disable-zoom'})
     disableZoom: boolean = false;
 
-    @property({type: Boolean, attribute: 'enable-pan'})
-    enablePan: boolean = false;
+    @property({type: Boolean, attribute: 'disable-pan'})
+    disablePan: boolean = false;
 
     @property({type: Number, attribute: 'interpolation-decay'})
     interpolationDecay: number = DECAY_MILLISECONDS;
@@ -460,8 +460,8 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
         controls.disableZoom = this.disableZoom;
       }
 
-      if (changedProperties.has('enablePan')) {
-        controls.enablePan = this.enablePan;
+      if (changedProperties.has('disablePan')) {
+        controls.enablePan = !this.disablePan;
       }
 
       if (changedProperties.has('interactionPrompt') ||

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -536,6 +536,23 @@ suite('Controls', () => {
         }
       };
 
+      const tap = (position: number) => {
+        return {
+          x: {
+            initialValue: position,
+            keyframes: [
+              {frames: 1, value: position},
+            ]
+          },
+          y: {
+            initialValue: position,
+            keyframes: [
+              {frames: 1, value: position},
+            ]
+          }
+        };
+      };
+
       test('one finger rotates', async () => {
         const orbit = element.getCameraOrbit();
 
@@ -617,6 +634,55 @@ suite('Controls', () => {
             expect(newTarget.y).to.be.closeTo(target.y, 0.001, 'Y');
             expect(newTarget.z).to.be.closeTo(target.z, 0.001, 'Z');
           });
+
+      test('tap moves the model and re-centers', async () => {
+        element.cameraOrbit = '0deg 90deg auto';
+        element.jumpCameraToGoal();
+        await element.updateComplete;
+        const target = element.getCameraTarget();
+
+        // tap on the model
+        element.interact(5, tap(0.5));
+        await rafPasses();
+        element.jumpCameraToGoal();
+        await element.updateComplete;
+        await rafPasses();
+
+        const newTarget = element.getCameraTarget();
+        expect(newTarget.x).to.be.closeTo(target.x, 0.001, 'X');
+        expect(newTarget.y).to.be.closeTo(target.y, 0.001, 'Y');
+        expect(newTarget.z).to.be.greaterThan(target.z, 'Z');
+
+        // tap off the model
+        element.interact(5, tap(0));
+        await rafPasses();
+        element.jumpCameraToGoal();
+        await element.updateComplete;
+        await rafPasses();
+
+        const oldTarget = element.getCameraTarget();
+        expect(oldTarget.x).to.be.closeTo(target.x, 0.001, 'X recenter');
+        expect(oldTarget.y).to.be.closeTo(target.y, 0.001, 'Y recenter');
+        expect(oldTarget.z).to.be.closeTo(target.z, 0.001, 'Z recenter');
+      });
+
+      test('tap does not move the model with disable-tap is set', async () => {
+        element.disableTap = true;
+        await element.updateComplete;
+        element.cameraOrbit = '0deg 90deg auto';
+        element.jumpCameraToGoal();
+        await element.updateComplete;
+        const target = element.getCameraTarget();
+
+        element.interact(5, tap(0.5));
+        await rafPasses();
+        await rafPasses();
+
+        const newTarget = element.getCameraTarget();
+        expect(newTarget.x).to.be.eq(target.x, 'X');
+        expect(newTarget.y).to.be.eq(target.y, 'Y');
+        expect(newTarget.z).to.be.eq(target.z, 'Z');
+      });
 
       test('user interaction cancels synthetic interaction', async () => {
         const orbit = element.getCameraOrbit();

--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -569,7 +569,6 @@ suite('Controls', () => {
           });
 
       test('two fingers pan', async () => {
-        element.enablePan = true;
         element.cameraOrbit = '0deg 90deg auto';
         element.jumpCameraToGoal();
         await element.updateComplete;
@@ -585,11 +584,27 @@ suite('Controls', () => {
         expect(newTarget.z).to.be.closeTo(target.z, 0.001, 'Z');
       });
 
+      test('two fingers do not pan if disable-pan is set', async () => {
+        element.disablePan = true;
+        await element.updateComplete;
+        element.cameraOrbit = '0deg 90deg auto';
+        element.jumpCameraToGoal();
+        await element.updateComplete;
+        const target = element.getCameraTarget();
+
+        element.interact(50, finger, finger);
+        await rafPasses();
+        await rafPasses();
+
+        const newTarget = element.getCameraTarget();
+        expect(newTarget.x).to.be.eq(target.x, 'X');
+        expect(newTarget.y).to.be.eq(target.y, 'Y');
+        expect(newTarget.z).to.be.eq(target.z, 'Z');
+      });
+
       test(
           'return two fingers to starting point returns target to starting point',
           async () => {
-            element.enablePan = true;
-            await element.updateComplete;
             const target = element.getCameraTarget();
 
             // Long enough duration to not be considered a re-centering tap.
@@ -623,8 +638,6 @@ suite('Controls', () => {
       });
 
       test('second interaction does not interrupt the first', async () => {
-        element.enablePan = true;
-        await element.updateComplete;
         const target = element.getCameraTarget();
         const orbit = element.getCameraOrbit();
 

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -132,6 +132,7 @@ export class SmoothControls extends EventDispatcher {
 
   // Pan state
   public enablePan = true;
+  public enableTap = true;
   private panProjection = new Matrix3();
   private panPerPixel = 0;
 
@@ -751,7 +752,7 @@ export class SmoothControls extends EventDispatcher {
       element.removeEventListener('pointermove', this.onPointerMove);
       element.removeEventListener('pointerup', this.onPointerUp);
       element.removeEventListener('touchmove', this.disableScroll);
-      if (this.enablePan) {
+      if (this.enablePan && this.enableTap) {
         this.recenter(event);
       }
     } else if (this.touchMode !== null) {

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -438,7 +438,7 @@
       {
         "name": "disable-pan",
         "htmlName": "disablePan",
-        "description": "Disables panning interactions, which are enabled by default using two-finger touch, or dragging with right-click or modifier keys. By default, pan is limited to the bounding sphere of the model. Tapping on the model focuses on that point, while tapping off the model zooms back to the original framing. When panning, the center point is shown visually (and can be suppressed/changed using the <a href=\"#entrydocs-stagingandcameras-slots-panTarget\">pan-target</a> slot) and when the pan gesture ends, the camera is focused on that model point (if there was a surface under the dot), so that the camera doesn't orbit around a random point in space."
+        "description": "Disables panning interactions, which are enabled by default using two-finger touch, or dragging with right-click or modifier keys."
       },
       {
         "name": "disable-tap",

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -436,9 +436,9 @@
         ]
       },
       {
-        "name": "enable-pan",
-        "htmlName": "enablePan",
-        "description": "Enable panning interactions using two-finger touch, or dragging with right-click or modifier keys. Pan is limited to the bounding sphere of the model. Tapping on the model focuses on that point, while tapping off the model zooms back to the original framing. When panning, the center point is shown visually (and can be suppressed/changed using the <a href=\"#entrydocs-stagingandcameras-slots-panTarget\">pan-target</a> slot) and when the pan gesture ends, the camera is focused on that model point (if there was a surface under the dot), so that the camera doesn't orbit around a random point in space. Note this attribute also changes the camera defaults: field-of-view will default to 30 degrees (minimum 12 degrees) and the minimum radius is twice the bounding radius to keep the camera from entering the object.",
+        "name": "disable-pan",
+        "htmlName": "disablePan",
+        "description": "Disable panning interactions, which are enabled by default using two-finger touch, or dragging with right-click or modifier keys. By default, pan is limited to the bounding sphere of the model. Tapping on the model focuses on that point, while tapping off the model zooms back to the original framing. When panning, the center point is shown visually (and can be suppressed/changed using the <a href=\"#entrydocs-stagingandcameras-slots-panTarget\">pan-target</a> slot) and when the pan gesture ends, the camera is focused on that model point (if there was a surface under the dot), so that the camera doesn't orbit around a random point in space.",
         "links": [
           "<a href=\"../examples/stagingandcameras/#panning\">Related example</a>"
         ]

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -438,7 +438,12 @@
       {
         "name": "disable-pan",
         "htmlName": "disablePan",
-        "description": "Disable panning interactions, which are enabled by default using two-finger touch, or dragging with right-click or modifier keys. By default, pan is limited to the bounding sphere of the model. Tapping on the model focuses on that point, while tapping off the model zooms back to the original framing. When panning, the center point is shown visually (and can be suppressed/changed using the <a href=\"#entrydocs-stagingandcameras-slots-panTarget\">pan-target</a> slot) and when the pan gesture ends, the camera is focused on that model point (if there was a surface under the dot), so that the camera doesn't orbit around a random point in space.",
+        "description": "Disables panning interactions, which are enabled by default using two-finger touch, or dragging with right-click or modifier keys. By default, pan is limited to the bounding sphere of the model. Tapping on the model focuses on that point, while tapping off the model zooms back to the original framing. When panning, the center point is shown visually (and can be suppressed/changed using the <a href=\"#entrydocs-stagingandcameras-slots-panTarget\">pan-target</a> slot) and when the pan gesture ends, the camera is focused on that model point (if there was a surface under the dot), so that the camera doesn't orbit around a random point in space."
+      },
+      {
+        "name": "disable-tap",
+        "htmlName": "disableTap",
+        "description": "Disables tap-to-recenter behavior (both center-the-tapped-point and reset-view-when-tapping-outside). This attribute has no effect in combination with 'disable-pan', as the tap-to-recenter behavior is part of the panning interactions. It is recommended to create custom re-centering behavior when using 'disable-tap' as after panning and rotating, it is effectively impossible for the user to exactly return to their starting view.",
         "links": [
           "<a href=\"../examples/stagingandcameras/#panning\">Related example</a>"
         ]

--- a/packages/modelviewer.dev/data/examples.json
+++ b/packages/modelviewer.dev/data/examples.json
@@ -117,7 +117,7 @@
       },
       {
         "htmlId": "panning",
-        "name": "Panning"
+        "name": "Disable Tap"
       },
       {
         "htmlId": "turnSkybox",

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -331,7 +331,6 @@
       src="../../assets/SketchfabModels/ThorAndTheMidgardSerpent.glb"
       alt="Thor and the Midgard Serpent"
       camera-controls
-      enable-pan
       touch-action="none"
       camera-orbit="-8.142746deg 68.967deg 0.6179899m"
       camera-target="-0.003m 0.0722m 0.0391m"

--- a/packages/modelviewer.dev/examples/color.html
+++ b/packages/modelviewer.dev/examples/color.html
@@ -145,7 +145,6 @@
           src="../assets/ShopifyModels/GeoPlanter.glb"
           poster="../assets/ShopifyModels/GeoPlanter.webp"
           shadow-intensity="1"
-          enable-pan
           camera-controls
           alt="3D model of a cactus"
         >
@@ -242,7 +241,6 @@
      <figure>
       <model-viewer
         src="../../shared-assets/models/silver-gold.gltf"
-        enable-pan
         skybox-image="../../shared-assets/environments/neutral.hdr"
         ar
         ar-modes="webxr scene-viewer quick-look"
@@ -265,7 +263,6 @@
      <figure>
       <model-viewer
         src="../../shared-assets/models/silver-gold-unlit.gltf"
-        enable-pan
         skybox-image="../../shared-assets/environments/neutral.hdr"
         camera-controls
         alt="3D model of six example material spheres"
@@ -283,7 +280,6 @@
      <figure>
       <model-viewer
         src="../../shared-assets/models/silver-gold.gltf"
-        enable-pan
         skybox-image="../../shared-assets/environments/white_furnace.hdr"
         camera-controls
         alt="3D model of six example material spheres"
@@ -329,7 +325,6 @@
       <model-viewer
         id="exposure"
         src="../../shared-assets/models/silver-gold.gltf"
-        enable-pan
         skybox-image="../../shared-assets/environments/neutral.hdr"
         camera-controls
         alt="3D model of six example material spheres"
@@ -431,7 +426,6 @@
       <model-viewer
         id="toneMapping"
         src="../../shared-assets/models/silver-gold.gltf"
-        enable-pan
         skybox-image="../../shared-assets/environments/neutral.hdr"
         camera-controls
         alt="3D model of six example material spheres"
@@ -653,7 +647,6 @@
         id="environments"
         src="../assets/ShopifyModels/Mixer.glb"
         skybox-image="../../shared-assets/environments/neutral.hdr"
-        enable-pan
         camera-controls
         alt="3D model of a blender"
       >

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -187,12 +187,20 @@
           <div class="heading">
             <h2 class="demo-title">Disable Tap</h2>
             <p>Pan is enabled by default via two fingers on touch or using
-            right-click or any modifier key with mouse drag. Clicking on the
+            right-click or any modifier key with mouse drag. When panning, the
+            center point is shown visually (and can be suppressed/changed using
+            the <a
+            href="../../docs/index.html#entrydocs-stagingandcameras-slots-panTarget">pan-target</a>
+            slot) and when the pan gesture ends, the camera is focused on that
+            model point (if there was a surface under the dot), so that the
+            camera doesn't orbit around a random point in space. Clicking on the
             model focuses on that point, while clicking off the model returns to
-            the default center. There is a  <span
-            class="attribute">disable-pan</span> attribute to turn all of this
-            off, but here we demonstrate only turning off the click/tap
-            behaviors via the  <span class="attribute">disable-tap</span>
+            the default center.</p>
+
+            <p>There is a  <span class="attribute">disable-pan</span> attribute
+            to turn all of this off, but here we demonstrate only turning off
+            the click/tap behaviors via the  <span
+            class="attribute">disable-tap</span>
             attribute. Note that after panning and rotating the model, it can be
             very hard to get back to the original centering, so it's recommended
             to implement your own re-centering logic via  <span

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -191,7 +191,7 @@
           </div>
           <example-snippet stamp-to="panning" highlight-as="html">
             <template>
-<model-viewer id="pan-demo" enable-pan auto-rotate shadow-intensity="1" camera-controls touch-action="pan-y" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum"></model-viewer>
+<model-viewer id="pan-demo" auto-rotate shadow-intensity="1" camera-controls touch-action="pan-y" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum"></model-viewer>
             </template>
           </example-snippet>
         </div>
@@ -317,7 +317,7 @@
     background-color: rgba(0, 0, 0, 0.7);
   }
 </style>
-<model-viewer id="prompt-demo" camera-controls touch-action="pan-y" enable-pan interaction-prompt="none" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" shadow-intensity="1" ar ar-modes="webxr scene-viewer quick-look">
+<model-viewer id="prompt-demo" camera-controls touch-action="pan-y" interaction-prompt="none" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" shadow-intensity="1" ar ar-modes="webxr scene-viewer quick-look">
   <div class="dot" slot="finger0"></div>
   <div class="dot" slot="finger1"></div>
 </model-viewer>

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -185,13 +185,23 @@
       <div class="content">
         <div class="wrapper">
           <div class="heading">
-            <h2 class="demo-title">Pan and focus</h2>
-            <p>Enables two-finger pan on touch or using right-click or any modifier key with mouse drag. 
-              Clicking on the model focuses on that point, while clicking off the model returns to the default center.</p>
+            <h2 class="demo-title">Disable Tap</h2>
+            <p>Pan is enabled by default via two fingers on touch or using
+            right-click or any modifier key with mouse drag. Clicking on the
+            model focuses on that point, while clicking off the model returns to
+            the default center. There is a  <span
+            class="attribute">disable-pan</span> attribute to turn all of this
+            off, but here we demonstrate only turning off the click/tap
+            behaviors via the  <span class="attribute">disable-tap</span>
+            attribute. Note that after panning and rotating the model, it can be
+            very hard to get back to the original centering, so it's recommended
+            to implement your own re-centering logic via  <span
+            class="attribute">camera-target</span>
+              if you decide to go this route.</p>
           </div>
           <example-snippet stamp-to="panning" highlight-as="html">
             <template>
-<model-viewer id="pan-demo" auto-rotate shadow-intensity="1" camera-controls touch-action="pan-y" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum"></model-viewer>
+<model-viewer id="pan-demo" disable-tap auto-rotate shadow-intensity="1" camera-controls touch-action="pan-y" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum"></model-viewer>
             </template>
           </example-snippet>
         </div>

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -71,7 +71,7 @@
 <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
 
 <!-- Use it like any other HTML element -->
-<model-viewer alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" src="shared-assets/models/NeilArmstrong.glb" ar ar-modes="webxr scene-viewer quick-look" environment-image="shared-assets/environments/moon_1k.hdr" poster="shared-assets/models/NeilArmstrong.webp" shadow-intensity="1" camera-controls touch-action="pan-y" enable-pan></model-viewer>
+<model-viewer alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" src="shared-assets/models/NeilArmstrong.glb" ar ar-modes="webxr scene-viewer quick-look" environment-image="shared-assets/environments/moon_1k.hdr" poster="shared-assets/models/NeilArmstrong.webp" shadow-intensity="1" camera-controls touch-action="pan-y"></model-viewer>
                 </template>
               </example-snippet>
             </div>

--- a/packages/space-opera/src/test/snippet_viewer/snippet_viewer_test.ts
+++ b/packages/space-opera/src/test/snippet_viewer/snippet_viewer_test.ts
@@ -38,7 +38,7 @@ describe('snippet viewer test', () => {
     // clang-format off
 
     // Pulled from real DOM of astronaut example.
-    snippetViewer.renderedSnippet = html`<!--?lit$343342268$--><model-viewer enable-pan="" src="Astronaut.glb" ar="" ar-modes="webxr scene-viewer quick-look" camera-controls="" poster="poster.webp" shadow-intensity="1" ar-status="not-presenting">
+    snippetViewer.renderedSnippet = html`<!--?lit$343342268$--><model-viewer src="Astronaut.glb" ar="" ar-modes="webxr scene-viewer quick-look" camera-controls="" poster="poster.webp" shadow-intensity="1" ar-status="not-presenting">
     <!--?lit$128424273$--><!---->
 <div class="progress-bar hide" slot="progress-bar">
 <div class="update-bar"></div>
@@ -53,7 +53,7 @@ View in your space
     // clang-format on
 
     const goldenFormattedHTML =
-        `<model-viewer enable-pan src="Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" camera-controls poster="poster.webp" shadow-intensity="1">
+        `<model-viewer src="Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" camera-controls poster="poster.webp" shadow-intensity="1">
     <div class="progress-bar hide" slot="progress-bar">
         <div class="update-bar"></div>
     </div>
@@ -74,7 +74,7 @@ View in your space
 
     // Pulled from real DOM of astronaut example with a hotspot.
     // hotspot <button> is beteen two comments on the same line
-    snippetViewer.renderedSnippet = html`<!--?lit$128424273$--><model-viewer enable-pan="" src="Astronaut.glb" ar="" ar-modes="webxr scene-viewer quick-look" camera-controls="" poster="poster.webp" shadow-intensity="1" ar-status="not-presenting">
+    snippetViewer.renderedSnippet = html`<!--?lit$128424273$--><model-viewer src="Astronaut.glb" ar="" ar-modes="webxr scene-viewer quick-look" camera-controls="" poster="poster.webp" shadow-intensity="1" ar-status="not-presenting">
     <!--?lit$128424273$--><!----><button class="Hotspot" slot="hotspot-1" data-position="-0.043973778464142396m 1.2075171453793048m 0.29653766978435936m" data-normal="-0.4260645307016329m -0.06968452861538316m 0.9020050344369756m" data-visibility-attribute="visible"><div class="HotspotAnnotation">asdf</div></button><!----><!---->
 <div class="progress-bar hide" slot="progress-bar">
 <div class="update-bar"></div>
@@ -89,7 +89,7 @@ View in your space
     // clang-format on
 
     const goldenFormattedHTML =
-        `<model-viewer enable-pan src="Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" camera-controls poster="poster.webp" shadow-intensity="1">
+        `<model-viewer src="Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" camera-controls poster="poster.webp" shadow-intensity="1">
     <button class="Hotspot" slot="hotspot-1" data-position="-0.043973778464142396m 1.2075171453793048m 0.29653766978435936m" data-normal="-0.4260645307016329m -0.06968452861538316m 0.9020050344369756m" data-visibility-attribute="visible">
         <div class="HotspotAnnotation">asdf</div>
     </button>

--- a/packages/space-opera/src/types.ts
+++ b/packages/space-opera/src/types.ts
@@ -128,7 +128,7 @@ export const INITIAL_STATE: State = {
       poster: {height: 512, mimeType: 'image/webp'},
       hotspots: [],
       relativeFilePaths: {posterName: 'poster.webp'},
-      extraAttributes: {'enable-pan': ''},
+      extraAttributes: {},
     },
   },
 };


### PR DESCRIPTION
Fixes #3611 

Replaces `enable-pan` with `disable-pan` and adds `disable-tap`.