### PR TITLE
Added postinstall script that updates the three importmap version

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 **/node_modules
+scripts/**/*.js
 packages/*/dist
 packages/**/*.d.ts
 packages/*/src/*-css.ts

--- a/packages/model-viewer-effects/README.md
+++ b/packages/model-viewer-effects/README.md
@@ -52,7 +52,7 @@ npm install three @google/model-viewer @google/model-viewer-effects
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@^0.151.0/build/three.module.js"
+      "three": "https://cdn.jsdelivr.net/npm/three@^0.151.2/build/three.module.min.js"
     }
   }
 </script>

--- a/packages/model-viewer/package-lock.json
+++ b/packages/model-viewer/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@google/model-viewer",
       "version": "3.1.1",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lit": "^2.7.2"

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -45,6 +45,7 @@
   "typings": "lib/model-viewer.d.ts",
   "types": "lib/model-viewer.d.ts",
   "scripts": {
+    "postinstall": "node ../../scripts/postinstall.js",
     "clean": "rm -rf ./lib ./dist",
     "prepare": "if [ ! -L './shared-assets' ]; then ln -s ../shared-assets ./shared-assets; fi && ../shared-assets/scripts/fetch-khronos-gltf-samples.sh",
     "build": "npm run build:tsc && npm run build:rollup",

--- a/packages/modelviewer.dev/data/faq.json
+++ b/packages/modelviewer.dev/data/faq.json
@@ -99,7 +99,7 @@
       {
         "name": "How do I avoid duplicating three.js in my bundle?",
         "htmlName": "duplication",
-        "description": "Three.js used to be marked as our dependency, which meant it was duplicated if you used it in another part of your code base too. As of v3.0.2, it is marked as our peer dependency, allowing you to share it. Note that we pin its version due to frequent breaking changes, so you will not have much version flexibility. This can be worked around using npm's --legacy-peer-deps mode, but please do not file issues if you do this, as we can only ensure our tested quality on one version of three.js at a time. If you are working directly with our bundle, then you may prefer to use the <code>model-viewer-no-three.min.js</code> bundle, and bring Three.js manually using an import-map.",
+        "description": "Three.js used to be marked as our dependency, which meant it was duplicated if you used it in another part of your code base too. As of v3.0.2, it is marked as our peer dependency, allowing you to share it. Note that we pin its version due to frequent breaking changes, so you will not have much version flexibility. This can be worked around using npm's --legacy-peer-deps mode, but please do not file issues if you do this, as we can only ensure our tested quality on one version of three.js at a time. If you are working directly with our bundle, then you may prefer to use the <code>model-viewer-module.min.js</code> bundle, and bring Three.js manually using an import-map.",
         "links": [
           "<a href='https://docs.npmjs.com/cli/v7/using-npm/config#legacy-peer-deps'>NPM legacy-peer-deps documentation</a>"
         ]

--- a/packages/modelviewer.dev/examples/postprocessing/index.html
+++ b/packages/modelviewer.dev/examples/postprocessing/index.html
@@ -32,7 +32,7 @@
   <script type="importmap">
     {
       "imports": {
-        "three": "https://cdn.jsdelivr.net/npm/three@^0.151.0/build/three.module.min.js"
+        "three": "https://cdn.jsdelivr.net/npm/three@^0.151.2/build/three.module.min.js"
       }
     }
   </script>
@@ -107,7 +107,7 @@ button {
 <script type="importmap-noexecute">
 {
   "imports": {
-    "three": "https://cdn.jsdelivr.net/npm/three@0.151.0/build/three.module.js"
+    "three": "https://cdn.jsdelivr.net/npm/three@^0.151.2/build/three.module.min.js"
   }
 }
 </script>

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-// eslint-disable-next-line no-undef
 const fs = require('fs');
 const THREE_REGEX = /three@[~^]?([\dvx*]+(?:[-.](?:[\dx*]+|alpha|beta))*)/gm;
 let NEW_THREE_VERSION;
@@ -25,4 +23,3 @@ function updateThreeVersion(filePath) {
 
 updateThreeVersion('../model-viewer-effects/README.md');
 updateThreeVersion('../modelviewer.dev/examples/postprocessing/index.html');
-// updateThreeVersion('.././packages/model-viewer-effects/README.md');

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line no-undef
+const fs = require('fs');
+const THREE_REGEX = /three@[~^]?([\dvx*]+(?:[-.](?:[\dx*]+|alpha|beta))*)/gm;
+let NEW_THREE_VERSION;
+const THREE_PACKAGE_REGEX = /"three": ".*"/g;
+fs.readFile('package.json', {encoding: 'utf8'}, (err, data) => {
+  NEW_THREE_VERSION = `three@${THREE_PACKAGE_REGEX.exec(data)[0].split(' ')[1].replaceAll('"', '')}`;
+  console.log(NEW_THREE_VERSION);
+});
+
+function updateThreeVersion(filePath) {
+  fs.readFile(filePath, {encoding: 'utf8'}, (err, data) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    const OLD_THREE_VERSION = THREE_REGEX.exec(data)[0];
+    data = data.replaceAll(OLD_THREE_VERSION, NEW_THREE_VERSION);
+    fs.writeFile(filePath, data, {encoding: 'utf8'}, (err) => {
+      if (err) console.log(err);
+    });
+  });
+}
+
+updateThreeVersion('../model-viewer-effects/README.md');
+updateThreeVersion('../modelviewer.dev/examples/postprocessing/index.html');
+// updateThreeVersion('.././packages/model-viewer-effects/README.md');


### PR DESCRIPTION
Whenever npm install is run in `packages/model-viewer`, `packages/model-viewer-effects/README.md` and the examples in `packages/modelviewer.dev/examples/postprocessing/index.html` are automatically updated to be in sync with the three version in `package.json`.