### PR TITLE
fix xr pre-placement

### DIFF
--- a/packages/model-viewer/src/three-components/PlacementBox.ts
+++ b/packages/model-viewer/src/three-components/PlacementBox.ts
@@ -137,6 +137,7 @@ export class PlacementBox extends Mesh {
   getExpandedHit(scene: ModelScene, screenX: number, screenY: number): Vector3
       |null {
     this.hitPlane.scale.set(1000, 1000, 1000);
+    this.hitPlane.updateMatrixWorld();
     const hitResult = this.getHit(scene, screenX, screenY);
     this.hitPlane.scale.set(1, 1, 1);
     return hitResult;


### PR DESCRIPTION
In WebXR mode, the model had become difficult to drag around (before the floor is found) because when your finger went beyond the placement box, it would stop getting a hit result, and so stop moving. Must have been a change in three.js - just prodding the hit matrix to update was enough to solve it. 