### PR TITLE
remove lottie-web dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3689,9 +3689,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
+      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -5425,9 +5425,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.16.0.tgz",
+      "integrity": "sha512-VJBdeMa9Bz27NNlx+DI/YXGQtXdjUU+9gdfN1rYfra7vtTjhodl5tVNmR42bo+ORHuDqDT+lGAUAb+lzvY42Bw==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -6547,9 +6547,9 @@
       }
     },
     "node_modules/nx/node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.0.tgz",
+      "integrity": "sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",

--- a/packages/model-viewer/package-lock.json
+++ b/packages/model-viewer/package-lock.json
@@ -32,7 +32,6 @@
         "karma-mocha": "^2.0.1",
         "karma-mocha-reporter": "^2.2.5",
         "karma-sourcemap-loader": "^0.3.8",
-        "lottie-web": "5.9.6",
         "mocha": "^10.0.0",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.77.2",
@@ -2880,9 +2879,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001452",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001452.tgz",
-      "integrity": "sha512-Lkp0vFjMkBB3GTpLR8zk4NwW5EdRdnitwYJHDOOKIU85x4ckYCPQ+9WlVvSVClHxVReefkUMtWZH2l9KGlD51w==",
+      "version": "1.0.30001454",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001454.tgz",
+      "integrity": "sha512-4E63M5TBbgDoA9dQoFRdjL6iAmzTrz3rwYWoKDlvnvyvBxjCZ0rrUoX3THhEMie0/RYuTCeMbeTYLGAWgnLwEg==",
       "dev": true,
       "funding": [
         {
@@ -3547,9 +3546,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.297",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.297.tgz",
-      "integrity": "sha512-dTXLXBdzfDYnZYq+bLer21HrFsEkzlR2OSIOsR+qroDmhmQU3i4T4KdY0Lcp83ZId3HnWTpPAEfhaJtVxmS/dQ==",
+      "version": "1.4.300",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.300.tgz",
+      "integrity": "sha512-tHLIBkKaxvG6NnDWuLgeYrz+LTwAnApHm2R3KBNcRrFn0qLmTrqQeB4X4atfN6YJbkOOOSdRBeQ89OfFUelnEQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -5836,12 +5835,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/lottie-web": {
-      "version": "5.9.6",
-      "resolved": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.9.6.tgz",
-      "integrity": "sha512-JFs7KsHwflugH5qIXBpB4905yC1Sub2MZWtl/elvO/QC6qj1ApqbUZJyjzJseJUtVpgiDaXQLjBlIJGS7UUUXA==",
-      "dev": true
-    },
     "node_modules/loupe": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
@@ -7117,9 +7110,9 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.0.tgz",
-      "integrity": "sha512-ZdhUQlng0RoscyW7jADnUZ25F5eVtHdMyXSb2PiwafvteRAOJUjFoUPEYZSIfP99fBIs3maLIRfpEddT78wAAQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.1.tgz",
+      "integrity": "sha512-nCOzW2V/X15XpLsK2rlgdwrysrBq+AauCn+omItIz4R1pIcmeot5zvjdmOBRLzEH/CkC6IxMJVmxDe3QcMuNVQ==",
       "dev": true,
       "dependencies": {
         "@babel/regjsgen": "^0.8.0",

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -103,8 +103,7 @@
     "rollup-plugin-dts": "^4.2.2",
     "rollup-plugin-polyfill": "^3.0.0",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "4.8.4",
-    "lottie-web": "5.9.6"
+    "typescript": "4.8.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/model-viewer/src/features/scene-graph/api.ts
+++ b/packages/model-viewer/src/features/scene-graph/api.ts
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type {AnimationItem} from 'lottie-web';
 
 import {AlphaMode, MagFilter, MinFilter, WrapMode} from '../../three-components/gltf-instance/gltf-2.0.js';
 
@@ -324,9 +323,11 @@ export declare interface Image {
   readonly element?: HTMLVideoElement|HTMLCanvasElement;
 
   /**
-   * The Lottie animation object, if this is a Lottie texture.
+   * The Lottie animation object, if this is a Lottie texture. You may wish to
+   * do image.animation as import('lottie-web').AnimationItem; to get its type
+   * info.
    */
-  readonly animation?: AnimationItem;
+  readonly animation?: any;
 
   /**
    * A method to create an object URL of this image at the desired

--- a/packages/model-viewer/src/features/scene-graph/image.ts
+++ b/packages/model-viewer/src/features/scene-graph/image.ts
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import type {AnimationItem} from 'lottie-web';
 import {Mesh, MeshBasicMaterial, OrthographicCamera, PlaneGeometry, Scene, Texture as ThreeTexture, WebGLRenderTarget} from 'three';
 
 import {blobCanvas} from '../../model-viewer-base.js';
@@ -76,7 +75,7 @@ export class Image extends ThreeDOMElement implements ImageInterface {
     return;
   }
 
-  get animation(): AnimationItem|undefined {
+  get animation(): any|undefined {
     const texture = this[$threeTexture] as any;
     if (texture && texture.isCanvasTexture && texture.animation) {
       return texture.animation;

--- a/packages/render-fidelity-tools/package-lock.json
+++ b/packages/render-fidelity-tools/package-lock.json
@@ -1078,14 +1078,14 @@
       }
     },
     "node_modules/@babylonjs/core": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.46.0.tgz",
-      "integrity": "sha512-6PCaBByAxeXjM+lX14K2Do1pVbsOeQPA4TCd/Ve+1Gcr2CFKsfPb7c7mtFB90fTlWkN6+tE3zRDeu1ZdvSVKPQ=="
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-5.47.0.tgz",
+      "integrity": "sha512-7RXNZI6IulXVFMFEcWH+Sr3ncQZ4JSu1Rer6voSqzPoRYuBhShwgrq9ntnu9OfXXpa+564fJrNMgj7fD/xWoow=="
     },
     "node_modules/@babylonjs/loaders": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.46.0.tgz",
-      "integrity": "sha512-wJDeXfkO6ObFkJhvCCZGm9u7HXSovrahn5poS0j/dcIc451Tbj5T4tbg6jzL7Gm8kNG/MVEvDt8FKgnH403GyA==",
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-5.47.0.tgz",
+      "integrity": "sha512-yceepCwsyCnjvfjUAiiJUjXa8A8FB7MM1XWvyTsm8kuzQ/b05y9JQoZ+/7sYM2BdONOaEiz/4GYnUYJVPg8eZw==",
       "peerDependencies": {
         "@babylonjs/core": "^5.22.0",
         "babylonjs-gltf2interface": "^5.22.0"
@@ -2425,9 +2425,9 @@
       }
     },
     "node_modules/babylonjs-gltf2interface": {
-      "version": "5.46.0",
-      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.46.0.tgz",
-      "integrity": "sha512-6oJc8ionie906epKgZ3MGlbRkhzxDKvKqXg/YhSY63Vlyr+gSdaDh6RxzB1APqzR9r8RIWYUPP4jVjABMPPHMQ==",
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-5.47.0.tgz",
+      "integrity": "sha512-yUPaEq2aFhTnh4P7r43IpYbCd+2bp+uMevDCbfVAaHTTITlXLNde2AU+7DUXJcG6aRJxxIsPN+r4x8O7IdF0+w==",
       "peer": true
     },
     "node_modules/balanced-match": {
@@ -2744,9 +2744,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001452",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001452.tgz",
-      "integrity": "sha512-Lkp0vFjMkBB3GTpLR8zk4NwW5EdRdnitwYJHDOOKIU85x4ckYCPQ+9WlVvSVClHxVReefkUMtWZH2l9KGlD51w==",
+      "version": "1.0.30001454",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001454.tgz",
+      "integrity": "sha512-4E63M5TBbgDoA9dQoFRdjL6iAmzTrz3rwYWoKDlvnvyvBxjCZ0rrUoX3THhEMie0/RYuTCeMbeTYLGAWgnLwEg==",
       "dev": true,
       "funding": [
         {
@@ -3306,9 +3306,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.297",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.297.tgz",
-      "integrity": "sha512-dTXLXBdzfDYnZYq+bLer21HrFsEkzlR2OSIOsR+qroDmhmQU3i4T4KdY0Lcp83ZId3HnWTpPAEfhaJtVxmS/dQ==",
+      "version": "1.4.300",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.300.tgz",
+      "integrity": "sha512-tHLIBkKaxvG6NnDWuLgeYrz+LTwAnApHm2R3KBNcRrFn0qLmTrqQeB4X4atfN6YJbkOOOSdRBeQ89OfFUelnEQ==",
       "dev": true
     },
     "node_modules/emitter-component": {
@@ -6025,9 +6025,9 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.0.tgz",
-      "integrity": "sha512-ZdhUQlng0RoscyW7jADnUZ25F5eVtHdMyXSb2PiwafvteRAOJUjFoUPEYZSIfP99fBIs3maLIRfpEddT78wAAQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.1.tgz",
+      "integrity": "sha512-nCOzW2V/X15XpLsK2rlgdwrysrBq+AauCn+omItIz4R1pIcmeot5zvjdmOBRLzEH/CkC6IxMJVmxDe3QcMuNVQ==",
       "dev": true,
       "dependencies": {
         "@babel/regjsgen": "^0.8.0",

--- a/packages/space-opera/package-lock.json
+++ b/packages/space-opera/package-lock.json
@@ -3826,9 +3826,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001452",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001452.tgz",
-      "integrity": "sha512-Lkp0vFjMkBB3GTpLR8zk4NwW5EdRdnitwYJHDOOKIU85x4ckYCPQ+9WlVvSVClHxVReefkUMtWZH2l9KGlD51w==",
+      "version": "1.0.30001454",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001454.tgz",
+      "integrity": "sha512-4E63M5TBbgDoA9dQoFRdjL6iAmzTrz3rwYWoKDlvnvyvBxjCZ0rrUoX3THhEMie0/RYuTCeMbeTYLGAWgnLwEg==",
       "dev": true,
       "funding": [
         {
@@ -4538,9 +4538,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.297",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.297.tgz",
-      "integrity": "sha512-dTXLXBdzfDYnZYq+bLer21HrFsEkzlR2OSIOsR+qroDmhmQU3i4T4KdY0Lcp83ZId3HnWTpPAEfhaJtVxmS/dQ==",
+      "version": "1.4.300",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.300.tgz",
+      "integrity": "sha512-tHLIBkKaxvG6NnDWuLgeYrz+LTwAnApHm2R3KBNcRrFn0qLmTrqQeB4X4atfN6YJbkOOOSdRBeQ89OfFUelnEQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -7933,9 +7933,9 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.0.tgz",
-      "integrity": "sha512-ZdhUQlng0RoscyW7jADnUZ25F5eVtHdMyXSb2PiwafvteRAOJUjFoUPEYZSIfP99fBIs3maLIRfpEddT78wAAQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.1.tgz",
+      "integrity": "sha512-nCOzW2V/X15XpLsK2rlgdwrysrBq+AauCn+omItIz4R1pIcmeot5zvjdmOBRLzEH/CkC6IxMJVmxDe3QcMuNVQ==",
       "dev": true,
       "dependencies": {
         "@babel/regjsgen": "^0.8.0",


### PR DESCRIPTION
Fixes #4090 

So, I attempted to include `lottie-web` just for types info on the `animation` object of a LottieTexture, but that does not seem to be how npm works. I've decided the simplest thing is just to remove it entirely and mark `animation` as type `any`. If you actually want to use it in TS, you can import `lottie-web` and cast it appropriately. 