### PR TITLE
Default to USDZ autogeneration on iOS AR

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -32,7 +32,7 @@ export type ARMode = 'quick-look'|'scene-viewer'|'webxr'|'none';
 const deserializeARModes = enumerationDeserializer<ARMode>(
     ['quick-look', 'scene-viewer', 'webxr', 'none']);
 
-const DEFAULT_AR_MODES = 'webxr scene-viewer';
+const DEFAULT_AR_MODES = 'webxr scene-viewer quick-look';
 
 const ARMode: {[index: string]: ARMode} = {
   QUICK_LOOK: 'quick-look',

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -282,12 +282,12 @@
       {
         "name": "ar-modes",
         "htmlName": "arModes",
-        "description": "A prioritized list of the types of AR experiences to enable. Allowed values are \"webxr\", to launch the AR experience in the browser, \"scene-viewer\", to launch the <a href=\"https://developers.google.com/ar/develop/java/scene-viewer\">Scene Viewer</a> app, \"quick-look\", to launch the iOS Quick Look app. You can specify any number of modes separated by whitespace. Note that the presence of an ios-src will enable quick-look by itself; specifying quick-look here allows us to generate a USDZ on the fly rather than downloading a separate ios-src file.",
+        "description": "A prioritized list of the types of AR experiences to enable. Allowed values are \"webxr\", to launch the AR experience in the browser, \"scene-viewer\", to launch the <a href=\"https://developers.google.com/ar/develop/java/scene-viewer\">Scene Viewer</a> app, \"quick-look\", to launch the iOS Quick Look app. You can specify any number of modes separated by whitespace. Including quick-look here without an ios-src (our default) will generate a USDZ on the fly rather than downloading a separate ios-src file.",
         "links": [
           "<a href=\"../examples/augmentedreality/\">Related examples</a>"
         ],
         "default": {
-          "default": "webxr scene-viewer",
+          "default": "webxr scene-viewer quick-look",
           "options": "prioritized list possible AR modes: webxr, scene-viewer, and quick-look"
         }
       },
@@ -318,7 +318,7 @@
       {
         "name": "ios-src",
         "htmlName": "iosSrc",
-        "description": "The url to a <a href=\"https://graphics.pixar.com/usd/docs/Usdz-File-Format-Specification.html\">USDZ</a> model which will be used on <a href=\"https://www.apple.com/ios/augmented-reality/\">supported iOS 12+ devices</a> via <a href=\"https://developer.apple.com/videos/play/wwdc2018/603/\">AR Quick Look</a> on Safari. The presence of this attribute will automatically enable the quick-look ar-mode, however it is no longer necessary. If instead the quick-look ar-mode is specified and ios-src is not specified, then we will generate a USDZ on the fly when the AR button is pressed. This means modifications via the scene-graph API will now be reflected in Quick Look. However, USDZ generation is not perfect, for instance animations are not yet supported, so in some cases supplying ios-src may give better results.",
+        "description": "The url to a <a href=\"https://graphics.pixar.com/usd/docs/Usdz-File-Format-Specification.html\">USDZ</a> model which will be used on <a href=\"https://www.apple.com/ios/augmented-reality/\">supported iOS 12+ devices</a> via <a href=\"https://developer.apple.com/videos/play/wwdc2018/603/\">AR Quick Look</a> on Safari. The presence of this attribute will automatically enable the quick-look ar-mode, however it is no longer necessary. If instead the quick-look ar-mode is specified and ios-src is not specified (the default), then we will generate a USDZ on the fly when the AR button is pressed. This means modifications via the scene-graph API will now be reflected in Quick Look. However, USDZ generation is not perfect, for instance animations are not yet supported, so in some cases supplying ios-src may give better results.",
         "links": [
           "<a href=\"../examples/augmentedreality/#ar\"><span class='attribute'>ios-src</span> example</a>"
         ]

--- a/packages/modelviewer.dev/examples/animation/index.html
+++ b/packages/modelviewer.dev/examples/animation/index.html
@@ -56,7 +56,7 @@
           </div>
           <example-snippet stamp-to="autoplay" highlight-as="html">
             <template>
-<model-viewer camera-controls touch-action="pan-y" autoplay ar shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
+<model-viewer camera-controls touch-action="pan-y" autoplay ar ar-modes="webxr scene-viewer" shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
             </template>
           </example-snippet>
         </div>
@@ -73,7 +73,7 @@
           </div>
           <example-snippet stamp-to="selectingAnimations" highlight-as="html">
             <template>
-<model-viewer camera-controls touch-action="pan-y" autoplay animation-name="Running" ar shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animate 3D model of a robot"></model-viewer>
+<model-viewer camera-controls touch-action="pan-y" autoplay animation-name="Running" ar ar-modes="webxr scene-viewer" shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animate 3D model of a robot"></model-viewer>
             </template>
           </example-snippet>
         </div>
@@ -90,7 +90,7 @@
           </div>
           <example-snippet stamp-to="controlSpeed" highlight-as="html">
             <template>
-<model-viewer id="change-speed-demo" camera-controls touch-action="pan-y" animation-name="Dance" ar shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animate 3D model of a robot"></model-viewer>
+<model-viewer id="change-speed-demo" camera-controls touch-action="pan-y" animation-name="Dance" ar ar-modes="webxr scene-viewer" shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animate 3D model of a robot"></model-viewer>
 <script type="module">
   const modelViewer = document.querySelector('#change-speed-demo');
   const speeds = [1, 2, 0.5, -1];
@@ -119,7 +119,7 @@
           </div>
           <example-snippet stamp-to="crossFade" highlight-as="html">
             <template>
-<model-viewer id="paused-change-demo" camera-controls touch-action="pan-y" autoplay animation-name="Running" ar shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
+<model-viewer id="paused-change-demo" camera-controls touch-action="pan-y" autoplay animation-name="Running" ar ar-modes="webxr scene-viewer" shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
 <script>
 (() => {
   const modelViewer = document.querySelector('#paused-change-demo');
@@ -146,7 +146,7 @@
           </div>
           <example-snippet stamp-to="paused" highlight-as="html">
             <template>
-<model-viewer id="xfade-demo" camera-controls touch-action="pan-y" animation-name="Running" ar shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
+<model-viewer id="xfade-demo" camera-controls touch-action="pan-y" animation-name="Running" ar ar-modes="webxr scene-viewer" shadow-intensity="1" src="../../shared-assets/models/RobotExpressive.glb" alt="An animated 3D model of a robot"></model-viewer>
 <script>
 (() => {
   const modelViewer = document.querySelector('#xfade-demo');

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -350,7 +350,7 @@
       touch-action="none"
       poster="../../assets/SketchfabModels/ThorAndTheMidgardSerpent.webp"
       ar
-      ar-modes="webxr scene-viewer quick-look"
+     
     >
   <button class="view-button" slot="hotspot-0" 
     data-position="-0.0569m 0.0969m -0.1398m" data-normal="-0.5829775m 0.2863482m -0.7603565m" 

--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -73,15 +73,14 @@
               achieved, as the AR session is still inside of the browser. This also removes the need to redownload the model.
             </p>
             <p>
-              Note that by specifically including <code>quick-look</code> in
-              <code>ar-modes</code>, but not specifying an <code>ios-src</code>,
+              Note that by not specifying an <code>ios-src</code>,
               the USDZ will instead be auto-generated when the user clicks the
               AR button on iOS to launch Quick Look. 
             </p>
           </div>
           <example-snippet stamp-to="webXR" highlight-as="html">
             <template>
-<model-viewer src="../../assets/ShopifyModels/Chair.glb" poster="../../assets/ShopifyModels/Chair.webp" shadow-intensity="1" ar ar-modes="webxr scene-viewer quick-look" camera-controls touch-action="pan-y" alt="A 3D model carousel">
+<model-viewer src="../../assets/ShopifyModels/Chair.glb" poster="../../assets/ShopifyModels/Chair.webp" shadow-intensity="1" ar camera-controls touch-action="pan-y" alt="A 3D model carousel">
   
   <button slot="ar-button" id="ar-button">
     View in your space
@@ -283,12 +282,11 @@
                 <code>xr-spatial-tracking</code></a> policy.
             </p>
             <p>
-              In this example an <code>ios-src</code> attribute is specified,
-              which enables Quick Look on iOS even if it is not specified in
-              <code>ar-modes</code>. This requires an extra download, but can be
-              useful if the auto-generated USDZ is not adequate (for instance it
-              does not support animations yet). Also, this source can be either
-              a .usdz or a .reality file.
+              In this example an <code>ios-src</code> attribute is specified.
+              This requires an extra download, but can be useful if the
+              auto-generated USDZ is not adequate (for instance it does not
+              support animations yet). Also, this source can be either a .usdz
+              or a .reality file.
             </p>
             <p>
               Additionally, <code>ar-scale="fixed"</code> is used to prevent the
@@ -365,7 +363,7 @@
           </div>
           <example-snippet stamp-to="wall" highlight-as="html">
             <template>
-<model-viewer src="../../assets/boom_2_.glb" ar ar-placement="wall" ar-modes="webxr scene-viewer quick-look" camera-controls touch-action="pan-y" alt="A 3D model of some wall art"></model-viewer>
+<model-viewer src="../../assets/boom_2_.glb" ar ar-placement="wall" camera-controls touch-action="pan-y" alt="A 3D model of some wall art"></model-viewer>
             </template>
           </example-snippet>
 
@@ -384,7 +382,7 @@
           </div>
           <example-snippet stamp-to="customButton" highlight-as="html">
             <template>
-<model-viewer ar ar-modes="webxr scene-viewer quick-look" camera-controls touch-action="pan-y" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
+<model-viewer ar camera-controls touch-action="pan-y" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
   <button slot="ar-button" style="background-color: white; border-radius: 4px; border: none; position: absolute; top: 16px; right: 16px; ">
       👋 Activate AR
   </button>
@@ -414,7 +412,7 @@
               <template>
 <div class="demo" style="background: linear-gradient(#ffffff, #ada996); overflow-x: hidden;">
   <span style="position: absolute; text-align: center; font-size: 100px; line-height: 100px; left: 50%; transform: translateX(-50%);">Background<br>is visible<br>through<br>transparent<br>objects.</span>
-  <model-viewer camera-controls touch-action="pan-y" src="../../shared-assets/models/glTF-Sample-Models/2.0/ToyCar/glTF-Binary/ToyCar.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D transparency test" style="background-color: unset;"></model-viewer>
+  <model-viewer camera-controls touch-action="pan-y" src="../../shared-assets/models/glTF-Sample-Models/2.0/ToyCar/glTF-Binary/ToyCar.glb" ar alt="A 3D transparency test" style="background-color: unset;"></model-viewer>
 </div>
               </template>
             </example-snippet>

--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -144,7 +144,7 @@
   }
 
   #ar-button {
-    background-image: url(../../assets/ic_view_in_ar_new_googblue_48dp.webp);
+    background-image: url(../../assets/ic_view_in_ar_new_googblue_48dp.png);
     background-repeat: no-repeat;
     background-size: 20px 20px;
     background-position: 12px 50%;

--- a/packages/modelviewer.dev/examples/color.html
+++ b/packages/modelviewer.dev/examples/color.html
@@ -243,7 +243,7 @@
         src="../../shared-assets/models/silver-gold.gltf"
         skybox-image="../../shared-assets/environments/neutral.hdr"
         ar
-        ar-modes="webxr scene-viewer quick-look"
+       
         camera-controls
         alt="3D model of six example material spheres"
       >

--- a/packages/modelviewer.dev/examples/lighthouse.html
+++ b/packages/modelviewer.dev/examples/lighthouse.html
@@ -253,7 +253,7 @@
         interaction-prompt-threshold="0"
         shadow-intensity="1"
         ar
-        ar-modes="webxr scene-viewer quick-look"
+       
         camera-controls
         alt="3D model of a chair with footrest"
       >
@@ -315,7 +315,7 @@
       interaction-prompt-threshold="0"
       shadow-intensity="1"
       ar
-      ar-modes="webxr scene-viewer quick-look"
+     
       camera-controls
       alt="3D model of a countertop mixer"
     >

--- a/packages/modelviewer.dev/examples/lighthouse2.html
+++ b/packages/modelviewer.dev/examples/lighthouse2.html
@@ -249,7 +249,7 @@
         interaction-prompt-threshold="0"
         shadow-intensity="1"
         ar
-        ar-modes="webxr scene-viewer quick-look"
+       
         camera-controls
         generate-schema
         alt="3D model of a chair with footrest"
@@ -300,7 +300,7 @@
       interaction-prompt-threshold="0"
       shadow-intensity="1"
       ar
-      ar-modes="webxr scene-viewer quick-look"
+     
       camera-controls
       generate-schema
       alt="3D model of a countertop mixer"

--- a/packages/modelviewer.dev/examples/loading/index.html
+++ b/packages/modelviewer.dev/examples/loading/index.html
@@ -392,7 +392,7 @@ self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimize
           </div>
           <example-snippet stamp-to="renderScale" highlight-as="html">
             <template>
-<model-viewer id="scale" alt="A 3D model of a toy car" camera-controls touch-action="pan-y" auto-rotate src="../../shared-assets/models/glTF-Sample-Models/2.0/ToyCar/glTF-Binary/ToyCar.glb" ar ar-modes="webxr scene-viewer quick-look">
+<model-viewer id="scale" alt="A 3D model of a toy car" camera-controls touch-action="pan-y" auto-rotate src="../../shared-assets/models/glTF-Sample-Models/2.0/ToyCar/glTF-Binary/ToyCar.glb" ar>
   Reported DPR: <span id="reportedDpr"></span><br/>
   Rendered DPR: <span id="renderedDpr"></span><br/>
   Minimum DPR: <span id="minimumDpr"></span><br/>

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -83,7 +83,7 @@ button {
           </div>
           <example-snippet stamp-to="variants" highlight-as="html">
             <template>
-<model-viewer id="shoe" camera-controls touch-action="pan-y" src="../../shared-assets/models/glTF-Sample-Models/2.0/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a Shoe">
+<model-viewer id="shoe" camera-controls touch-action="pan-y" src="../../shared-assets/models/glTF-Sample-Models/2.0/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb" ar alt="A 3D model of a Shoe">
   <div class="controls">
     <div>Variant: <select id="variant"></select></div>
   </div>
@@ -140,7 +140,7 @@ select.addEventListener('input', (event) => {
           </div>
           <example-snippet stamp-to="transforms" highlight-as="html">
             <template>
-<model-viewer id="transform" orientation="20deg 0 0" shadow-intensity="1" camera-controls touch-action="pan-y" ar ar-modes="webxr scene-viewer quick-look" src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
+<model-viewer id="transform" orientation="20deg 0 0" shadow-intensity="1" camera-controls touch-action="pan-y" ar src="../../shared-assets/models/Astronaut.glb" alt="A 3D model of an astronaut">
   <div class="controls">
     <div>Roll: <input id="roll" value="20" size="3" class="number"> degrees</div>
     <div>Pitch: <input id="pitch" value="0" size="3" class="number"> degrees</div>
@@ -215,7 +215,7 @@ z.addEventListener('input', () => {
           </div>
           <example-snippet stamp-to="changeColor" highlight-as="html">
             <template>
-<model-viewer id="color" camera-controls touch-action="pan-y" interaction-prompt="none" src="../../shared-assets/models/Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of an astronaut">
+<model-viewer id="color" camera-controls touch-action="pan-y" interaction-prompt="none" src="../../shared-assets/models/Astronaut.glb" ar alt="A 3D model of an astronaut">
   <div class="controls", id="color-controls">
     <button data-color="1,0,0,1">Red</button>
     <button data-color="0,1,0,1">Green</button>
@@ -259,7 +259,7 @@ document.querySelector('#color-controls').addEventListener('click', (event) => {
           </div>
           <example-snippet stamp-to="changeMaterial" highlight-as="html">
             <template>
-<model-viewer id="sphere" camera-controls touch-action="pan-y" interaction-prompt="none" src="../../shared-assets/models/reflective-sphere.gltf" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a sphere">
+<model-viewer id="sphere" camera-controls touch-action="pan-y" interaction-prompt="none" src="../../shared-assets/models/reflective-sphere.gltf" ar alt="A 3D model of a sphere">
   <div class="controls">
     <div>
       <p>Metalness: <span id="metalness-value"></span></p>
@@ -317,7 +317,7 @@ modelViewerParameters.addEventListener("load", (ev) => {
           </div>
           <example-snippet stamp-to="createTexturesExample" highlight-as="html">
             <template>
-<model-viewer id="duck" camera-controls touch-action="pan-y" src="../../shared-assets/models/glTF-Sample-Models/2.0/Duck/glTF-Binary/Duck.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a duck">
+<model-viewer id="duck" camera-controls touch-action="pan-y" src="../../shared-assets/models/glTF-Sample-Models/2.0/Duck/glTF-Binary/Duck.glb" ar alt="A 3D model of a duck">
   <div class="controls">
       <p>Normals</p>
       <select id="normals2">
@@ -386,7 +386,7 @@ modelViewerTexture.addEventListener("load", () => {
           </div>
           <example-snippet stamp-to="swapTextures" highlight-as="html">
             <template>
-<model-viewer id="helmet" camera-controls touch-action="pan-y" src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb" ar ar-modes="webxr scene-viewer quick-look" alt="A 3D model of a helmet">
+<model-viewer id="helmet" camera-controls touch-action="pan-y" src="../../shared-assets/models/glTF-Sample-Models/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb" ar alt="A 3D model of a helmet">
   <div class="controls">
     <div>
       <p>Diffuse</p>

--- a/packages/modelviewer.dev/examples/stagingandcameras/index.html
+++ b/packages/modelviewer.dev/examples/stagingandcameras/index.html
@@ -156,7 +156,7 @@
           </div>
           <example-snippet stamp-to="defaultTarget" highlight-as="html">
             <template>
-<model-viewer camera-controls touch-action="pan-y" auto-rotate src="../../shared-assets/models/odd-shape-labeled.glb" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1" ar ar-modes="webxr scene-viewer quick-look"></model-viewer>
+<model-viewer camera-controls touch-action="pan-y" auto-rotate src="../../shared-assets/models/odd-shape-labeled.glb" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1" ar></model-viewer>
             </template>
           </example-snippet>
         </div>
@@ -173,7 +173,7 @@
           </div>
           <example-snippet stamp-to="cameraTarget" highlight-as="html">
             <template>
-<model-viewer camera-controls touch-action="pan-y" camera-target="0m 0m 0m" auto-rotate src="../../shared-assets/models/odd-shape-labeled.glb" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1" ar ar-modes="webxr scene-viewer quick-look"></model-viewer>
+<model-viewer camera-controls touch-action="pan-y" camera-target="0m 0m 0m" auto-rotate src="../../shared-assets/models/odd-shape-labeled.glb" alt="An abstract 3D model with labeled origin and center" shadow-intensity="1" ar></model-viewer>
             </template>
           </example-snippet>
         </div>
@@ -335,7 +335,7 @@
     background-color: rgba(0, 0, 0, 0.7);
   }
 </style>
-<model-viewer id="prompt-demo" camera-controls touch-action="pan-y" interaction-prompt="none" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" shadow-intensity="1" ar ar-modes="webxr scene-viewer quick-look">
+<model-viewer id="prompt-demo" camera-controls touch-action="pan-y" interaction-prompt="none" src="../../shared-assets/models/NeilArmstrong.glb" alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" shadow-intensity="1" ar>
   <div class="dot" slot="finger0"></div>
   <div class="dot" slot="finger1"></div>
 </model-viewer>

--- a/packages/modelviewer.dev/examples/twitter/generator.html
+++ b/packages/modelviewer.dev/examples/twitter/generator.html
@@ -136,7 +136,7 @@
         but you can also specify <code>style</code> and put all of your desired CSS on the value side.</p>
 
     <p>By default, this player sets the following attributes: <code>
-      shadow-intensity="1" autoplay ar ar-modes="webxr scene-viewer quick-look" camera-controls auto-rotate
+      shadow-intensity="1" autoplay ar camera-controls auto-rotate
       interaction-prompt-threshold="1500"</code>.</p>
 
     <button id="download">Download Poster & Thumbnail</button>

--- a/packages/modelviewer.dev/examples/twitter/player.html
+++ b/packages/modelviewer.dev/examples/twitter/player.html
@@ -64,7 +64,7 @@
     id="mv"
     shadow-intensity="1"
     autoplay
-    ar-modes="webxr scene-viewer quick-look"
+   
     camera-controls
     auto-rotate
     interaction-prompt-threshold="1500"

--- a/packages/modelviewer.dev/index.html
+++ b/packages/modelviewer.dev/index.html
@@ -71,7 +71,7 @@
 <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
 
 <!-- Use it like any other HTML element -->
-<model-viewer alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" src="shared-assets/models/NeilArmstrong.glb" ar ar-modes="webxr scene-viewer quick-look" environment-image="shared-assets/environments/moon_1k.hdr" poster="shared-assets/models/NeilArmstrong.webp" shadow-intensity="1" camera-controls touch-action="pan-y"></model-viewer>
+<model-viewer alt="Neil Armstrong's Spacesuit from the Smithsonian Digitization Programs Office and National Air and Space Museum" src="shared-assets/models/NeilArmstrong.glb" ar environment-image="shared-assets/environments/moon_1k.hdr" poster="shared-assets/models/NeilArmstrong.webp" shadow-intensity="1" camera-controls touch-action="pan-y"></model-viewer>
                 </template>
               </example-snippet>
             </div>

--- a/packages/modelviewer.dev/src/docs-and-examples/create-html.ts
+++ b/packages/modelviewer.dev/src/docs-and-examples/create-html.ts
@@ -316,9 +316,6 @@ export function createExamplesHeader() {
   const outer = document.getElementById('toggle');
   outer!.innerHTML += `
 <h1 class="tab" onclick="toggleSidebar()">&#9776</h1>
-<div class="exampleHeader">
-  <h1>Examples</h1>
-</div>
 `;
 }
 

--- a/packages/modelviewer.dev/styles/examples.css
+++ b/packages/modelviewer.dev/styles/examples.css
@@ -19,7 +19,7 @@
 :root {
   --color-red: #ff5252;
   --font-monospace: 'Roboto Mono', monospace;
-  --border-style: 1px solid rgba(0,0,0,.15);
+  --border-style: 1px solid rgba(0, 0, 0, .15);
   --grouping-title-margin-top: 40px;
   --snippet-offset: 20px -20px;
   --pre-padding: 16px 20px;
@@ -36,7 +36,7 @@
   --neg-sidebar-width: 0px;
   --sidebar-width: 300px;
   --sidebar-speed: .15s;
-  --border-style-dark: 1px solid rgba(0,0,0,.5);
+  --border-style-dark: 1px solid rgba(0, 0, 0, .5);
 }
 
 .sidebar {
@@ -83,21 +83,8 @@
   z-index: 1;
 }
 
-.exampleHeader {
-  background-color: rgba(246, 246, 246, 0.9);
-  padding: 10px 20px 10px 40px;
-  width: 100%;
-  position: fixed;
-  top: 0;
-  overflow: hidden;
-  margin-left: var(--sidebar-width);
-  white-space: nowrap;
-  font-size: .8em;
-  z-index: 1008;
-  visibility: hidden;
-}
-
 .tab {
+  background-color: rgba(246, 246, 246);
   position: fixed;
   top: 5px;
   left: 10px;
@@ -116,7 +103,7 @@ body {
   font-family: 'Rubik', sans-serif;
   font-size: 16px;
   line-height: 24px;
-  color: rgba(0,0,0,.87);
+  color: rgba(0, 0, 0, .87);
   margin: 0;
   padding: 0;
   font-weight: 400;
@@ -126,14 +113,17 @@ body {
 * {
   box-sizing: border-box;
 }
+
 a {
   cursor: pointer;
   text-decoration: none;
   color: var(--color-red);
 }
+
 b {
   font-weight: 500;
 }
+
 #button-github {
   background-color: white;
   border-radius: 100%;
@@ -142,6 +132,7 @@ b {
   top: 12px;
   z-index: 1000;
 }
+
 #sticky-shortcut {
   padding: 0 20px;
   margin-top: -60px;
@@ -155,7 +146,8 @@ b {
   overflow: hidden;
   border-bottom: var(--border-style);
 }
-#sticky-shortcut > div {
+
+#sticky-shortcut>div {
   margin-right: 12px;
   white-space: nowrap;
 }
@@ -167,25 +159,30 @@ table {
   border-collapse: collapse;
   width: 100%;
 }
+
 table.browser-support {
   margin-bottom: 32px;
 }
+
 table.browser-support td:first-child,
 table.browser-support th:first-child {
   display: block;
   line-height: 24px;
   padding: 12px 2px 8px 0;
-  text-align:left;
-  flex:2;
+  text-align: left;
+  flex: 2;
   min-width: 92px;
 }
+
 table.browser-support tr {
   display: flex;
   border-top: var(--border-style);
 }
+
 table.browser-support tr:first-child {
   border-top: none;
 }
+
 table.browser-support th,
 table.browser-support td {
   flex: 1;
@@ -197,16 +194,20 @@ table.browser-support td {
   justify-content: center;
   align-items: center;
 }
+
 table.browser-support th {
-  color: rgba(0,0,0,.54);
+  color: rgba(0, 0, 0, .54);
 }
+
 table.browser-support td {
   font-weight: 500;
 }
+
 table.browser-support img {
   width: 24px;
   height: 24px;
 }
+
 .browser-support-desc {
   max-width: 420px;
   position: relative;
@@ -217,65 +218,84 @@ table.browser-support img {
 #browser-support-icon-group {
   margin-top: var(--browser-support-icons-margin-top);
 }
+
 .zero-interaction {
   pointer-events: none !important;
 }
+
 .icon-desc {
   padding: 8px 0;
   width: 50%;
   min-width: 240px;
   float: left;
 }
-.icon-desc > * {
+
+.icon-desc>* {
   margin-right: 16px;
   display: inline-block;
   vertical-align: middle;
 }
+
 .size-24 {
   width: 24px;
   height: 24px;
 }
+
 .logo-chrome {
   content: url("https://github.com/alrra/browser-logos/raw/master/src/chrome/chrome_48x48.png");
 }
+
 .logo-canary {
   content: url("https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome-canary/chrome-canary_48x48.png");
 }
+
 .logo-safari {
   content: url("https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png");
 }
+
 .logo-firefox {
   content: url("https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png");
 }
+
 .logo-edge {
   content: url("https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png");
 }
+
 .logo-ie {
   content: url("https://raw.githubusercontent.com/alrra/browser-logos/master/src/archive/internet-explorer_9-11/internet-explorer_9-11_48x48.png");
 }
+
 .logo-samsung {
   content: url("https://raw.githubusercontent.com/alrra/browser-logos/master/src/samsung-internet/samsung-internet_48x48.png");
 }
+
 .icon-check {
   opacity: .6;
   content: url("https://www.gstatic.com/images/icons/material/system/2x/done_black_24dp.png");
 }
+
 .icon-warning {
   opacity: .6;
   content: url("https://www.gstatic.com/images/icons/material/system/2x/assignment_turned_in_black_24dp.png");
 }
+
 .icon-na {
   opacity: .6;
   content: url("https://www.gstatic.com/images/icons/material/system/2x/not_interested_black_24dp.png");
 }
+
 .icon-flag {
   opacity: .5;
   content: url("https://www.gstatic.com/images/icons/material/system/2x/flag_black_24dp.png");
 }
 
-h1, h2, h3, h4 {
+h1,
+h2,
+h3,
+h4 {
   font-weight: 400;
 }
+
 h1 {
   /* font-weight: 500; */
   white-space: nowrap;
@@ -284,28 +304,33 @@ h1 {
   margin-bottom: .12em;
   margin-top: 0;
 }
+
 h2 {
   font-size: 1.72em;
   line-height: 1.32em;
   margin-top: .12em;
   margin-bottom: .12em;
 }
+
 h3 {
   font-size: 1.4em;
   line-height: 1.34em;
   margin-top: .12em;
   margin-bottom: .12em;
 }
+
 h4 {
   font-size: 1.2em;
   line-height: 1.4em;
   margin-top: .1em;
   margin-bottom: .1em;
 }
+
 h1 span {
   display: inline-block;
-  transform:translate3d(0,3px,0);
+  transform: translate3d(0, 3px, 0);
 }
+
 .content example-snippet {
   display: block;
   margin: var(--snippet-offset);
@@ -319,17 +344,20 @@ h1 span {
 .footer {
   background: #eee;
   padding: 40px 40px 40px 40px;
-  color: rgba(0,0,0,.54);
+  color: rgba(0, 0, 0, .54);
 }
+
 .footer ul {
   margin-top: 0;
   padding-left: 0px;
   margin-bottom: 0;
   list-style: none;
 }
+
 .font-medium {
   font-weight: 500;
 }
+
 p {
   margin-top: .25em;
   margin-bottom: .25em;
@@ -344,6 +372,7 @@ model-viewer:focus {
   margin-top: 8px;
   max-width: 480px;
 }
+
 #intro div {
   font-weight: 500;
 }
@@ -355,6 +384,7 @@ model-viewer:focus {
   grid-template-columns: 50% 50%;
   grid-template-areas: "content demo";
 }
+
 .sample {
   border-bottom: var(--border-style);
 }
@@ -371,13 +401,14 @@ model-viewer:focus {
   box-sizing: border-box;
 }
 
-.sample > .demo {
+.sample>.demo {
   height: 100vh;
 }
 
 .demo-title {
   padding: var(--demo-title-padding);
 }
+
 .demo-title:before {
   background: #222;
   height: 2px;
@@ -386,7 +417,9 @@ model-viewer:focus {
   display: block;
   margin-bottom: 16px;
 }
-.demo-title + h4, h4 + h4 {
+
+.demo-title+h4,
+h4+h4 {
   margin-top: -24px;
   margin-bottom: 40px;
 }
@@ -412,10 +445,11 @@ model-viewer:focus {
   right: 0;
   z-index: 1000;
   margin: 16px;
-  background-color: rgba(0,0,0,.5);
+  background-color: rgba(0, 0, 0, .5);
 }
+
 .content pre {
-  background-color: rgba(0,0,0,.04);
+  background-color: rgba(0, 0, 0, .04);
 }
 
 pre,
@@ -435,15 +469,19 @@ code {
   background-position: 50% 50%;
   opacity: .87;
 }
+
 .icon-button:hover {
   opacity: 1;
 }
+
 .icon-github {
   background-image: url(../assets/ic_github_black_24dp.svg);
 }
+
 .icon-modelviewer {
   background-image: url(../assets/ic_modelviewer_red.svg);
 }
+
 .icon-modelviewer-black {
   background-image: url(../assets/ic_modelviewer.svg);
 }
@@ -452,11 +490,13 @@ code {
   display: flex;
   align-items: center;
   margin-bottom: 6px;
-  color: rgba(0,0,0,.87);
+  color: rgba(0, 0, 0, .87);
 }
+
 .lockup h1 {
   margin: 0;
 }
+
 .lockup .icon-button {
   margin-left: -4px;
   margin-right: 8px;
@@ -473,6 +513,7 @@ code {
   display: flex;
   align-items: center;
 }
+
 #button-home .icon-modelviewer {
   margin-right: 6px;
   margin-left: -6px;
@@ -484,6 +525,7 @@ code {
   height: 100%;
   background-color: #eee;
 }
+
 .content {
   grid-area: content;
   position: relative;
@@ -515,6 +557,7 @@ code {
   margin-left: auto;
   margin-right: auto;
 }
+
 .heading {
   max-width: 760px;
 }
@@ -529,6 +572,7 @@ code {
 .no-show {
   display: none;
 }
+
 paper-button {
   margin-top: 16px;
   font-weight: 500;
@@ -552,13 +596,16 @@ paper-button {
   grid-row-gap: 8px;
   list-style: none;
 }
+
 #list-example li {
   padding-right: 20px;
   max-width: 480px;
 }
+
 #list-example p {
   margin-top: 2px;
 }
+
 #list-example a {
   margin: 0;
 }
@@ -579,20 +626,23 @@ paper-button {
   list-style: none;
   padding-left: 0;
 }
+
 .list-attribute li {
   display: flex;
   border-bottom: var(--border-style);
   margin-bottom: 14px;
   padding-bottom: 10px;
 }
-.list-attribute li > div {
+
+.list-attribute li>div {
   min-width: 200px;
   flex: 1;
   font-weight: 500;
   padding-right: 16px;
 }
-.list-attribute li > p,
-.list-attribute li > span {
+
+.list-attribute li>p,
+.list-attribute li>span {
   flex: 2;
   margin: 0;
 }
@@ -604,6 +654,7 @@ paper-button {
   grid-gap: 0;
   grid-template: 1fr 1fr / 1fr 1fr;
 }
+
 .grid model-viewer {
   width: 100%;
   height: 100%;
@@ -683,8 +734,8 @@ paper-button {
 }
 
 .eg-image {
-    max-width: 20vw;
-    display: block;
+  max-width: 20vw;
+  display: block;
 }
 
 @media only screen and (min-width: 1664px) {
@@ -692,23 +743,27 @@ paper-button {
     --snippet-offset: 40px -40px;
     --pre-padding: 28px 40px;
   }
+
   body {
     font-size: 18px;
     line-height: 26px;
   }
+
   .demo pre {
     margin: 16px auto;
   }
-    .eg-image {
-        max-width: 20vw;
-        display: block;
-    }
+
+  .eg-image {
+    max-width: 20vw;
+    display: block;
+  }
 }
 
 @media only screen and (max-width: 1280px) {
   #list-example {
     grid-template-columns: 1fr;
   }
+
   .wrapper {
     margin: 0px 20px;
     padding: 20px;
@@ -739,22 +794,17 @@ paper-button {
   .header {
     padding: 10px 20px 10px 40px;
   }
-  
+
   .tab {
     visibility: visible;
   }
 
-  .exampleHeader {
-    margin-left: 0;
-    visibility: visible;
-  }
-  
-  .examples-container > .sample > #demo-container-1 {
+  .examples-container>.sample>#demo-container-1 {
     margin-top: 75px;
     padding-top: 0px;
   }
-  
-  .sample > .demo {
+
+  .sample>.demo {
     top: 0;
     height: 150vw;
   }
@@ -763,26 +813,32 @@ paper-button {
     font-size: 14px;
     line-height: 22px;
   }
+
   h1 {
     font-size: 1.8em;
     line-height: 1.4em;
   }
+
   h2 {
     font-size: 1.56em;
     line-height: 1.36em;
   }
+
   h3 {
     font-size: 1.2em;
     line-height: 1.48em;
     font-weight: 500;
   }
+
   h4 {
     font-size: 1em;
     line-height: 1.5em;
   }
+
   .lockup {
     margin-bottom: 2px;
   }
+
   .lockup .icon-button {
     margin-left: 0px;
     margin-right: 6px;
@@ -790,46 +846,54 @@ paper-button {
     height: var(--icon-size);
     background-size: var(--icon-size);
   }
+
   #button-github {
     right: 10px;
     bottom: 10px;
     top: auto;
-    box-shadow: 0 0 4px rgba(0,0,0,.2);
+    box-shadow: 0 0 4px rgba(0, 0, 0, .2);
   }
+
   #button-home {
     margin: 0px 0 12px 0;
   }
+
   #header {
     position: relative;
     width: 100%;
   }
+
   #intro {
     margin-bottom: 20px;
   }
 
   body.single-example .demo-title {
-    transform: translate3d(0,-36px,0);
+    transform: translate3d(0, -36px, 0);
   }
 
-  .demo-title + h4 {
+  .demo-title+h4 {
     margin-bottom: 20px;
   }
 
   .grouping-title {
     font-weight: 500;
   }
+
   .wrapper {
     padding: 0 0 20px 0;
   }
+
   .demo {
     position: relative;
     flex-direction: column-reverse;
     background-color: #455A64;
   }
+
   .index {
     width: 48px;
     height: 48px;
   }
+
   .sample {
     display: block;
   }
@@ -838,27 +902,31 @@ paper-button {
     max-width: unset;
     padding-top: 16px;
   }
+
   #list-example {
     margin-top: 12px;
     font-size: 16px;
   }
+
   .list-attribute li {
     flex-direction: column;
     padding-top: 0px;
     margin-bottom: 12px;
   }
-  .list-attribute li > h4 {
+
+  .list-attribute li>h4 {
     padding-top: 10px;
   }
+
   .footer {
     padding: 20px;
   }
 
 
   .eg-image {
-      display: block;
-      margin-left: auto;
-      margin-right: auto;
-      max-width: 50vw;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 50vw;
   }
 }

--- a/packages/space-opera/src/test/snippet_viewer/snippet_viewer_test.ts
+++ b/packages/space-opera/src/test/snippet_viewer/snippet_viewer_test.ts
@@ -38,7 +38,7 @@ describe('snippet viewer test', () => {
     // clang-format off
 
     // Pulled from real DOM of astronaut example.
-    snippetViewer.renderedSnippet = html`<!--?lit$343342268$--><model-viewer src="Astronaut.glb" ar="" ar-modes="webxr scene-viewer quick-look" camera-controls="" poster="poster.webp" shadow-intensity="1" ar-status="not-presenting">
+    snippetViewer.renderedSnippet = html`<!--?lit$343342268$--><model-viewer src="Astronaut.glb" ar="" camera-controls="" poster="poster.webp" shadow-intensity="1" ar-status="not-presenting">
     <!--?lit$128424273$--><!---->
 <div class="progress-bar hide" slot="progress-bar">
 <div class="update-bar"></div>
@@ -53,7 +53,7 @@ View in your space
     // clang-format on
 
     const goldenFormattedHTML =
-        `<model-viewer src="Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" camera-controls poster="poster.webp" shadow-intensity="1">
+        `<model-viewer src="Astronaut.glb" ar camera-controls poster="poster.webp" shadow-intensity="1">
     <div class="progress-bar hide" slot="progress-bar">
         <div class="update-bar"></div>
     </div>
@@ -74,7 +74,7 @@ View in your space
 
     // Pulled from real DOM of astronaut example with a hotspot.
     // hotspot <button> is beteen two comments on the same line
-    snippetViewer.renderedSnippet = html`<!--?lit$128424273$--><model-viewer src="Astronaut.glb" ar="" ar-modes="webxr scene-viewer quick-look" camera-controls="" poster="poster.webp" shadow-intensity="1" ar-status="not-presenting">
+    snippetViewer.renderedSnippet = html`<!--?lit$128424273$--><model-viewer src="Astronaut.glb" ar="" camera-controls="" poster="poster.webp" shadow-intensity="1" ar-status="not-presenting">
     <!--?lit$128424273$--><!----><button class="Hotspot" slot="hotspot-1" data-position="-0.043973778464142396m 1.2075171453793048m 0.29653766978435936m" data-normal="-0.4260645307016329m -0.06968452861538316m 0.9020050344369756m" data-visibility-attribute="visible"><div class="HotspotAnnotation">asdf</div></button><!----><!---->
 <div class="progress-bar hide" slot="progress-bar">
 <div class="update-bar"></div>
@@ -89,7 +89,7 @@ View in your space
     // clang-format on
 
     const goldenFormattedHTML =
-        `<model-viewer src="Astronaut.glb" ar ar-modes="webxr scene-viewer quick-look" camera-controls poster="poster.webp" shadow-intensity="1">
+        `<model-viewer src="Astronaut.glb" ar camera-controls poster="poster.webp" shadow-intensity="1">
     <button class="Hotspot" slot="hotspot-1" data-position="-0.043973778464142396m 1.2075171453793048m 0.29653766978435936m" data-normal="-0.4260645307016329m -0.06968452861538316m 0.9020050344369756m" data-visibility-attribute="visible">
         <div class="HotspotAnnotation">asdf</div>
     </button>


### PR DESCRIPTION
Fixes #3801 

Also removes the examples header from the mobile view of modelviewer.dev, which makes it more like the desktop version and makes the progress bar more visible. 