### PR TITLE
Hotspot data query API

### DIFF
--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Matrix3, Matrix4, Vector2, Vector3} from 'three';
+import {Matrix3, Matrix4, Vector3} from 'three';
 
 import ModelViewerElementBase, {$needsRender, $scene, $tick, toVector2D, toVector3D, Vector2D, Vector3D} from '../model-viewer-base.js';
 import {Hotspot, HotspotConfiguration} from '../three-components/Hotspot.js';
@@ -32,7 +32,7 @@ const worldToModelNormal = new Matrix3();
 export declare type HotspotData = {
   readonly position: Vector3D;
   readonly normal: Vector3D;
-  readonly screenPosition: Vector2D;
+  readonly screenPosition: Vector3D;
   readonly facingCamera: boolean;
 }
 
@@ -159,13 +159,14 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       vector.x = (vector.x * widthHalf) + widthHalf;
       vector.y = -(vector.y * heightHalf) + heightHalf;
 
-      const screenPosition = toVector2D(
-        new Vector2(
+      const screenPosition = toVector3D(
+        new Vector3(
           vector.x,
-          vector.y
+          vector.y,
+          vector.z
         ));
 
-      if (!Number.isFinite(screenPosition.u) || !Number.isFinite(screenPosition.v)) {
+      if (!Number.isFinite(screenPosition.x) || !Number.isFinite(screenPosition.y)) {
         return null;
       }
 

--- a/packages/model-viewer/src/features/annotation.ts
+++ b/packages/model-viewer/src/features/annotation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Matrix3, Matrix4} from 'three';
+import {Matrix3, Matrix4, Vector2, Vector3} from 'three';
 
 import ModelViewerElementBase, {$needsRender, $scene, $tick, toVector2D, toVector3D, Vector2D, Vector3D} from '../model-viewer-base.js';
 import {Hotspot, HotspotConfiguration} from '../three-components/Hotspot.js';
@@ -29,8 +29,16 @@ const $removeHotspot = Symbol('removeHotspot');
 const worldToModel = new Matrix4();
 const worldToModelNormal = new Matrix3();
 
+export declare type HotspotData = {
+  readonly position: Vector3D;
+  readonly normal: Vector3D;
+  readonly screenPosition: Vector2D;
+  readonly facingCamera: boolean;
+}
+
 export declare interface AnnotationInterface {
   updateHotspot(config: HotspotConfiguration): void;
+  queryHotspot(name: string): HotspotData | null;
   positionAndNormalFromPoint(pixelX: number, pixelY: number):
       {position: Vector3D, normal: Vector3D, uv: Vector2D|null}|null
 }
@@ -122,6 +130,46 @@ export const AnnotationMixin = <T extends Constructor<ModelViewerElementBase>>(
       hotspot.updatePosition(config.position);
       hotspot.updateNormal(config.normal);
       this[$needsRender]();
+    }
+
+    /**
+     * This method returns in-scene data about a requested hotspot including
+     * its position in screen (canvas) space and its current visibility.
+     */
+    queryHotspot(name: string): HotspotData | null {
+      const hotspot = this[$hotspotMap].get(name);
+      if (hotspot == null) {
+        return null;
+      }
+
+      const position = toVector3D(hotspot.position);
+      const normal = toVector3D(hotspot.normal);
+      const facingCamera = hotspot.facingCamera;
+
+      const scene = this[$scene];
+      const camera = scene.getCamera();
+      const vector = new Vector3();
+
+      vector.setFromMatrixPosition(hotspot.matrixWorld);
+      vector.project(camera);
+
+      const widthHalf = scene.width / 2;
+      const heightHalf = scene.height / 2;
+
+      vector.x = (vector.x * widthHalf) + widthHalf;
+      vector.y = -(vector.y * heightHalf) + heightHalf;
+
+      const screenPosition = toVector2D(
+        new Vector2(
+          vector.x,
+          vector.y
+        ));
+
+      if (!Number.isFinite(screenPosition.u) || !Number.isFinite(screenPosition.v)) {
+        return null;
+      }
+
+      return {position, normal, screenPosition, facingCamera};
     }
 
     /**

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -97,19 +97,19 @@ suite('Annotation', () => {
     });
 
     test('querying it returns valid data', () => {
-      const hotspot = element.queryHotspot('hotspot-1');
 
-      expect(hotspot?.position.toString()).to.equal(toVector3D(new Vector3(1, 1, 1)).toString());
-      expect(hotspot?.normal.toString()).to.equal(toVector3D(new Vector3(0, 0, -1)).toString());
-      expect(hotspot?.facingCamera).to.be.true;
+      // to test querying, place hotspot in the center and verify the screen position is 
+      // half the default width and height (300 x 150) with a depth value of ~1.
+      const defaultDimensions = { width: 300, height: 150 };
+      element.updateHotspot({ name: 'hotspot-1', position: `0m 0m 0m`});
 
-      // Testing the screen space coordinate is contingent on lots of default values
-      // (canvas size, camera position and camera fov).
-      // Just test to see that it's valid.
-      expect(hotspot?.screenPosition?.u).to.satisfy(Number.isFinite);
-      expect(hotspot?.screenPosition?.v).to.satisfy(Number.isFinite);
-      expect(hotspot?.screenPosition?.u).to.satisfy(Number.isFinite);
-      expect(hotspot?.screenPosition?.v).to.satisfy(Number.isFinite);
+      const hotspotData = element.queryHotspot('hotspot-1');
+
+      expect(hotspotData?.screenPosition.x).to.be.closeTo(defaultDimensions.width / 2, 0.0001);
+      expect(hotspotData?.screenPosition.y).to.be.closeTo(defaultDimensions.height / 2, 0.0001);
+      expect(hotspotData?.position.toString()).to.equal(toVector3D(new Vector3(0, 0, 0)).toString());
+      expect(hotspotData?.normal.toString()).to.equal(toVector3D(new Vector3(0, 0, -1)).toString());
+      expect(hotspotData?.facingCamera).to.be.true;
     });
 
     suite('adding a second hotspot with the same name', () => {

--- a/packages/model-viewer/src/test/features/annotation-spec.ts
+++ b/packages/model-viewer/src/test/features/annotation-spec.ts
@@ -16,7 +16,7 @@
 import {Vector3} from 'three';
 
 import {ModelViewerElement} from '../../model-viewer';
-import {$needsRender, $scene, Vector2D, Vector3D} from '../../model-viewer-base';
+import {$needsRender, $scene, toVector3D, Vector2D, Vector3D} from '../../model-viewer-base';
 import {Hotspot} from '../../three-components/Hotspot.js';
 import {ModelScene} from '../../three-components/ModelScene';
 import {timePasses, waitForEvent} from '../../utilities';
@@ -94,6 +94,22 @@ suite('Annotation', () => {
 
     test('creates a corresponding slot', () => {
       expect(sceneContainsHotspot(scene, hotspot)).to.be.true;
+    });
+
+    test('querying it returns valid data', () => {
+      const hotspot = element.queryHotspot('hotspot-1');
+
+      expect(hotspot?.position.toString()).to.equal(toVector3D(new Vector3(1, 1, 1)).toString());
+      expect(hotspot?.normal.toString()).to.equal(toVector3D(new Vector3(0, 0, -1)).toString());
+      expect(hotspot?.facingCamera).to.be.true;
+
+      // Testing the screen space coordinate is contingent on lots of default values
+      // (canvas size, camera position and camera fov).
+      // Just test to see that it's valid.
+      expect(hotspot?.screenPosition?.u).to.satisfy(Number.isFinite);
+      expect(hotspot?.screenPosition?.v).to.satisfy(Number.isFinite);
+      expect(hotspot?.screenPosition?.u).to.satisfy(Number.isFinite);
+      expect(hotspot?.screenPosition?.v).to.satisfy(Number.isFinite);
     });
 
     suite('adding a second hotspot with the same name', () => {

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -755,6 +755,11 @@
         "description": "Updates the position and/or normal of the hotspot associated with <span class='attribute'>slot=\"name\"</span>. The position and normal are given in the same string format as the hotspot attributes <span class='attribute'>data-position</span> and <span class='attribute'>data-normal</span>, which are also in the same format as the <span class='attribute'>camera-target</span> attribute."
       },
       {
+        "name": "queryHotspot(name)",
+        "htmlName": "queryHotspot",
+        "description": "Returns information about the current state of the hotspot corresponding to the hotspot name given as a read-only snapshot: The position, normal, screen (canvas) position and current visibility. The function returns null if no hotspot is found."
+      },
+      {
         "name": "positionAndNormalFromPoint(clientX, clientY)",
         "htmlName": "positionAndNormalFromPoint",
         "description": "Returns the world position, normal and texture coordinate of the point on the mesh corresponding to the input pixel coordinates given relative to the screen. The position and normal are returned as Vector3D, which has a method toString() that outputs a format suitable for putting in a hotspot's <span class='attribute'>data-position</span> and <span class='attribute'>data-normal</span> attributes. The texture coordinate is returned as Vector2D, which has also a own toString() method. The function returns null if no object is hit.",

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -757,7 +757,10 @@
       {
         "name": "queryHotspot(name)",
         "htmlName": "queryHotspot",
-        "description": "Returns information about the current state of the hotspot corresponding to the hotspot name given as a read-only snapshot: The position, normal, screen (canvas) position and current visibility. The function returns null if no hotspot is found."
+        "description": "Returns information about the current state of the hotspot corresponding to the hotspot name given as a read-only snapshot: The position, normal, screen (canvas) position and current visibility. The function returns null if no hotspot is found.",
+        "links": [
+          "<a href=\"../examples/annotations/#overlays\"><span class='attribute'>custom overlays</span> example</a>"
+        ]
       },
       {
         "name": "positionAndNormalFromPoint(clientX, clientY)",

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -757,7 +757,7 @@
       {
         "name": "queryHotspot(name)",
         "htmlName": "queryHotspot",
-        "description": "Returns information about the current state of the hotspot corresponding to the hotspot name given as a read-only snapshot: The position, normal, screen (canvas) position and current visibility. The function returns null if no hotspot is found.",
+        "description": "Returns information about the current state of the hotspot corresponding to the hotspot name given as a read-only snapshot: The position, normal, screen (canvas) position and current visibility. The screen position is represented as a Vector3 with z as the OpenGL depth information. The function returns null if no hotspot is found.",
         "links": [
           "<a href=\"../examples/annotations/#overlays\"><span class='attribute'>custom overlays</span> example</a>"
         ]

--- a/packages/modelviewer.dev/data/examples.json
+++ b/packages/modelviewer.dev/data/examples.json
@@ -142,6 +142,10 @@
         "name": "Dimensions"
       },
       {
+        "htmlId": "overlays",
+        "name": "Custom Overlays"
+      },
+      {
         "htmlId": "cameraViews",
         "name": "Camera Views"
       }

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -321,6 +321,218 @@
     </div>
 
     <div class="sample">
+      <div id="overlays" class="demo"></div>
+      <div class="content">
+        <div class="wrapper">
+          <h4 id="intro"><span class="font-medium">Custom Overlays. </span></h4>
+          <p>
+            Hotspots can be queried to build custom overlays in screen space.
+          </p>
+          <p>
+            For example, by using an SVG canvas and updating the line nodes we can draw rudimentary dimensions lines.
+            Note that this kind of extended functionality cannot support occlusion in the 3d scene as it is drawn on top.
+          </p>
+          <example-snippet stamp-to="overlays" highlight-as="html">
+            <template>
+<style>
+  .dimensionLineContainer{
+    pointer-events: none;
+    position: fixed;
+    display: block;
+    width: 100%;
+    height: 100%; 
+  }
+
+  .dimensionLine{
+    stroke: #16a5e6;
+    stroke-width: 2;
+    stroke-dasharray: 2
+  }
+
+  .dot{
+    display: block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: none;
+    box-sizing: border-box;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+    background: #fff;
+    pointer-events: none;
+    --min-hotspot-opacity: 0;
+  }
+
+  .dim{
+    background: #fff;
+    border-radius: 4px;
+    border: none;
+    box-sizing: border-box;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+    color: rgba(0, 0, 0, 0.8);
+    display: block;
+    font-family: Futura, Helvetica Neue, sans-serif;
+    font-size: 18px;
+    font-weight: 700;
+    max-width: 128px;
+    overflow-wrap: break-word;
+    padding: 0.5em 1em;
+    position: absolute;
+    width: max-content;
+    height: max-content;
+    transform: translate3d(-50%, -50%, 0);
+    pointer-events: none;
+    --min-hotspot-opacity: 0;
+  }
+
+  .show{
+    --min-hotspot-opacity: 1;
+  }
+
+  .hide{
+    display: none;
+  }
+  /* This keeps child nodes hidden while the element loads */
+  :not(:defined) > * {
+    display: none;
+  }
+  </style>
+  <model-viewer id="dimension-overlay-demo" ar ar-modes="webxr" ar-scale="fixed" camera-orbit="-30deg auto auto" max-camera-orbit="auto 100deg auto" shadow-intensity="1" camera-controls touch-action="pan-y" src="../../assets/ShopifyModels/Chair.glb" alt="A 3D model of an armchair.">
+    <button slot="hotspot-dot+X-Y+Z" class="dot" data-position="1 -1 1" data-normal="1 0 0"></button>
+    <button slot="hotspot-dim+X-Y" class="dim" data-position="1 -1 0" data-normal="1 0 0"></button>
+    <button slot="hotspot-dot+X-Y-Z" class="dot" data-position="1 -1 -1" data-normal="1 0 0"></button>
+    <button slot="hotspot-dim+X-Z" class="dim" data-position="1 0 -1" data-normal="1 0 0"></button>
+    <button slot="hotspot-dot+X+Y-Z" class="dot show" data-position="1 1 -1" data-normal="0 1 0"></button>
+    <button slot="hotspot-dim+Y-Z" class="dim show" data-position="0 -1 -1" data-normal="0 1 0"></button>
+    <button slot="hotspot-dot-X+Y-Z" class="dot show" data-position="-1 1 -1" data-normal="0 1 0"></button>
+    <button slot="hotspot-dim-X-Z" class="dim" data-position="-1 0 -1" data-normal="-1 0 0"></button>
+    <button slot="hotspot-dot-X-Y-Z" class="dot" data-position="-1 -1 -1" data-normal="-1 0 0"></button>
+    <button slot="hotspot-dim-X-Y" class="dim" data-position="-1 -1 0" data-normal="-1 0 0"></button>
+    <button slot="hotspot-dot-X-Y+Z" class="dot" data-position="-1 -1 1" data-normal="-1 0 0"></button>
+    <svg xmlns="http://www.w3.org/2000/svg" class="dimensionLineContainer">
+      <line class="dimensionLine"></line>
+      <line class="dimensionLine"></line>
+      <line class="dimensionLine"></line>
+      <line class="dimensionLine"></line>
+      <line class="dimensionLine"></line>
+    </svg>
+  </model-viewer>
+    
+    
+<script type="module">
+  const modelViewer1 = document.querySelector('#dimension-overlay-demo');
+
+  modelViewer1.addEventListener('load', () => {
+    const center = modelViewer1.getBoundingBoxCenter();
+    const size = modelViewer1.getDimensions();
+    const x2 = size.x / 2;
+    const y2 = size.y / 2;
+    const z2 = size.z / 2;
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dot+X-Y+Z',
+      position: `${center.x + x2} ${center.y - y2} ${center.z + z2}`
+    });
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dim+X-Y',
+      position: `${center.x + x2} ${center.y - y2} ${center.z}`
+    });
+    modelViewer1.querySelector('button[slot="hotspot-dim+X-Y"]').textContent =
+        `${(size.z * 100).toFixed(0)} cm`;
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dot+X-Y-Z',
+      position: `${center.x + x2} ${center.y - y2} ${center.z - z2}`
+    });
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dim+X-Z',
+      position: `${center.x + x2} ${center.y} ${center.z - z2}`
+    });
+    modelViewer1.querySelector('button[slot="hotspot-dim+X-Z"]').textContent =
+        `${(size.y * 100).toFixed(0)} cm`;
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dot+X+Y-Z',
+      position: `${center.x + x2} ${center.y + y2} ${center.z - z2}`
+    });
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dim+Y-Z',
+      position: `${center.x} ${center.y + y2} ${center.z - z2}`
+    });
+    modelViewer1.querySelector('button[slot="hotspot-dim+Y-Z"]').textContent =
+        `${(size.x * 100).toFixed(0)} cm`;
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dot-X+Y-Z',
+      position: `${center.x - x2} ${center.y + y2} ${center.z - z2}`
+    });
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dim-X-Z',
+      position: `${center.x - x2} ${center.y} ${center.z - z2}`
+    });
+    modelViewer1.querySelector('button[slot="hotspot-dim-X-Z"]').textContent =
+        `${(size.y * 100).toFixed(0)} cm`;
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dot-X-Y-Z',
+      position: `${center.x - x2} ${center.y - y2} ${center.z - z2}`
+    });
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dim-X-Y',
+      position: `${center.x - x2} ${center.y - y2} ${center.z}`
+    });
+    modelViewer1.querySelector('button[slot="hotspot-dim-X-Y"]').textContent =
+        `${(size.z * 100).toFixed(0)} cm`;
+
+    modelViewer1.updateHotspot({
+      name: 'hotspot-dot-X-Y+Z',
+      position: `${center.x - x2} ${center.y - y2} ${center.z + z2}`
+    });
+  });
+
+  // update svg
+  function drawLine(svgLine, dotHotspot1, dotHotspot2, dimensionHotspot) {
+    if (dotHotspot1 && dotHotspot1) {
+      svgLine.setAttribute('x1', dotHotspot1.screenPosition.u);
+      svgLine.setAttribute('y1', dotHotspot1.screenPosition.v);
+      svgLine.setAttribute('x2', dotHotspot2.screenPosition.u);
+      svgLine.setAttribute('y2', dotHotspot2.screenPosition.v);
+
+      // use provided optional hotspot to tie visibility of this svg line to
+      if (dimensionHotspot && !dimensionHotspot.facingCamera) {
+        svgLine.classList.add('hide');
+      }
+      else {
+        svgLine.classList.remove('hide');
+      }
+    }
+  }
+
+  const lines = modelViewer1.querySelectorAll('line');
+
+  // use requestAnimationFrame to update with renderer
+  const startSVGRenderLoop = () => {
+    drawLine(lines[0], modelViewer1.queryHotspot('hotspot-dot+X-Y+Z'), modelViewer1.queryHotspot('hotspot-dot+X-Y-Z'), modelViewer1.queryHotspot('hotspot-dim+X-Y'));
+    drawLine(lines[1], modelViewer1.queryHotspot('hotspot-dot+X-Y-Z'), modelViewer1.queryHotspot('hotspot-dot+X+Y-Z'), modelViewer1.queryHotspot('hotspot-dim+X-Z'));
+    drawLine(lines[2], modelViewer1.queryHotspot('hotspot-dot+X+Y-Z'), modelViewer1.queryHotspot('hotspot-dot-X+Y-Z')); // always visible
+    drawLine(lines[3], modelViewer1.queryHotspot('hotspot-dot-X+Y-Z'), modelViewer1.queryHotspot('hotspot-dot-X-Y-Z'), modelViewer1.queryHotspot('hotspot-dim-X-Z'));
+    drawLine(lines[4], modelViewer1.queryHotspot('hotspot-dot-X-Y-Z'), modelViewer1.queryHotspot('hotspot-dot-X-Y+Z'), modelViewer1.queryHotspot('hotspot-dim-X-Y'));
+    requestAnimationFrame(startSVGRenderLoop);
+  };
+
+  startSVGRenderLoop();
+</script>
+            </template>
+          </example-snippet>
+        </div>
+      </div>
+    </div>
+
+    <div class="sample">
       <div id="cameraViews" class="demo"></div>
       <div class="content">
         <div class="wrapper">
@@ -415,15 +627,15 @@
 </model-viewer>
 
 <script type="module">
-  const modelViewer1 = document.querySelector("#hotspot-camera-view-demo");
+  const modelViewer2 = document.querySelector("#hotspot-camera-view-demo");
   const annotationClicked = (annotation) => {
     let dataset = annotation.dataset;
-    modelViewer1.cameraTarget = dataset.target;
-    modelViewer1.cameraOrbit = dataset.orbit;
-    modelViewer1.fieldOfView = '45deg';
+    modelViewer2.cameraTarget = dataset.target;
+    modelViewer2.cameraOrbit = dataset.orbit;
+    modelViewer2.fieldOfView = '45deg';
   }
 
-  modelViewer1.querySelectorAll('button').forEach((hotspot) => {
+  modelViewer2.querySelectorAll('button').forEach((hotspot) => {
     hotspot.addEventListener('click', () => annotationClicked(hotspot));
   });
 </script>

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -497,10 +497,10 @@
   // update svg
   function drawLine(svgLine, dotHotspot1, dotHotspot2, dimensionHotspot) {
     if (dotHotspot1 && dotHotspot1) {
-      svgLine.setAttribute('x1', dotHotspot1.screenPosition.u);
-      svgLine.setAttribute('y1', dotHotspot1.screenPosition.v);
-      svgLine.setAttribute('x2', dotHotspot2.screenPosition.u);
-      svgLine.setAttribute('y2', dotHotspot2.screenPosition.v);
+      svgLine.setAttribute('x1', dotHotspot1.screenPosition.x);
+      svgLine.setAttribute('y1', dotHotspot1.screenPosition.y);
+      svgLine.setAttribute('x2', dotHotspot2.screenPosition.x);
+      svgLine.setAttribute('y2', dotHotspot2.screenPosition.y);
 
       // use provided optional hotspot to tie visibility of this svg line to
       if (dimensionHotspot && !dimensionHotspot.facingCamera) {


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue

Discussion at https://github.com/google/model-viewer/discussions/3833
<!-- Example: Fixes #1234 -->

This is a first pass to add the ability to query a read-only snapshot of in-scene information about a hotspot by name, most crucially the screen space (canvas) position. 

Entirely open to suggestions about the API (in particular it does feel odd that the returned position Vector2D is `u` and `v`, though it makes sense where it's currently only used for UV lookups) and how on earth to test a screen space position given that it relies on so many model-viewer defaults...

The PR includes a working example to aid discussion, which may or may not be complete overkill for this 😅