### PR TITLE
fixed bug showing 2 canvases

### DIFF
--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -493,13 +493,12 @@ export class Renderer extends EventDispatcher {
           0, Math.ceil(this.height * this.dpr) - height, width, height);
       this.threeRenderer.render(scene, scene.camera);
 
-      if (this.multipleScenesVisible || scene.renderCount === 0) {
+      if (this.multipleScenesVisible ||
+          (!scene.element.modelIsVisible && scene.renderCount === 0)) {
         this.copyPixels(scene, width, height);
-      } else {
-        if (canvas3D.parentElement !== scene.canvas.parentElement) {
-          scene.canvas.parentElement!.appendChild(canvas3D);
-          scene.canvas.classList.remove('show');
-        }
+      } else if (canvas3D.parentElement !== scene.canvas.parentElement) {
+        scene.canvas.parentElement!.appendChild(canvas3D);
+        scene.canvas.classList.remove('show');
       }
 
       scene.hasRendered();


### PR DESCRIPTION
When switching back and forth between models we could end up showing both the webGL canvas and the canvas 2D, one updating and the other stuck. This regression was caused by #4046 and fixed here.