### PR TITLE
Refactor render scaling

### DIFF
--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -69,6 +69,7 @@ export class ModelScene extends Scene {
   public width = 1;
   public height = 1;
   public aspect = 1;
+  public scaleStep = 0;
   public renderCount = 0;
   public externalRenderer: RendererInterface|null = null;
 

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -169,6 +169,11 @@ export class ModelScene extends Scene {
     this.isDirty = false;
   }
 
+  forceRescale() {
+    this.scaleStep = -1;
+    this.queueRender();
+  }
+
   /**
    * Pass in a THREE.Object3D to be controlled
    * by this model.

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -203,31 +203,21 @@ export class Renderer extends EventDispatcher {
     this.width = width;
     this.height = height;
     this.dpr = dpr;
+    width = Math.ceil(width * dpr);
+    height = Math.ceil(height * dpr);
 
     if (this.canRender) {
-      this.threeRenderer.setSize(
-          Math.ceil(width * dpr), Math.ceil(height * dpr), false);
+      this.threeRenderer.setSize(width, height, false);
     }
-
-    // Expand the canvas size to make up for shrinking the viewport.
-    const scale = this.scaleFactor;
-    const widthCSS = Math.ceil(width / scale);
-    const heightCSS = Math.ceil(height / scale);
-    // The canvas element must by styled outside of three due to the offscreen
-    // canvas not being directly stylable.
-    this.canvas3D.style.width = `${widthCSS}px`;
-    this.canvas3D.style.height = `${heightCSS}px`;
 
     // Each scene's canvas must match the renderer size. In general they can be
     // larger than the element that contains them, but the overflow is hidden
     // and only the portion that is shown is copied over.
     for (const scene of this.scenes) {
       const {canvas} = scene;
-      canvas.width = Math.ceil(width * dpr);
-      canvas.height = Math.ceil(height * dpr);
-      canvas.style.width = `${widthCSS}px`;
-      canvas.style.height = `${heightCSS}px`;
-      scene.queueRender();
+      canvas.width = width;
+      canvas.height = height;
+      scene.forceRescale();
     }
   }
 
@@ -267,18 +257,8 @@ export class Renderer extends EventDispatcher {
 
   registerScene(scene: ModelScene) {
     this.scenes.add(scene);
-    const {canvas} = scene;
-    const scale = this.scaleFactor;
 
-    canvas.width = Math.ceil(this.width * this.dpr);
-    canvas.height = Math.ceil(this.height * this.dpr);
-
-    canvas.style.width = `${this.width / scale}px`;
-    canvas.style.height = `${this.height / scale}px`;
-
-    scene.queueRender();
-
-    this.dispatchRenderScale(scene);
+    scene.forceRescale();
 
     if (this.canRender && this.scenes.size > 0) {
       this.threeRenderer.setAnimationLoop(


### PR DESCRIPTION
Fixes #2502

Actually, I think most of #2502 was already fixed, but this is a significant refactor that I believe makes the renderer a lot less prone to bugs of this type. We had some occasional reports of the renderer scaling down and never coming back to full res even when the model stopped. I was never able to get a repro, but I'm betting the issue had to do with external factors (page performance, low-battery mode, etc) causing the page to not hit frame-rate, which then caused us to scale the render down even though it wasn't our fault. 

Now we only measure performance while we're rendering. We also immediately scale up to 100% when we stop rendering (model stops moving), so no need to wait for it to go through the steps. We also immediately scale back down to the previous steady-state when the model starts moving again, instead of waiting for the feedback loop to converge again. 

Additionally, the CSS rescaling has been centralized to ensure it is being done consistently and no more often than necessary. 