### PR TITLE
fix: Remove doubled period from start of alt text.

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -808,7 +808,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     }
 
     get[$ariaLabel]() {
-      return super[$ariaLabel] +
+      return super[$ariaLabel].replace(/\.$/, '') +
           (this.cameraControls ? INTERACTION_PROMPT : '');
     }
 


### PR DESCRIPTION
Removes ending period from custom alt text if it exists.

### Reference Issue
Fixes #4236 