### PR TITLE
Point cloud improvements

### DIFF
--- a/packages/model-viewer/src/three-components/GLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/GLTFInstance.ts
@@ -132,10 +132,11 @@ export class GLTFInstance implements GLTF {
   dispose(): void {
     this.scenes.forEach((scene: Group) => {
       scene.traverse((object: Object3D) => {
-        if (!(object as Mesh).isMesh) {
+        const mesh = object as Mesh;
+        if (!mesh.material) {
           return;
         }
-        const mesh = object as Mesh;
+
         const materials =
             Array.isArray(mesh.material) ? mesh.material : [mesh.material];
         materials.forEach(material => {

--- a/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/ModelViewerGLTFInstance.ts
@@ -62,7 +62,7 @@ export class ModelViewerGLTFInstance extends GLTFInstance {
         node.name = node.uuid;
       }
       const mesh = node as Mesh;
-      if (mesh.isMesh) {
+      if (mesh.material) {
         const {geometry} = mesh;
         mesh.castShadow = true;
         if ((mesh as any).isSkinnedMesh) {
@@ -120,8 +120,8 @@ export class ModelViewerGLTFInstance extends GLTFInstance {
       // and materials are copied by reference. This is necessary
       // for the same model to be used twice with different
       // scene-graph operations.
-      if ((node as Mesh).isMesh) {
-        const mesh = node as Mesh;
+      const mesh = node as Mesh;
+      if (mesh.material) {
         const material = mesh.material as MeshStandardMaterial;
         if (material != null) {
           if (sourceUUIDToClonedMaterial.has(material.uuid)) {

--- a/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialLoaderPlugin.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialLoaderPlugin.ts
@@ -117,7 +117,7 @@ export default class GLTFMaterialsVariantsExtension implements
       scene.traverse(object => {
         const mesh = object as Mesh;
 
-        if (!mesh.isMesh) {
+        if (!mesh.material) {
           return;
         }
 

--- a/packages/model-viewer/src/three-components/gltf-instance/correlated-scene-graph.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/correlated-scene-graph.ts
@@ -181,26 +181,24 @@ export class CorrelatedSceneGraph {
    */
   private static[$parallelTraverseThreeScene](
       sceneOne: Group, sceneTwo: Group, callback: ThreeSceneObjectCallback) {
-    const isMesh = (object: unknown): object is Mesh => {
-      return (object as Mesh).isMesh;
-    };
-    const traverse = (a: ThreeSceneObject, b: ThreeSceneObject) => {
+    const traverse = (a: Object3D, b: Object3D) => {
       callback(a, b);
 
-      if ((a as Object3D).isObject3D) {
-        if (isMesh(a)) {
-          if (Array.isArray(a.material)) {
-            for (let i = 0; i < a.material.length; ++i) {
-              traverse(
-                  a.material[i], ((b as typeof a).material as Material[])[i]);
+      if (a.isObject3D) {
+        const meshA = a as Mesh;
+        const meshB = b as Mesh;
+        if (meshA.material) {
+          if (Array.isArray(meshA.material)) {
+            for (let i = 0; i < meshA.material.length; ++i) {
+              callback(meshA.material[i], (meshB.material as Material[])[i]);
             }
           } else {
-            traverse(a.material, (b as typeof a).material as Material);
+            callback(meshA.material, meshB.material as Material);
           }
         }
 
-        for (let i = 0; i < (a as Object3D).children.length; ++i) {
-          traverse((a as Object3D).children[i], (b as Object3D).children[i]);
+        for (let i = 0; i < a.children.length; ++i) {
+          traverse(a.children[i], b.children[i]);
         }
       }
     };

--- a/packages/space-opera/src/components/hotspot_panel/types.ts
+++ b/packages/space-opera/src/components/hotspot_panel/types.ts
@@ -19,6 +19,8 @@
 export interface HotspotConfig {
   // Name of the hotspot, needs to be unique among all hotspots.
   name: string;
-  surface: string
+  surface?: string;
+  position?: string;
+  normal?: string;
   annotation?: string;
 }

--- a/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
+++ b/packages/space-opera/src/components/model_viewer_preview/model_viewer_preview.ts
@@ -44,7 +44,7 @@ import {createSafeObjectUrlFromArrayBuffer} from '../utils/create_object_url.js'
 import {styles as hotspotStyles} from '../utils/hotspot/hotspot.css.js';
 import {renderModelViewer} from '../utils/render_model_viewer.js';
 
-import {dispatchGltfUrl, dispatchModel, getGltfUrl, renderCommonChildElements} from './reducer.js';
+import {dispatchGltfUrl, dispatchModel, getGltfUrl, getModelViewer, renderCommonChildElements} from './reducer.js';
 
 /**
  * Renders and updates the model-viewer tag, serving as a preview of the edits.
@@ -167,16 +167,30 @@ export class ModelViewerPreview extends ConnectedLitElement {
   }
 
   private addHotspot(event: MouseEvent) {
-    const surface =
-        this.modelViewer.surfaceFromPoint(event.clientX, event.clientY);
-    if (!surface) {
-          console.log('Click was not on model, no hotspot added.');
-          return;
+    if (getModelViewer().availableAnimations.length > 0) {
+          const surface =
+              this.modelViewer.surfaceFromPoint(event.clientX, event.clientY);
+          if (!surface) {
+            console.log('Click was not on model, no hotspot added.');
+            return;
+          }
+          reduxStore.dispatch(dispatchAddHotspot({
+            name: generateUniqueHotspotName(),
+            surface,
+          }));
+    } else {
+          const point = this.modelViewer.positionAndNormalFromPoint(
+              event.clientX, event.clientY);
+          if (!point) {
+            console.log('Click was not on model, no hotspot added.');
+            return;
+          }
+          reduxStore.dispatch(dispatchAddHotspot({
+            name: generateUniqueHotspotName(),
+            position: point.position.toString(),
+            normal: point.normal.toString()
+          }));
     }
-    reduxStore.dispatch(dispatchAddHotspot({
-      name: generateUniqueHotspotName(),
-      surface,
-    }));
     reduxStore.dispatch(dispatchUpdateHotspotMode(false));
   }
 

--- a/packages/space-opera/src/components/model_viewer_snippet/parse_hotspot_config.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/parse_hotspot_config.ts
@@ -54,14 +54,15 @@ function parseHotspotConfig(element: HTMLElement): HotspotConfig {
         `Invalid hotspot slot name: ${element.getAttribute('slot')}`);
   }
   const surface = element.dataset['surface'];
-  if (!surface) {
-    throw new Error(
-        `Only surface hotspots are supported: no surface for hotspot at slot "${
-            element.getAttribute('slot')}"`);
+  const position = element.dataset['position'];
+  const normal = element.dataset['normal'];
+  if (!surface && !position) {
+    throw new Error(`no surface or position for hotspot at slot "${
+        element.getAttribute('slot')}"`);
   }
   const annotation =
       element.querySelector('.HotspotAnnotation')?.innerHTML || undefined;
-  return {name, surface, annotation};
+  return {name, surface, position, normal, annotation};
 }
 
 /**

--- a/packages/space-opera/src/components/utils/hotspot/render_hotspots.ts
+++ b/packages/space-opera/src/components/utils/hotspot/render_hotspots.ts
@@ -40,7 +40,12 @@ export function renderHotspot(config: HotspotConfig) {
   const hotspotElement = document.createElement('button');
   hotspotElement.classList.add('Hotspot');
   hotspotElement.slot = `hotspot-${config.name}`;
-  hotspotElement.dataset['surface'] = config.surface;
+  if (config.surface != null) {
+    hotspotElement.dataset['surface'] = config.surface;
+  } else {
+    hotspotElement.dataset['position'] = config.position;
+    hotspotElement.dataset['normal'] = config.normal;
+  }
   hotspotElement.dataset['visibilityAttribute'] = 'visible';
 
   if (config.annotation) {

--- a/packages/space-opera/src/test/model_viewer_snippet/parse_hotspot_config_test.ts
+++ b/packages/space-opera/src/test/model_viewer_snippet/parse_hotspot_config_test.ts
@@ -79,6 +79,6 @@ snippet without position',
        expect(errorList.length).toBe(1);
        expect(errorList[0])
            .toEqual(new Error(
-               'Only surface hotspots are supported: no surface for hotspot at slot "hotspot-1"'));
+               'no surface or position for hotspot at slot "hotspot-1"'));
      });
 });


### PR DESCRIPTION
Fixes #4217 

We had a bunch of code that was mesh-specific, when really it should apply equally well to point or line objects.

This also updates our editor to automatically create surface hotspots only for animated models and world-position hotspots otherwise, which allows this to work for point cloud models.