### PR TITLE
Remove preload event

### DIFF
--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -573,24 +573,26 @@ export default class ModelViewerElementBase extends ReactiveElement {
    * attribute.
    */
   async[$updateSource]() {
-    if (this.loaded || !this[$shouldAttemptPreload]()) {
+    const scene = this[$scene];
+    if (this.loaded || !this[$shouldAttemptPreload]() ||
+        this.src === scene.url) {
       return;
     }
 
     if (this.generateSchema) {
-      this[$scene].updateSchema(this.src);
+      scene.updateSchema(this.src);
     }
     this[$updateStatus]('Loading');
     // If we are loading a new model, we need to stop the animation of
     // the current one (if any is playing). Otherwise, we might lose
     // the reference to the scene root and running actions start to
     // throw exceptions and/or behave in unexpected ways:
-    this[$scene].stopAnimation();
+    scene.stopAnimation();
 
     const updateSourceProgress = this[$progressTracker].beginActivity();
     const source = this.src;
     try {
-      const srcUpdated = this[$scene].setSource(
+      const srcUpdated = scene.setSource(
           source,
           (progress: number) =>
               updateSourceProgress(clamp(progress, 0, 1) * 0.95));
@@ -612,10 +614,6 @@ export default class ModelViewerElementBase extends ReactiveElement {
           });
         });
       });
-
-
-      const detail = {url: source};
-      this.dispatchEvent(new CustomEvent('preload', {detail}));
     } catch (error) {
       this.dispatchEvent(new CustomEvent(
           'error', {detail: {type: 'loadfailure', sourceError: error}}));

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -569,8 +569,7 @@ export default class ModelViewerElementBase extends ReactiveElement {
 
   /**
    * Parses the element for an appropriate source URL and
-   * sets the views to use the new model based off of the `preload`
-   * attribute.
+   * sets the views to use the new model based.
    */
   async[$updateSource]() {
     const scene = this[$scene];

--- a/packages/model-viewer/src/test/features/loading-spec.ts
+++ b/packages/model-viewer/src/test/features/loading-spec.ts
@@ -53,16 +53,11 @@ suite('Loading', () => {
 
   test('does not load when hidden from render tree', async () => {
     let loadDispatched = false;
-    let preloadDispatched = false;
     const loadHandler = () => {
       loadDispatched = true;
     };
-    const preloadHandler = () => {
-      preloadDispatched = true;
-    };
 
     element.addEventListener('load', loadHandler);
-    element.addEventListener('preload', preloadHandler);
 
     element.style.display = 'none';
 
@@ -75,10 +70,8 @@ suite('Loading', () => {
     await timePasses(500);  // Arbitrary time to allow model to load
 
     element.removeEventListener('load', loadHandler);
-    element.removeEventListener('preload', preloadHandler);
 
     expect(loadDispatched).to.be.false;
-    expect(preloadDispatched).to.be.false;
   });
 
   suite('load', () => {
@@ -162,29 +155,22 @@ suite('Loading', () => {
 
   suite('loading', () => {
     suite('src changes quickly', () => {
-      test('eventually notifies that current src is preloaded', async () => {
+      test('eventually notifies that current src is loaded', async () => {
         element.loading = 'eager';
         element.src = CUBE_GLB_PATH;
 
-        await timePasses();
+        const loadCubeEvent =
+            waitForEvent(element, 'load') as Promise<CustomEvent>;
 
-        let preloadEvent = null;
-        const onPreload = (event: CustomEvent) => {
-          if (event.detail.url === HORSE_GLB_PATH) {
-            preloadEvent = event;
-          }
-        };
-        element.addEventListener<any>('preload', onPreload);
+        await timePasses();
 
         element.src = HORSE_GLB_PATH;
 
-        await until(() => element.loaded);
+        const loadCube = await loadCubeEvent;
+        const loadHorse = await waitForEvent(element, 'load') as CustomEvent;
 
-        await timePasses();
-
-        element.removeEventListener<any>('preload', onPreload);
-
-        expect(preloadEvent).to.be.ok;
+        expect(loadCube.detail.url).to.be.eq(CUBE_GLB_PATH);
+        expect(loadHorse.detail.url).to.be.eq(HORSE_GLB_PATH);
       });
     });
 

--- a/packages/model-viewer/src/test/three-components/ModelScene-spec.ts
+++ b/packages/model-viewer/src/test/three-components/ModelScene-spec.ts
@@ -44,15 +44,6 @@ suite('ModelScene', () => {
     document.body.removeChild(element);
   });
 
-  suite('setModelSource', () => {
-    test('fires a model-load event when loaded', async function() {
-      let fired = false;
-      scene.addEventListener('model-load', () => fired = true);
-      await scene.setSource(assetPath('models/Astronaut.glb'));
-      expect(fired).to.be.ok;
-    });
-  });
-
   suite('with a model', () => {
     setup(async () => {
       await scene.setSource(assetPath('models/Astronaut.glb'));

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -231,7 +231,7 @@ export class ARRenderer extends EventDispatcher {
 
     this.oldTarget.copy(scene.getTarget());
 
-    scene.addEventListener('model-load', this.onUpdateScene);
+    scene.element.addEventListener('load', this.onUpdateScene);
 
     const radians = HIT_ANGLE_DEG * Math.PI / 180;
     const ray = this.placeOnWall === true ?
@@ -350,7 +350,7 @@ export class ARRenderer extends EventDispatcher {
       scene.setTarget(point.x, point.y, point.z);
       scene.xrCamera = null;
 
-      scene.removeEventListener('model-load', this.onUpdateScene);
+      scene.element.removeEventListener('load', this.onUpdateScene);
       scene.orientHotspots(0);
       element.requestUpdate('cameraTarget');
       element.requestUpdate('maxCameraOrbit');

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -204,8 +204,6 @@ export class ModelScene extends Scene {
 
       this.boundingSphere.radius = framingInfo.framedRadius;
       this.idealAspect = framingInfo.fieldOfViewAspect;
-
-      this.dispatchEvent({type: 'model-load', url: this.url});
       return;
     }
 
@@ -272,7 +270,6 @@ export class ModelScene extends Scene {
 
     this.updateShadow();
     this.setShadowIntensity(this.shadowIntensity);
-    this.dispatchEvent({type: 'model-load', url: this.url});
   }
 
   reset() {

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -221,11 +221,6 @@
         "description": "Fires when the poster has fully transitioned away. Additional delay from the \"load\" event can be caused by the renderer compiling its shaders."
       },
       {
-        "name": "preload",
-        "htmlName": "preload",
-        "description": "When <span class='attribute'>loading=\"eager\"</span> this event is fired when preloading is done."
-      },
-      {
         "name": "model-visibility",
         "htmlName": "modelVisibility",
         "description": "This event is fired when the visibility of the model changes. When the model is loaded, the element is in the viewport (assuming there is an IntersectionObserver), this event will fire and event.detail.visible will be \"true\"."


### PR DESCRIPTION
Fixes #3800

This removes the `preload` event, as this is entirely duplicate of the `load` event now. It also refactors and further simplifies our internal loading logic, fixing some bugs like a black blink on first render with a custom environment map due to the poster being dismissed before the lighting was loaded. Also fixes the `load` event being dispatched multiple times for a given `src` and improves performance by ensuring everything is loaded before the first render happens so we don't have to compile the shaders two different ways. 