### PR TITLE
make AR placement box double-sided

### DIFF
--- a/packages/model-viewer/src/three-components/PlacementBox.ts
+++ b/packages/model-viewer/src/three-components/PlacementBox.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {BufferGeometry, Float32BufferAttribute, FrontSide, Material, Mesh, MeshBasicMaterial, PlaneBufferGeometry, Vector2, Vector3} from 'three';
+import {BufferGeometry, DoubleSide, Float32BufferAttribute, Material, Mesh, MeshBasicMaterial, PlaneBufferGeometry, Vector2, Vector3} from 'three';
 
 import {Damper} from './Damper.js';
 import {ModelScene} from './ModelScene.js';
@@ -93,7 +93,7 @@ export class PlacementBox extends Mesh {
 
     this.side = side;
     const material = this.material as MeshBasicMaterial;
-    material.side = FrontSide;
+    material.side = DoubleSide;
     material.transparent = true;
     material.opacity = 0;
     this.goalOpacity = 0;
@@ -102,6 +102,7 @@ export class PlacementBox extends Mesh {
     this.hitPlane =
         new Mesh(new PlaneBufferGeometry(2 * (x + RADIUS), 2 * (y + RADIUS)));
     this.hitPlane.visible = false;
+    (this.hitPlane.material as Material).side = DoubleSide;
     this.add(this.hitPlane);
 
     boundingBox.getCenter(this.position);


### PR DESCRIPTION
Sometimes WebXR wall placement is not great and you can end up behind the model. Dragging and such was disabled in this case, so now it's double-sided. 