### PR TITLE
fix video texture on Firefox

### DIFF
--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -516,9 +516,13 @@ modelViewerTexture1.addEventListener("load", () => {
 <script type="module">
 const modelViewerAnimated = document.querySelector("model-viewer#animated");
 
-const videoTexture = modelViewerAnimated.createVideoTexture("../../shared-assets/models/lottie-logo.mp4");
+let videoTexture = null;
 let canvasTexture = null;
 let lottieTexture = null;
+
+customElements.whenDefined('model-viewer').then(() => {
+  videoTexture = modelViewerAnimated.createVideoTexture("../../shared-assets/models/lottie-logo.mp4");
+});
 
 function getCanvasTexture() {
   if(canvasTexture) return canvasTexture;


### PR DESCRIPTION
Fixes #4102 

The example was not waiting for the MV library to load, causing errors like `createVideoTexture` is not a function. 