### PR TITLE
Remove references to unpkg.com and update to jsDelivr.com for stability

### DIFF
--- a/packages/modelviewer.dev/examples/loading/index.html
+++ b/packages/modelviewer.dev/examples/loading/index.html
@@ -116,7 +116,7 @@
 </model-viewer>
 
 <script>
-  document.querySelector('#button-load').addEventListener('click', 
+  document.querySelector('#button-load').addEventListener('click',
     () => document.querySelector('#lazy-load').dismissPoster());
 </script>
             </template>
@@ -342,7 +342,7 @@ ModelViewerElement.dracoDecoderLocation = 'http://example.com/location/of/draco/
             <template>
 <script>
 self.ModelViewerElement = self.ModelViewerElement || {};
-self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimizer/meshopt_decoder.js';
+self.ModelViewerElement.meshoptDecoderLocation = 'https://cdn.jsdelivr.net/npm/meshoptimizer/meshopt_decoder.js';
 </script>
             </template>
           </example-snippet>
@@ -383,11 +383,11 @@ self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimize
             <h4>To see throttling happen, you'll have to tax your GPU. This model is intentionally complex (including transparency and clear coat)
               so that it will throttle on a fairly broad range of devices. Note that expanding your window and zooming in will tend to tax the GPU
               more since more pixels are being shaded. Also note that the render returns to full scale any time the scene stops moving. If you use
-              very complex 3D models, you may want to disable auto-rotate for this reason. 
+              very complex 3D models, you may want to disable auto-rotate for this reason.
             </h4>
             <h4>Our renderer tries to keep the frame rate between 38 and 60 frames per second. It's a pretty safe bet that if you are at the reportedDpr,
               you are smoothly running at 60 fps, and if you are at the minimumDpr you are likely well below 38 fps. This event only fires in 3D mode;
-              The AR modes also do dynamic render scaling, but do not report their status. 
+              The AR modes also do dynamic render scaling, but do not report their status.
             </h4>
           </div>
           <example-snippet stamp-to="renderScale" highlight-as="html">
@@ -508,7 +508,7 @@ self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimize
   <!-- Enables Meshopt decoder. -->
   <script>
     self.ModelViewerElement = self.ModelViewerElement || {};
-    self.ModelViewerElement.meshoptDecoderLocation = 'https://unpkg.com/meshoptimizer/meshopt_decoder.js';
+    self.ModelViewerElement.meshoptDecoderLocation = 'https://cdn.jsdelivr.net/npm/meshoptimizer/meshopt_decoder.js';
   </script>
 
   <!-- Loads <model-viewer> on modern browsers: -->

--- a/packages/space-opera/src/components/best_practices/constants.ts
+++ b/packages/space-opera/src/components/best_practices/constants.ts
@@ -24,7 +24,7 @@ export const modelViewerTemplate = `<!doctype html>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link type="text/css" href="./styles.css" rel="stylesheet"/>
     <!-- OPTIONAL: The :focus-visible polyfill removes the focus ring for some input types -->
-    <script src="https://unpkg.com/focus-visible@5.0.2/dist/focus-visible.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/focus-visible@5.0.2/dist/focus-visible.js" defer></script>
   </head>
   <body>
     <!-- <model-viewer> HTML element -->

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -92,7 +92,7 @@ export class ModelViewerPreview extends ConnectedLitElement {
     this.addEventListener('dragover', this.onDragover);
     (self as any).ModelViewerElement = (self as any).ModelViewerElement || {};
     (self as any).ModelViewerElement.meshoptDecoderLocation =
-        'https://unpkg.com/meshoptimizer/meshopt_decoder.js';
+        'https://cdn.jsdelivr.net/npm/meshoptimizer/meshopt_decoder.js';
   }
 
   forcePost() {


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
Fixes: Issue #4195 

The MeshOptimizer cannot be resolved due to unpkg.com being down. This changes where meshopt_decoder.js is pulled from to jsDelivr.com which is a more stable option for a CDN.
