### PR TITLE
fix: model-viewer@v3 uses lottie-web as a dev dependency

### DIFF
--- a/packages/model-viewer/src/features/scene-graph/api.ts
+++ b/packages/model-viewer/src/features/scene-graph/api.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {AnimationItem} from 'lottie-web';
+import type {AnimationItem} from 'lottie-web';
 
 import {AlphaMode, MagFilter, MinFilter, WrapMode} from '../../three-components/gltf-instance/gltf-2.0.js';
 

--- a/packages/model-viewer/src/features/scene-graph/image.ts
+++ b/packages/model-viewer/src/features/scene-graph/image.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {AnimationItem} from 'lottie-web';
+import type {AnimationItem} from 'lottie-web';
 import {Mesh, MeshBasicMaterial, OrthographicCamera, PlaneGeometry, Scene, Texture as ThreeTexture, WebGLRenderTarget} from 'three';
 
 import {blobCanvas} from '../../model-viewer-base.js';


### PR DESCRIPTION
This issue was caused because the lottie-web is listed as a dev dep to use it's types, in this case `import` statement is wrong as it would import all the module on runtime, using `import type` will fix the issue and used to check the types only on compilation stage

Fixes #4090

