### PR TITLE
fixed setting currentTime

### DIFF
--- a/packages/model-viewer/src/features/animation.ts
+++ b/packages/model-viewer/src/features/animation.ts
@@ -130,7 +130,9 @@ export const AnimationMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       this[$paused] = true;
 
-      this[$changeAnimation]();
+      if (this.animationName != null) {
+        this[$changeAnimation]();
+      }
 
       if (this.autoplay) {
         this.play();

--- a/packages/model-viewer/src/features/animation.ts
+++ b/packages/model-viewer/src/features/animation.ts
@@ -130,6 +130,8 @@ export const AnimationMixin = <T extends Constructor<ModelViewerElementBase>>(
 
       this[$paused] = true;
 
+      this[$changeAnimation]();
+
       if (this.autoplay) {
         this.play();
       }

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -670,8 +670,6 @@ export class ModelScene extends Scene {
     }
     const {animations} = this;
     if (animations == null || animations.length === 0) {
-      console.warn(
-          `Cannot play animation (model does not have any animations)`);
       return;
     }
 


### PR DESCRIPTION
Fixes #4226 

Just a (almost) one-liner, along with ditching the useless warning. It's required to set `animation-name="0"` (or any other name) before setting `currentTime` will work. Otherwise the model stays at resting pose.