### PR TITLE
robustify pointing

### DIFF
--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -712,7 +712,7 @@ export class SmoothControls extends EventDispatcher {
     }
 
     // In case no one gave us a pointerup or pointercancel event.
-    if (event.pointerType == 'mouse' && event.buttons === 0) {
+    if (event.pointerType === 'mouse' && event.buttons === 0) {
       this.onPointerUp(event);
       return;
     }

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -711,6 +711,12 @@ export class SmoothControls extends EventDispatcher {
       return;
     }
 
+    // In case no one gave us a pointerup or pointercancel event.
+    if (event.pointerType == 'mouse' && event.buttons === 0) {
+      this.onPointerUp(event);
+      return;
+    }
+
     const numTouches = this.pointers.length;
     const dx = (event.clientX - pointer.clientX) / numTouches;
     const dy = (event.clientY - pointer.clientY) / numTouches;


### PR DESCRIPTION
Once in a while I see our pointer get "stuck down", as in mouse moves with no button down continue to rotate the model. It's rare and usually only happens when dev tools is open. However, recently we found one older macbook that repros it semi-consistently on a particular page, so figured it's better safe than sorry. This should be a solid backstop to any weird situation where we fail to get a `pointerup` or `pointercancel` event.