### PR TITLE
test AR directly in mobile editor

### DIFF
--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -28,7 +28,7 @@ import {customElement, query, state} from 'lit/decorators.js';
 
 import {reduxStore} from '../../space_opera_base.js';
 import {modelViewerPreviewStyles} from '../../styles.css.js';
-import {BestPracticesState, extractStagingConfig, ModelViewerConfig, State} from '../../types.js';
+import {ArConfigState, BestPracticesState, extractStagingConfig, ModelViewerConfig, State} from '../../types.js';
 import {getBestPractices} from '../best_practices/reducer.js';
 import {arButtonCSS, progressBarCSS} from '../best_practices/styles.css.js';
 import {dispatchCameraIsDirty} from '../camera_settings/reducer.js';
@@ -37,7 +37,7 @@ import {ConnectedLitElement} from '../connected_lit_element/connected_lit_elemen
 import {dispatchAddHotspot, dispatchSetHotspots, dispatchUpdateHotspotMode, generateUniqueHotspotName, getHotspotMode, getHotspots} from '../hotspot_panel/reducer.js';
 import {HotspotConfig} from '../hotspot_panel/types.js';
 import {createBlobUrlFromEnvironmentImage, dispatchAddEnvironmentImage} from '../ibl_selector/reducer.js';
-import {dispatchSetForcePost, getRefreshable} from '../mobile_view/reducer.js';
+import {dispatchSetForcePost, getArConfig, getRefreshable} from '../mobile_view/reducer.js';
 import {getExtraAttributes} from '../model_viewer_snippet/reducer.js';
 import {dispatchSetEnvironmentName, dispatchSetModelName} from '../relative_file_paths/reducer.js';
 import {createSafeObjectUrlFromArrayBuffer} from '../utils/create_object_url.js';
@@ -55,6 +55,7 @@ export class ModelViewerPreview extends ConnectedLitElement {
       [modelViewerPreviewStyles, hotspotStyles, arButtonCSS, progressBarCSS];
   @query('model-viewer') readonly modelViewer!: ModelViewerElement;
   @state() config: ModelViewerConfig = {};
+  @state() arConfig: ArConfigState = {};
   @state() hotspots: HotspotConfig[] = [];
   @state() addHotspotMode = false;
   @state() gltfUrl?: string;
@@ -71,6 +72,7 @@ export class ModelViewerPreview extends ConnectedLitElement {
   stateChanged(state: State) {
     this.addHotspotMode = getHotspotMode(state) || false;
     this.config = getConfig(state);
+    this.arConfig = getArConfig(state);
     this.hotspots = getHotspots(state);
     this.extraAttributes = getExtraAttributes(state);
     this.refreshButtonIsReady = getRefreshable(state);
@@ -128,12 +130,10 @@ export class ModelViewerPreview extends ConnectedLitElement {
           <small>Drop an HDR for lighting</small></div>`);
     }
 
-    const emptyARConfig = {};
-
     return html`${
         renderModelViewer(
             editedConfig,
-            emptyARConfig,
+            this.arConfig,
             this.extraAttributes,
             {
               load: () => {


### PR DESCRIPTION
We had a request to be able to view models in AR offline: https://twitter.com/modelviewer/status/1604596420660678659

Really this should have already been working via the editor, but I realized the AR button was not showing up on mobile, which is fixed here. This is another convenient way to test models in AR - instead of using mobile deploy, if you have the GLBs on your mobile file system, just load them up in the editor and test them all on a single device.