### PR TITLE
fixed pre-rendering for element reuse

### DIFF
--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -274,6 +274,7 @@ export class ModelScene extends Scene {
 
   reset() {
     this.url = null;
+    this.renderCount = 0;
     this.queueRender();
     if (this.shadow != null) {
       this.shadow.setIntensity(0);


### PR DESCRIPTION
We found stale hotspots when loading a new model, but only when also connecting a MV element back to the DOM. The hotspots are hidden until the model is loaded, and the load event should only be triggered *after* an initial render has occurred. However, when the element had been used before, the `renderCount` wasn't being reset, which meant the pre-render was being skipped. That's fixed here.