### PR TITLE
Fix lottie update

### DIFF
--- a/packages/model-viewer/src/features/scene-graph/texture-info.ts
+++ b/packages/model-viewer/src/features/scene-graph/texture-info.ts
@@ -102,6 +102,9 @@ export class TextureInfo implements TextureInfoInterface {
     const oldTexture = this[$texture]?.source[$threeTexture] as VideoTexture;
     if (oldTexture != null && oldTexture.isVideoTexture) {
       this[$activeVideo] = false;
+    } else if (this[$texture]?.source.animation) {
+      this[$texture].source.animation.removeEventListener(
+          'enterFrame', this[$onUpdate]);
     }
 
     this[$texture] = texture;
@@ -128,6 +131,8 @@ export class TextureInfo implements TextureInfoInterface {
         };
         requestAnimationFrame(update);
       }
+    } else if (texture?.source.animation != null) {
+      texture.source.animation.addEventListener('enterFrame', this[$onUpdate]);
     }
 
     let encoding: TextureEncoding = sRGBEncoding;

--- a/packages/model-viewer/src/features/scene-graph/texture-info.ts
+++ b/packages/model-viewer/src/features/scene-graph/texture-info.ts
@@ -55,13 +55,13 @@ export class TextureInfo implements TextureInfoInterface {
   };
 
   // Holds a reference to the Three data that backs the material object.
-  [$materials]: Set<MeshStandardMaterial>|null;
+  private[$materials]: Set<MeshStandardMaterial>|null;
 
   // Texture usage defines the how the texture is used (ie Normal, Emissive...
   // etc)
-  [$usage]: TextureUsage;
-  [$onUpdate]: () => void;
-  [$activeVideo] = false;
+  private[$usage]: TextureUsage;
+  private[$onUpdate]: () => void;
+  private[$activeVideo] = false;
 
   constructor(
       onUpdate: () => void, usage: TextureUsage,
@@ -99,7 +99,7 @@ export class TextureInfo implements TextureInfoInterface {
     const threeTexture: ThreeTexture|null =
         texture != null ? texture.source[$threeTexture] : null;
 
-    const oldTexture = this[$texture] as unknown as VideoTexture;
+    const oldTexture = this[$texture]?.source[$threeTexture] as VideoTexture;
     if (oldTexture != null && oldTexture.isVideoTexture) {
       this[$activeVideo] = false;
     }

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -507,9 +507,9 @@ modelViewerTexture1.addEventListener("load", () => {
   <div class="controls">
     <p>Texture Type</p>
     <select id="type">
+      <option value="lottie">Lottie</option>
       <option value="video">Video</option>
       <option value="canvas">Canvas</option>
-      <option value="lottie">Lottie</option>
     </select>
   </div>
 </model-viewer>
@@ -544,12 +544,12 @@ function getLottieTexture() {
   return lottieTexture;
 }
 
-modelViewerAnimated.addEventListener("load", () => {
+modelViewerAnimated.addEventListener("load", async () => {
 
   const material = modelViewerAnimated.model.materials[0];
   const {baseColorTexture} = material.pbrMetallicRoughness;
 
-  baseColorTexture.setTexture(videoTexture);
+  baseColorTexture.setTexture(await getLottieTexture());
 
   document.querySelector('#type').addEventListener('input', async (event) => {
     switch(event.target.value){


### PR DESCRIPTION
It turns out Lottie textures were pretty broken in the last release, but it wasn't clear because of a combination of bugs and examples. Most critically, Lottie textures were not triggering the scene to re-render, so they would only update when the camera moved. This wasn't noticed because of bug 2, in which video textures continue to re-render the scene even then they are removed from it. The example hid the problem because it always loaded the video texture before the Lottie texture, so everything appeared to be working. All of these are fixed here. 