### PR TITLE
Quicklook ar placement

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -434,13 +434,34 @@ configuration or device capabilities');
 
       updateSourceProgress(0.2);
 
-      const exporter = new USDZExporter();
-      const arraybuffer = await exporter.parse(model);
+      const usdzOptions = {
+        ar: {
+          anchoring: { type: 'plane' },
+          planeAnchoring: {
+            alignment: this.arPlacement === 'wall' ? 'vertical' : 'horizontal',
+          },
+        },
+      };
+
+      // necessary because quicklook internally rotates model when placing vertical. 
+      // See https://github.com/google/model-viewer/issues/3989
+      if (usdzOptions.ar.planeAnchoring.alignment === 'vertical') {
+        model.rotateX((-90 * Math.PI) / 180);
+        model.updateMatrixWorld();
+      }
+
+      const exporter = new USDZExporter() as any;
+      const arraybuffer = await exporter.parse(model, usdzOptions);
       const blob = new Blob([arraybuffer], {
         type: 'model/vnd.usdz+zip',
       });
 
       const url = URL.createObjectURL(blob);
+      
+      if (usdzOptions.ar.planeAnchoring.alignment === 'vertical') {
+        model.rotateX((90 * Math.PI) / 180);
+        model.updateMatrixWorld();
+      }
 
       updateSourceProgress(1);
 

--- a/packages/modelviewer.dev/examples/augmentedreality/index.html
+++ b/packages/modelviewer.dev/examples/augmentedreality/index.html
@@ -360,6 +360,8 @@
           <div class="heading">
             <h2 class="demo-title">Placing on a Wall</h2>
             <h4>This demonstrates the <code>ar-placement</code> attribute, which defaults to "floor", but using "wall" gives a different AR placement experience.</h4>
+            <p>QuickLook will ignore this attribute if a .usdz or .reality model is supplied through <code>ios-src</code> and instead look at the <code>planeAnchoring:alignment</code> option
+              inside the USDZ file.</p>
           </div>
           <example-snippet stamp-to="wall" highlight-as="html">
             <template>


### PR DESCRIPTION
Fixes #3989

Also had to fix the boom_2_.glb model because the model was offset quite a lot, which messed with the rotation required for quicklook AR.

I tried a few different approaches to reset the rotation of the model (like keeping a copy of the matrix). Only rotating it back worked for me though.