### PR TITLE
fix firefox video framerate

### DIFF
--- a/packages/model-viewer/src/features/scene-graph/texture-info.ts
+++ b/packages/model-viewer/src/features/scene-graph/texture-info.ts
@@ -99,19 +99,9 @@ export class TextureInfo implements TextureInfoInterface {
     const threeTexture: ThreeTexture|null =
         texture != null ? texture.source[$threeTexture] : null;
 
-    let frameId = 0;
-    const updateLoop = () => {
-      this[$onUpdate]();
-      frameId = requestAnimationFrame(updateLoop);
-    };
-
     const oldTexture = this[$texture] as unknown as VideoTexture;
     if (oldTexture != null && oldTexture.isVideoTexture) {
-      const element = oldTexture.image;
       this[$activeVideo] = false;
-      if (element.requestVideoFrameCallback == null) {
-        cancelAnimationFrame(frameId);
-      }
     }
 
     this[$texture] = texture;
@@ -129,7 +119,14 @@ export class TextureInfo implements TextureInfoInterface {
         };
         element.requestVideoFrameCallback(update);
       } else {
-        requestAnimationFrame(updateLoop);
+        const update = () => {
+          if (!this[$activeVideo]) {
+            return;
+          }
+          this[$onUpdate]();
+          requestAnimationFrame(update);
+        };
+        requestAnimationFrame(update);
       }
     }
 

--- a/packages/model-viewer/src/features/scene-graph/texture-info.ts
+++ b/packages/model-viewer/src/features/scene-graph/texture-info.ts
@@ -99,12 +99,18 @@ export class TextureInfo implements TextureInfoInterface {
     const threeTexture: ThreeTexture|null =
         texture != null ? texture.source[$threeTexture] : null;
 
+    let frameId = 0;
+    const updateLoop = () => {
+      this[$onUpdate]();
+      frameId = requestAnimationFrame(updateLoop);
+    };
+
     const oldTexture = this[$texture] as unknown as VideoTexture;
     if (oldTexture != null && oldTexture.isVideoTexture) {
       const element = oldTexture.image;
       this[$activeVideo] = false;
       if (element.requestVideoFrameCallback == null) {
-        element.removeEventListener('timeupdate', this[$onUpdate]);
+        cancelAnimationFrame(frameId);
       }
     }
 
@@ -123,7 +129,7 @@ export class TextureInfo implements TextureInfoInterface {
         };
         element.requestVideoFrameCallback(update);
       } else {
-        element.addEventListener('timeupdate', this[$onUpdate]);
+        requestAnimationFrame(updateLoop);
       }
     }
 


### PR DESCRIPTION
Animated textures were slow to update on firefox because it doesn't support `requestVideoFrameCallback` and it sends the `timeupdate` event very slowly. Now it will just render all the time if a video texture is present.