### PR TITLE
fix disconnect-reconnect showing poster on loaded model

### DIFF
--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -318,7 +318,9 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
     connectedCallback() {
       super.connectedCallback();
 
-      this.showPoster();
+      if (!this.loaded) {
+        this.showPoster();
+      }
 
       this[$progressTracker].addEventListener('progress', this[$onProgress]);
     }

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -27,7 +27,7 @@ import {clamp, debounce} from './utilities.js';
 import {dataUrlToBlob} from './utilities/data-conversion.js';
 import {ProgressTracker} from './utilities/progress-tracker.js';
 
-const CLEAR_MODEL_TIMEOUT_MS = 1000;
+const CLEAR_MODEL_TIMEOUT_MS = 10;
 const FALLBACK_SIZE_UPDATE_THRESHOLD_MS = 50;
 const ANNOUNCE_MODEL_VISIBILITY_DEBOUNCE_THRESHOLD = 0;
 const UNSIZED_MEDIA_WIDTH = 300;


### PR DESCRIPTION
Fixes #3967 

Turns out the poster just got in the way. `dismissPoster()` is another workaround, but shouldn't be necessary now.