### PR TITLE
fix adjacent visibility

### DIFF
--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -304,6 +304,9 @@ export default class ModelViewerElementBase extends ReactiveElement {
         // model above the fold, but only when the animated model was completely
         // below. Setting this margin to zero fixed it.
         rootMargin: '0px',
+        // With zero threshold, an element adjacent to but not intersecting the
+        // viewport will be reported as intersecting, which will cause
+        // unnecessary rendering. Any slight positive threshold alleviates this.
         threshold: 0.00001,
       });
     } else {

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -304,7 +304,7 @@ export default class ModelViewerElementBase extends ReactiveElement {
         // model above the fold, but only when the animated model was completely
         // below. Setting this margin to zero fixed it.
         rootMargin: '0px',
-        threshold: 0,
+        threshold: 0.00001,
       });
     } else {
       // If there is no intersection observer, then all models should be visible


### PR DESCRIPTION
The IntersectionObserver by default logs elements that are adjacent to the viewport (zero intersection) as intersecting: https://github.com/w3c/IntersectionObserver/issues/134#issuecomment-224365108

This is a problem for some carousels which have the element in view having the full width: it would cause the invisible neighboring carousel elements to render and steal frame budget. Just a one-line fix, but added tests to catch this subtlety. 