### PR TITLE
Don't reappend the 3D canvas every frame

### DIFF
--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -496,8 +496,10 @@ export class Renderer extends EventDispatcher {
       if (this.multipleScenesVisible || scene.renderCount === 0) {
         this.copyPixels(scene, width, height);
       } else {
-        scene.canvas.parentElement!.appendChild(canvas3D);
-        scene.canvas.classList.remove('show');
+        if (canvas3D.parentElement !== scene.canvas.parentElement) {
+          scene.canvas.parentElement!.appendChild(canvas3D);
+          scene.canvas.classList.remove('show');
+        }
       }
 
       scene.hasRendered();


### PR DESCRIPTION
Fixes #3876 

Issue: If we only have one visible scene we will call an appendChild of the 3D canvas at every frame. Apparently this was OK in most browsers but iOS 15 Safari doesn't like it. 
Note: that's why the model isn't visible if we move it but visible during idle since in that case the render loop not reaches this appendChild every frame

Issue was introduced here: #3704, that's why its not in v1.12.0 but already in v2.0.0

Tested with iOS Safari 15.2 and checked for regressions in MacOS Chrome

Implementation note:
The best solution I can think of would be to move this canvas selection logic upper in the render loop somewhere around the current `countVisibleScenes` but without lots of test devices I didn't wanted to mess around with the render loop too much (but open for suggestions)