### PR TITLE
Fixed render scale issue

### DIFF
--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -39,9 +39,9 @@ export interface ContextLostEvent extends Event {
 
 // Between 0 and 1: larger means the average responds faster and is less smooth.
 const DURATION_DECAY = 0.2;
-const LOW_FRAME_DURATION_MS = 18;
-const HIGH_FRAME_DURATION_MS = 26;
-const MAX_AVG_CHANGE_MS = 2;
+const LOW_FRAME_DURATION_MS = 40;
+const HIGH_FRAME_DURATION_MS = 60;
+const MAX_AVG_CHANGE_MS = 5;
 const SCALE_STEPS = [1, 0.79, 0.62, 0.5, 0.4, 0.31, 0.25];
 const DEFAULT_LAST_STEP = 3;
 

--- a/packages/modelviewer.dev/examples/loading/index.html
+++ b/packages/modelviewer.dev/examples/loading/index.html
@@ -421,7 +421,7 @@ self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimize
     reason.textContent = event.detail.reason;
   });
 
-  window.addEventListener('DOMContentLoaded', () => {
+  const setup = () => {
     const minScale = document.querySelector('#min-scale-value');
     // The static API must be queried after the element loads. Note that static properties affect all the <model-vieweer> elements on the page.
     const ModelViewerStatic = customElements.get('model-viewer');
@@ -430,7 +430,9 @@ self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimize
       ModelViewerStatic.minimumRenderScale = event.target.value;
       minScale.textContent = event.target.value;
     });
-  }, {once: true});
+  };
+
+  customElements.whenDefined('model-viewer').then(setup);
 </script>
             </template>
           </example-snippet>

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -488,7 +488,7 @@ modelViewerTexture1.addEventListener("load", () => {
           </div>
           <example-snippet stamp-to="pickMaterialExample" highlight-as="html">
             <template>
-<model-viewer id="pickMaterial" shadow-intensity="1" camera-controls touch-action="pan-y" src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer" scale="0.001 0.001 0.001" alt="A Material Picking Example">
+<model-viewer id="pickMaterial" shadow-intensity="1" camera-controls touch-action="pan-y" disable-tap src="../../shared-assets/models/glTF-Sample-Models/2.0/Buggy/glTF-Binary/Buggy.glb" ar ar-modes="webxr scene-viewer" scale="0.001 0.001 0.001" alt="A Material Picking Example">
 </model-viewer>
 <script type="module">
 const modelViewer = document.querySelector("model-viewer#pickMaterial");

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -72,7 +72,7 @@
           </div>
           <example-snippet stamp-to="cameraOrbit" highlight-as="html">
             <template>
-<model-viewer camera-controls touch-action="pan-y" camera-orbit="45deg 55deg 2.5m" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
+<model-viewer camera-controls touch-action="pan-y" camera-orbit="45deg 55deg 4m" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
             </template>
           </example-snippet>
         </div>
@@ -89,7 +89,7 @@
           </div>
           <example-snippet stamp-to="orbitAndScroll" highlight-as="html">
             <template>
-<model-viewer camera-controls touch-action="pan-y" camera-orbit="calc(-1.5rad + env(window-scroll-y) * 4rad) calc(0deg + env(window-scroll-y) * 180deg) calc(3m - env(window-scroll-y) * 1.5m)" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
+<model-viewer camera-controls touch-action="pan-y" camera-orbit="calc(-1.5rad + env(window-scroll-y) * 4rad) calc(0deg + env(window-scroll-y) * 180deg) calc(5m - env(window-scroll-y) * 10m)" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut"></model-viewer>
             </template>
           </example-snippet>
         </div>
@@ -233,7 +233,7 @@
           </div>
           <example-snippet stamp-to="turnSkybox" highlight-as="html">
             <template>
-<model-viewer id="envlight-demo" camera-controls touch-action="pan-y" oncontextmenu="return false;" src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf"  skybox-image="../../shared-assets/environments/spruit_sunrise_1k_HDR.hdr" alt="A 3D model of a damaged helmet"></model-viewer>
+<model-viewer id="envlight-demo" camera-controls touch-action="pan-y" disable-pan oncontextmenu="return false;" src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF/DamagedHelmet.gltf"  skybox-image="../../shared-assets/environments/spruit_sunrise_1k_HDR.hdr" alt="A 3D model of a damaged helmet"></model-viewer>
 
 <script type="module">
   const modelViewer = document.querySelector("#envlight-demo");


### PR DESCRIPTION
I found a situation where when scrolling rapidly, causing switches between the multi-canvas and single canvas paths as well as render scale changes, we would sometimes get a blink of the wrong-sized canvas, and sometimes even get stuck in the single-canvas mode with the canvas scaled incorrectly. It's been fixed by removing some if statements to ensure the `canvas3d` is always rescaled whenever the other canvas is rescaled. I also refactored the code to make it more readable, but the change is actually quite small.

I also updated the frame rate targets to rescale between 15 and 25 fps, as this still feels pretty responsive and it doesn't seem worth sacrificing pixel density yet. This is partly because I found desktop Safari seems to target 40 fps when taxed instead of 60, which was causing us to downscale the render even though it didn't help frame rate at all. 

I also have some minor updates to the examples to make them look nicer and work better. 