### PR TITLE
iOS16 ARQL banner click fix

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -397,6 +397,11 @@ configuration or device capabilities');
       if (generateUsdz) {
         anchor.setAttribute('download', 'model.usdz');
       }
+
+      // attach anchor to shadow DOM to ensure iOS16 ARQL banner click message event propagation 
+      anchor.style.display = 'none';
+      if(!anchor.isConnected) this.shadowRoot!.appendChild(anchor);
+
       console.log('Attempting to present in AR with Quick Look...');
       anchor.click();
       anchor.removeChild(img);


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
Fixes https://github.com/google/model-viewer/discussions/2755

### Issue
It appears Safari iOS16 is no longer propagating the `_apple_ar_quicklook_button_tapped` ARQL message event to the originating anchor element when the anchor is not attached to the DOM. This causes ModelViewer to never broadcast the `quick-look-button-tapped` event in iOS16. 

### Approach 
Changes have been made to `ar.ts` to append the ARQL anchor element to the shadow DOM and setting `display` to `none`.

With the anchor attached to the DOM, the `_apple_ar_quicklook_button_tapped` ARQL message is received and MV broadcasts the `quick-look-button-tapped` event now in iOS16. 

### Demo
An example of ModelViewer compiled with this code change can be found here:
https://modelviewer-ios16-arql-banner-fix.glitch.me/

### Compatibility  
This has been tested in Safari iOS 16.0 and regression tested in 15.6.1. Both with a full USDZ file path and also with auto USDZ generation. Both scenarios work on both iOS versions. 

If anyone else can test with other versions of iOS that would be greatly appreciated.