### PR TITLE
check postinstall file exists https://github.com/google/model-viewer/…

### DIFF
--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -47,7 +47,7 @@
   "typings": "lib/model-viewer.d.ts",
   "types": "lib/model-viewer.d.ts",
   "scripts": {
-    "postinstall": "node ../../scripts/postinstall.js",
+    "postinstall": "if [ -f '../../scripts/postinstall.js' ]; then node ../../scripts/postinstall.js; fi",
     "clean": "rm -rf ./lib ./dist",
     "prepare": "if [ ! -L './shared-assets' ]; then ln -s ../shared-assets ./shared-assets; fi && ../shared-assets/scripts/fetch-khronos-gltf-samples.sh",
     "build": "npm run build:tsc && npm run build:rollup",


### PR DESCRIPTION
…issues/4362

<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
<!-- Example: Fixes #1234 -->
Should fix #4362 introduced in version 3.2.0

This is a highly tooling specific script request which in `yarn` will cascade when projects implement 1 of the packages but not the entire mono-repo. I am using the model viewer tag in my own monorepo and yarn will call all the `postinstall` hooks it finds, looking then for `whatever/node_modules/scripts/postinstall.js` which is not a thing for downstream consumers.

I can't install w/ a fresh lock file currently but this is pattern off the other verifications of a file existing to avoid errors.