### PR TITLE
fixed NaN cameraOrbit

### DIFF
--- a/packages/model-viewer/src/test/features/controls-spec.ts
+++ b/packages/model-viewer/src/test/features/controls-spec.ts
@@ -759,6 +759,40 @@ suite('Controls', () => {
         expect(newOrbit.theta).to.be.closeTo(orbit.theta, 0.001, 'theta');
         expect(newOrbit.phi).to.be.closeTo(orbit.phi, 0.001, 'phi');
       });
+
+      test('zero element size does not produce NaNs', async () => {
+        element.style.width = '0px';
+        element.style.height = '0px';
+        await rafPasses();
+
+        const finger = {
+          x: {
+            initialValue: 0.6,
+            keyframes: [
+              {frames: 1, value: 0.7},
+              {frames: 1, value: 0.6},
+            ]
+          },
+          y: {
+            // No Y change to test potential 0 / 0
+            initialValue: 0.4,
+            keyframes: [
+              {frames: 1, value: 0.4},
+              {frames: 1, value: 0.4},
+            ]
+          }
+        };
+
+        element.interact(50, finger);
+        await rafPasses();
+        await rafPasses();
+        await rafPasses();
+
+        const newOrbit = element.getCameraOrbit();
+        expect(newOrbit.theta).to.be.finite;
+        expect(newOrbit.phi).to.be.finite;
+        expect(newOrbit.radius).to.be.finite;
+      });
     });
 
     suite('a11y', () => {

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -337,6 +337,10 @@ export class SmoothControls extends EventDispatcher {
       return false;
     }
 
+    if (!isFinite(nextTheta) || !isFinite(nextPhi) || !isFinite(nextRadius)) {
+      return false;
+    }
+
     this.goalSpherical.theta = nextTheta;
     this.goalSpherical.phi = nextPhi;
     this.goalSpherical.radius = nextRadius;
@@ -508,7 +512,7 @@ export class SmoothControls extends EventDispatcher {
   }
 
   private pixelLengthToSphericalAngle(pixelLength: number): number {
-    return 2 * Math.PI * pixelLength / this.element.clientHeight;
+    return 2 * Math.PI * pixelLength / this.scene.height;
   }
 
   private twoTouchDistance(touchOne: Pointer, touchTwo: Pointer): number {


### PR DESCRIPTION
There are two fixes here, one for the actual problem, and a second to act as a backstop against similar problems. Both were verified to independently fix the issue via the included test.

I also verified that no matter what nonsense you put into `camera-orbit` or `cameraOrbit`, it will never produce NaN, it instead falls back to the default initial values. 