### PR TITLE
Remove # hash params from SceneViewer source

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -306,6 +306,7 @@ configuration or device capabilities');
       const location = self.location.toString();
       const locationUrl = new URL(location);
       const modelUrl = new URL(this.src!, location);
+      if( modelUrl.hash ) modelUrl.hash = '';
       const params = new URLSearchParams(modelUrl.search);
 
       locationUrl.hash = noArViewerSigil;

--- a/packages/model-viewer/src/test/features/ar-spec.ts
+++ b/packages/model-viewer/src/test/features/ar-spec.ts
@@ -87,6 +87,37 @@ suite('AR', () => {
       expect(search.get('link')).to.contain('http://');
       expect(search.get('link')).to.contain('/foo.html');
     });
+
+    test('strips hash params from SceneViewer model src', () => {
+      element.src =
+          'https://example.com/model.gltf#applePayButtonType=plain&checkoutTitle=TitleText';
+      element.alt = 'alt';
+      (element as any)[$openSceneViewer]();
+
+      expect(intentUrls.length).to.be.equal(1);
+
+      const search = new URLSearchParams(new URL(intentUrls[0]).search);
+      const file = new URL( search.get('file') as any );
+      
+      expect(file.hash).to.equal('');
+    });
+
+    test('strips hash params but preserves query params', () => {
+      element.src =
+          'https://example.com/model.gltf?link=http://linkme.com&title=bar#applePayButtonType=plain&checkoutTitle=TitleText';
+      element.alt = 'alt';
+      (element as any)[$openSceneViewer]();
+
+      expect(intentUrls.length).to.be.equal(1);
+
+      const search = new URLSearchParams(new URL(intentUrls[0]).search);
+      const file = new URL( search.get('file') as any );
+      
+      expect(file.hash).to.equal('');
+      expect(search.get('title')).to.equal('bar');
+      expect(search.get('link')).to.equal('http://linkme.com/');
+    });
+
   });
 
   suite('openQuickLook', () => {


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
Fixes: https://github.com/google/model-viewer/issues/3992

### Issue
In some circumstances, when auto generating USDZ and appending # hash parameters to the model `src` path to configure ARQL, these can conflict with the constructed SceneViewer intent, causing SceneViewer to fail to load the model.

### Solution
When opening AR to SceneViewer, this update will check the model src path for presence of hash params and remove if needed.

### Demo
A variety of tests utilising SceneViewer and Auto USDZ, with a mix of query and hash params, can be seen here:
https://modelviewer-auto-usdz-params.glitch.me
Tested on a variety of Android and iOS devices, but any additional testers would be welcome. 

### Tests
Added two tests to check that hash params for configuring ARQL are completely removed from the model src path and that it also does not remove any query params that may still be used for SceneViewer configuration. 
- 'strips hash params from SceneViewer model src'
- 'strips hash params but preserves query params'
