### PR TITLE
added inputSensitivity

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -247,6 +247,7 @@ export declare interface ControlsInterface {
   resetInteractionPrompt(): void;
   zoom(keyPresses: number): void;
   interact(duration: number, finger0: Finger, finger1?: Finger): void;
+  inputSensitivity: number;
 }
 
 export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
@@ -360,6 +361,14 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     protected[$jumpCamera] = false;
     protected[$initialized] = false;
     protected[$maintainThetaPhi] = false;
+
+    get inputSensitivity(): number {
+      return this[$controls].inputSensitivity;
+    }
+
+    set inputSensitivity(value: number) {
+      this[$controls].inputSensitivity = value;
+    }
 
     getCameraOrbit(): SphericalPosition {
       const {theta, phi, radius} = this[$lastSpherical];
@@ -490,7 +499,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
       }
 
       if (changedProperties.has('orbitSensitivity')) {
-        controls.sensitivity = this.orbitSensitivity;
+        controls.orbitSensitivity = this.orbitSensitivity;
       }
 
       if (changedProperties.has('interpolationDecay')) {

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -126,7 +126,8 @@ export interface PointerChangeEvent extends ThreeEvent {
  * ensure that the camera's matrixWorld is in sync before using SmoothControls.
  */
 export class SmoothControls extends EventDispatcher {
-  public sensitivity = 1;
+  public orbitSensitivity = 1;
+  public inputSensitivity = 1;
   public changeSource = ChangeSource.NONE;
 
   private _interactionEnabled: boolean = false;
@@ -499,7 +500,9 @@ export class SmoothControls extends EventDispatcher {
   private userAdjustOrbit(
       deltaTheta: number, deltaPhi: number, deltaZoom: number) {
     this.adjustOrbit(
-        deltaTheta * this.sensitivity, deltaPhi * this.sensitivity, deltaZoom);
+        deltaTheta * this.orbitSensitivity * this.inputSensitivity,
+        deltaPhi * this.orbitSensitivity * this.inputSensitivity,
+        deltaZoom * this.inputSensitivity);
 
     // Always make sure that an initial event is triggered in case there is
     // contention between user interaction and imperative changes. This initial
@@ -603,7 +606,7 @@ export class SmoothControls extends EventDispatcher {
 
   private movePan(dx: number, dy: number) {
     const {scene} = this;
-    const dxy = vector3.set(dx, dy, 0);
+    const dxy = vector3.set(dx, dy, 0).multiplyScalar(this.inputSensitivity);
     const metersPerPixel =
         this.spherical.radius * Math.exp(this.logFov) * this.panPerPixel;
     dxy.multiplyScalar(metersPerPixel);


### PR DESCRIPTION
Fixes #3714 

This can be helpful for custom interaction prompts, to make the model motion more subtle compared to the finger motion. It can also be used with keydown/keyup listeners to check for e.g. the shift key and reduce sensitivity for fine-control mode, then reset when released. 