### PR TITLE
fixed AR scene cleanup

### DIFF
--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -322,6 +322,7 @@ export class ARRenderer extends EventDispatcher {
     }
 
     const scene = this.presentedScene;
+    this._presentedScene = null;
     if (scene != null) {
       const {element} = scene;
 
@@ -387,7 +388,6 @@ export class ARRenderer extends EventDispatcher {
     this.lastTick = null;
     this.turntableRotation = null;
     this.oldShadowIntensity = null;
-    this._presentedScene = null;
     this.frame = null;
     this.inputSource = null;
     this.overlay = null;


### PR DESCRIPTION
Fixes an issue where the AR example was losing its lighting upon returning to 3D mode; it was a regression caused by #3606.