### PR TITLE
iOS16 ARQL compatibility checks

### DIFF
--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -61,14 +61,6 @@ export const IS_IOS =
     (/iPad|iPhone|iPod/.test(navigator.userAgent) && !(self as any).MSStream) ||
     (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
 
-export const IS_AR_QUICKLOOK_CANDIDATE = (() => {
-  const tempAnchor = document.createElement('a');
-
-  return Boolean(
-      tempAnchor.relList && tempAnchor.relList.supports &&
-      tempAnchor.relList.supports('ar'));
-})();
-
 // @see https://developer.chrome.com/multidevice/user-agent
 export const IS_SAFARI = /Safari\//.test(navigator.userAgent);
 export const IS_FIREFOX = /firefox/i.test(navigator.userAgent);
@@ -87,3 +79,20 @@ declare global {
 }
 
 export const IS_WKWEBVIEW = Boolean(window.webkit && window.webkit.messageHandlers);
+
+// If running in iOS Safari proper, and not within a WKWebView component instance, check for ARQL feature support.
+// Otherwise, if running in a WKWebView instance, check for known ARQL compatible iOS browsers, including:
+// Chrome (CriOS), Edge (EdgiOS), Firefox (FxiOS), Google App (GSA), DuckDuckGo (DuckDuckGo).
+// All other iOS browsers / apps will fail by default.
+export const IS_AR_QUICKLOOK_CANDIDATE = (() => {
+    if(IS_IOS){
+        if(!IS_WKWEBVIEW){            
+            const tempAnchor = document.createElement('a');
+            return Boolean(tempAnchor.relList && tempAnchor.relList.supports && tempAnchor.relList.supports('ar'));
+        } else {
+            return  Boolean(/CriOS\/|EdgiOS\/|FxiOS\/|GSA\/|DuckDuckGo\//.test(navigator.userAgent));
+        }
+    } else {
+        return false;
+    }
+})();

--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -85,3 +85,5 @@ declare global {
       webkit?: any;
     }
 }
+
+export const IS_WKWEBVIEW = Boolean(window.webkit && window.webkit.messageHandlers);

--- a/packages/model-viewer/src/constants.ts
+++ b/packages/model-viewer/src/constants.ts
@@ -77,3 +77,11 @@ export const IS_IOS_CHROME = IS_IOS && /CriOS\//.test(navigator.userAgent);
 export const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
 
 export const IS_SCENEVIEWER_CANDIDATE = IS_ANDROID && !IS_FIREFOX && !IS_OCULUS;
+
+// Extend Window type with webkit property,
+// required to check if iOS is running within a WKWebView browser instance.
+declare global {
+    interface Window {
+      webkit?: any;
+    }
+}


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
Fixes #3528

This contribution is gladly provided by the team at **Nvzn Augmented Reality** (https://www.nvzn.net/)

### Issue

Recent updates to the new (soon to be released) iOS16 will change the behaviour of feature detection for AR QuickLook support.

In theory `a.relList.supports("ar")` can be used to test the browser for AR QuickLook support.

Prior to iOS16, an issue caused `a.relList.supports("ar")` to always return `true` for all WKWebView-based browsers, even though WKWebView itself does not, by default, support AR QuickLook.

Now in iOS16 `a.relList.supports("ar")` will always return `false` for all WKWebViews.

However, some WKWebView-based browsers, such as Chrome iOS, have implemented their own AR QuickLook handling. 

Prior to iOS16 ModelViewer would display the AR button for those WKWebView browsers, due to the false positive result.

With the iOS16 updates, current compatibility checks in ModelViewer will fail in all WKWebView browsers, and ModelViewer will no longer show the AR button for all WKWebView browsers, including the ones like Chrome that have implemented custom support.

This contribution seeks to address this change in iOS16 while maintaining backward compatibility with prior iOS versions.

Tightening iOS compatibility checks ensures that the AR button will continue to be shown for those WKWebView browsers that have implemented support for AR QuickLook. 

Additionally, this fix also prevents ModelViewer from displaying the AR button for incompatible WKWebView browsers (EG Facebook) which cause errors when trying to display AR.


### Approach

Changes have been made to `constants.ts`, specifically the logic for determining the value of `IS_AR_QUICKLOOK_CANDIDATE`.

If the browser is Safari proper, and `a.relList.supports("ar")` is true, then it will pass, and ModelViewer will display the AR button and allow opening AR.

If the browser is running as a WKWebView, the code checks the User-Agent string for known browsers with AR QuickLook compatibility, and if found, will pass, and ModelViewer will display the AR button.

All other browsers will, by default, fail and ModelViewer will not display the AR button.


### Demo

An example of ModelViewer compiled with this code change can be found here:

https://model-viewer-ios16-fix.glitch.me/



### Compatibility

The following iOS browsers / apps were tested in iOS15 and iOS16 for both general AR QuickLook compatibility, and for ModelViewer behaviour with this code change.

These browsers were found to support AR QuickLook and with this fix ModelViewer will display an AR button:

- Safari
- Chrome
- Edge
- Firefox
- Google App
- DuckDuckGo
- Twitter (uses SFSafariViewController component for embedded browser)

These browsers were found to not support AR QuickLook and so with this fix, ModelViewer will no longer display an AR button:

- Opera
- Brave
- Facebook
- Instagram
- LinkedIn


If there are additional iOS browsers or Social Apps that are believed to be compatible with AR QuickLook, these will need to be tested and the User-Agent strings added to the codebase. 


### Known Issues

Chrome and Edge browsers do not yet respect fixed scaling when viewing auto generated USDZ blobs, but viewing the auto generated model in AR QuickLook still works. The decision was made to not fail these browsers.

Although Firefox, Google App, DuckDuckGo browsers support viewing USDZ files, they are not yet compatible with opening auto-generated USDZ blobs. Firefox displays the blob name. Google App and DuckDuckGo do nothing. The decision was made to not block those browsers entirely, but it should be kept in mind that users of those browsers would have a broken experience if the site is utilising the auto generated USDZ feature.

Firefox iOS supports viewing AR QuickLook, however, when requesting the desktop version of a site, Firefox iOS drops the unique identifiers from the User-Agent string, meaning that we are unable to detect for the presence of Firefox and allow viewing AR QuickLook. The result is, Firefox iOS users viewing in Desktop mode will be unable to launch AR.
