### PR TITLE
Add getBoundingBoxCenter()

### DIFF
--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -14,6 +14,7 @@
  */
 
 import {property} from 'lit/decorators.js';
+import {Vector3} from 'three';
 
 import ModelViewerElementBase, {$altDefaulted, $announceModelVisibility, $getModelIsVisible, $isElementInViewport, $progressTracker, $scene, $sceneIsReady, $shouldAttemptPreload, $updateSource, $updateStatus, $userInputElement, toVector3D, Vector3D} from '../model-viewer-base.js';
 import {$loader, CachingGLTFLoader} from '../three-components/CachingGLTFLoader.js';
@@ -68,6 +69,7 @@ export declare interface LoadingInterface {
   dismissPoster(): void;
   showPoster(): void;
   getDimensions(): Vector3D;
+  getBoundingBoxCenter(): Vector3D;
 }
 
 export declare interface LoadingStaticInterface {
@@ -245,6 +247,10 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
      */
     getDimensions(): Vector3D {
       return toVector3D(this[$scene].size);
+    }
+
+    getBoundingBoxCenter(): Vector3D {
+      return toVector3D(this[$scene].boundingBox.getCenter(new Vector3()));
     }
 
     protected[$modelIsRevealed] = false;

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -172,6 +172,11 @@
         "description": "Returns the model's bounding box dimensions in meters, independent of turntable rotation. The returned object has x, y, and z properties along with a toString() method."
       },
       {
+        "name": "getBoundingBoxCenter()",
+        "htmlName": "getBoundingBoxCenter",
+        "description": "Returns the center point of the model's bounding box in meters, independent of turntable rotation. The returned object has x, y, and z properties along with a toString() method."
+      },
+      {
         "name": "toBlob(options: {mimeType, qualityArgument, idealAspect})",
         "htmlName": "toBlob",
         "description": "Returns a promise that resolves into a Blob object in the format specified by the <i>mimeType</i> (defaults to image/png). A Blob object represents a file-like object of immutable, raw data. You can also specify a value between 0 and 1 for <i>qualityArgument</i> (Currently only available on Chrome desktop and Firefox) which defaults to 0.92 and 0.8 for image/png and image/webp respectively. By setting <span class='attribute'>idealAspect</span> to true, the blob will be captured at the ideal poster aspect ratio instead of the canvas aspect ratio. This allows for easy poster creation, where a single poster will match the render seamlessly at any canvas aspect ratio."

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -242,7 +242,7 @@
   });
 
   modelViewer.addEventListener('load', () => {
-    const center = modelViewer.getCameraTarget();
+    const center = modelViewer.getBoundingBoxCenter();
     const size = modelViewer.getDimensions();
     const x2 = size.x / 2;
     const y2 = size.y / 2;

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -74,7 +74,7 @@
           <example-snippet stamp-to="addHotspots" highlight-as="html">
             <template>
 <style>
-  button{
+  .hotspot{
     display: block;
     width: 20px;
     height: 20px;
@@ -82,19 +82,20 @@
     border: none;
     background-color: blue;
     box-sizing: border-box;
+    pointer-events: none;
   }
 
-  button[slot="hotspot-hand"]{
+  .hotspot[slot="hotspot-hand"]{
     --min-hotspot-opacity: 0;
     background-color: red;
   }
 
-  button[slot="hotspot-foot"]:not([data-visible]) {
+  .hotspot[slot="hotspot-foot"]:not([data-visible]) {
     background-color: transparent;
     border: 3px solid blue;
   }
 
-  #annotation{
+  .annotation{
     background-color: #888888;
     position: absolute;
     transform: translate(10px, 10px);
@@ -107,12 +108,12 @@
   }
 </style>
 <model-viewer id="hotspot-demo" ar ar-modes="webxr" camera-controls touch-action="pan-y" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut.">
-  <button slot="hotspot-visor" data-position="0 1.75 0.35" data-normal="0 0 1"></button>
-  <button slot="hotspot-hand" data-position="-0.54 0.93 0.1" data-normal="-0.73 0.05 0.69">
-    <div id="annotation">This hotspot disappears completely</div>
+  <button class="hotspot" slot="hotspot-visor" data-position="0 1.75 0.35" data-normal="0 0 1"></button>
+  <button class="hotspot" slot="hotspot-hand" data-position="-0.54 0.93 0.1" data-normal="-0.73 0.05 0.69">
+    <div class="annotation">This hotspot disappears completely</div>
   </button>
-  <button slot="hotspot-foot" data-position="0.16 0.1 0.17" data-normal="-0.07 0.97 0.23" data-visibility-attribute="visible"></button>
-  <div id="annotation">This annotation is fixed in screen-space</div>
+  <button class="hotspot" slot="hotspot-foot" data-position="0.16 0.1 0.17" data-normal="-0.07 0.97 0.23" data-visibility-attribute="visible"></button>
+  <div class="annotation">This annotation is fixed in screen-space</div>
 </model-viewer>
             </template>
           </example-snippet>
@@ -146,6 +147,7 @@
     left: 16px;
     max-width: unset;
     transform: unset;
+    pointer-events: auto;
   }
 
   .dot{
@@ -153,14 +155,19 @@
     width: 12px;
     height: 12px;
     border-radius: 50%;
+    border: none;
+    box-sizing: border-box;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
     background: #fff;
+    pointer-events: none;
     --min-hotspot-opacity: 0;
   }
 
   .dim{
     background: #fff;
     border-radius: 4px;
+    border: none;
+    box-sizing: border-box;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
     color: rgba(0, 0, 0, 0.8);
     display: block;
@@ -174,6 +181,7 @@
     width: max-content;
     height: max-content;
     transform: translate3d(-50%, -50%, 0);
+    pointer-events: none;
     --min-hotspot-opacity: 0;
   }
 
@@ -425,6 +433,8 @@
   .view-button {
       background: #fff;
       border-radius: 4px;
+      border: none;
+      box-sizing: border-box;
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
       color: rgba(0, 0, 0, 0.8);
       display: block;


### PR DESCRIPTION
The dimensions example was getting incorrect placement of the labels when switching models in WebXR mode. This was because we were relying on `getCameraTarget` to find the center of the model, but that is in fact independent (especially since it can be set as an attribute). It's been fixed by adding `getBoundingBoxCenter()` right next to `getDimensions()`, as they should be used in concert.

I also updated the CSS in the annotations examples to be independent of each other, which makes them clearer and easier to copy.