### PR TITLE
fixed near/far plane for empty GLB

### DIFF
--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -286,8 +286,8 @@ export class SmoothControls extends EventDispatcher {
    * Sets the near and far planes of the camera.
    */
   updateNearFar(nearPlane: number, farPlane: number) {
-    this.camera.near = Math.max(nearPlane, farPlane / 1000);
-    this.camera.far = farPlane;
+    this.camera.far = farPlane === 0 ? 2 : farPlane;
+    this.camera.near = Math.max(nearPlane, this.camera.far / 1000);
     this.camera.updateProjectionMatrix();
   }
 


### PR DESCRIPTION
Fixes #3999 

Camera perspective matrices don't like getting zero for the near or far plane! This fixes both skybox and the hotspots. Since the far plane is set arbitrarily to 2 when the scene is empty, just use normalized vectors for hotspot positions when camera radius is set to zero. 