### PR TITLE
update render fidelity main page to list renderers in a table.

### DIFF
--- a/packages/render-fidelity-tools/test/results-viewer.html
+++ b/packages/render-fidelity-tools/test/results-viewer.html
@@ -142,7 +142,7 @@
         href="https://www.3ds.com/products-services/3dexcite/resource-center/stellar-physically-correct/"
         target="_blank" rel="noopener">Dassault STELLAR</a></td>
     <td>Path Tracing</td>
-    <td>Unknown</td>
+    <td>Windows, Linux</td>
 </tr> 
 <tr>
   <td><a


### PR DESCRIPTION
Updated the homepage of the render fidelity page to have a list of renders in a table along with their main capabilities, and how they are tested:

![Screenshot 2023-10-25 at 9 02 58 AM](https://github.com/google/model-viewer/assets/588541/13656602-e2bc-4b5a-8e41-7109f9f2052d)

