### PR TITLE
don't resize to zero

### DIFF
--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -517,11 +517,14 @@ export default class ModelViewerElementBase extends ReactiveElement {
   /**
    * Called on initialization and when the resize observer fires.
    */
-  [$updateSize]({width, height}: {width: any, height: any}) {
+  [$updateSize]({width, height}: {width: number, height: number}) {
+    if (width === 0 || height === 0) {
+      return;
+    }
     this[$container].style.width = `${width}px`;
     this[$container].style.height = `${height}px`;
 
-    this[$onResize]({width: parseFloat(width), height: parseFloat(height)});
+    this[$onResize]({width, height});
   }
 
   [$tick](_time: number, _delta: number) {


### PR DESCRIPTION
This is more for general robustness; when a MV element is detached from the DOM tree, it gets a resize event for zero size. There's no reason to make any changes for this, since as soon as it's reattached it will get a new size. We found some strange cases where it seems to not get updated size message (`ResizeObserver` bug?), but it was difficult to debug as the render was just blank (no size). Now it will keep working, at least if it came back at the same size. 