### PR TITLE
fix iOS model dispose

### DIFF
--- a/packages/model-viewer/src/three-components/GLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/GLTFInstance.ts
@@ -144,7 +144,7 @@ export class GLTFInstance implements GLTF {
             const texture = (material as any)[propertyName];
             if (texture instanceof Texture) {
               const image = texture.source.data;
-              if (image instanceof ImageBitmap) {
+              if (image.close != null) {
                 image.close();
               }
               texture.dispose();


### PR DESCRIPTION
When we hit the modelCacheSize limit and start disposing of models, we were getting an error on iOS 14 because it doesn't support `ImageBitmap`. I didn't realize that `typeof` still requires the feature to be present in order to safely check. 