### PR TITLE
Add href to AR button, improve accessibility

### DIFF
--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -315,6 +315,8 @@ canvas {
     <slot name="ar-button">
       <a id="default-ar-button" part="default-ar-button" class="fab"
           tabindex="2"
+          role="button"
+          href="javascript:void(0);"
           aria-label="View in your space">
         ${ARGlyph}
       </a>


### PR DESCRIPTION
Fixes #3545. Following the specs set out in  [ARIA in HTML - Document conformance requirements for use of ARIA attributes in HTML](https://www.w3.org/TR/html-aria/#docconformance) an anchor tag should ususally have an href and an anchor tag with href should also have a role. Since this anchor behaves like a button and launches AR, I believe the best solution would be a void href with a role of button.

Confirm the changes worked and all tests passed. Also since we like bigger numbers, the Lighthouse score for "Accessibility" went from 78 to 83 with this change!  

Please let me know if any changes need to be made and I will happily make them (especially if you would like to see tests added, wasn't quite sure where to start there)

I am participating in [Hacktoberfest](https://hacktoberfest.com/) and would love to have this PR count towards my total. No biggie if you can't but adding a "hacktoberfest-accepted" label to the PR would make it count for me!
