### PR TITLE
fix other SVG example

### DIFF
--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -152,7 +152,7 @@
   <div slot="hotspot-nose" class="anchor" data-surface="0 0 228 113 111 0.217 0.341 0.442"></div>
   <div slot="hotspot-hoof" class="anchor" data-surface="0 0 752 733 735 0.132 0.379 0.489"></div>
   <div slot="hotspot-tail" class="anchor" data-surface="0 0 220 221 222 0.405 0.061 0.534"></div>
-  <svg id="lines" xmlns="http://www.w3.org/2000/svg" class="lineContainer">
+  <svg id="lines" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" class="lineContainer">
     <line class="line"></line>
     <line class="line"></line>
     <line class="line"></line>
@@ -211,10 +211,7 @@
 
   .lineContainer{
     pointer-events: none;
-    position: fixed;
     display: block;
-    width: 100%;
-    height: 100%; 
   }
 
   .line{


### PR DESCRIPTION
Fixes missing SVG pointers on animated hotspot example on iOS - same fix as before, but forgot to apply to the new example.