### PR TITLE
fix video texture on iOS

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -150,8 +150,9 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       const video = document.createElement('video');
       video.src = uri;
       video.muted = true;
-      video.play();
+      video.playsInline = true;
       video.loop = true;
+      video.play();
       const texture = new VideoTexture(video);
 
       return this[$buildTexture](texture);


### PR DESCRIPTION
The videoTexture would not automatically play on iOS - turns out to be a simple fix.