### PR TITLE
await openIOSARQuickLook when activating AR

### DIFF
--- a/packages/model-viewer/src/features/ar.ts
+++ b/packages/model-viewer/src/features/ar.ts
@@ -197,7 +197,7 @@ export const ARMixin = <T extends Constructor<ModelViewerElementBase>>(
     async activateAR() {
       switch (this[$arMode]) {
         case ARMode.QUICK_LOOK:
-          this[$openIOSARQuickLook]();
+          await this[$openIOSARQuickLook]();
           break;
         case ARMode.WEBXR:
           await this[$enterARWithWebXR]();


### PR DESCRIPTION
### Reference Issue
Fixes #4404

The function `openIOSARQuickLook` is asynchronous and should be awaited.
