### PR TITLE
Reduce time for fidelity test CI locally by 50s, Github CI by 130s

### DIFF
--- a/packages/render-fidelity-tools/src/artifact-creator.ts
+++ b/packages/render-fidelity-tools/src/artifact-creator.ts
@@ -279,9 +279,9 @@ export class ArtifactCreator {
       return;
     }
 
-    console.log(`🚀 Launching browser`);
-
+  
     if( this.browser == undefined) {
+      console.log(`🚀 Launching browser`);
       this.browser = await puppeteer.launch({
         headless: false,          
       });

--- a/packages/render-fidelity-tools/src/artifact-creator.ts
+++ b/packages/render-fidelity-tools/src/artifact-creator.ts
@@ -17,10 +17,11 @@ import {promises as fs} from 'fs';
 import mkdirp from 'mkdirp';
 import {join, resolve} from 'path';
 import pngjs from 'pngjs';
-import puppeteer from 'puppeteer';
+import puppeteer, { Browser } from 'puppeteer';
 
 import {DEVICE_PIXEL_RATIO, Dimensions, FIDELITY_TEST_THRESHOLD, FidelityRegressionResults, GoldenConfig, ImageComparator, ImageComparisonAnalysis, ImageComparisonConfig, ScenarioConfig, toDecibel} from './common.js';
 import {ConfigReader} from './config-reader.js';
+
 
 const $configReader = Symbol('configReader');
 
@@ -32,6 +33,8 @@ export interface ScenarioRecord extends ScenarioConfig {
 
 export class ArtifactCreator {
   private[$configReader]: ConfigReader = new ConfigReader(this.config);
+  private browser: Browser | undefined = undefined;
+  private pagePromise: Promise<any> | undefined = undefined;
 
   constructor(
       protected config: ImageComparisonConfig, protected rootDirectory: string,
@@ -39,6 +42,18 @@ export class ArtifactCreator {
     console.log('🌈 Preparing to capture screenshots for fidelity comparison');
   }
 
+  async close() {
+    if( this.pagePromise !== undefined ) {
+      const page = await this.pagePromise;
+      await page.close();
+      this.pagePromise = undefined;
+    }
+
+    if (this.browser !== undefined) {
+      await this.browser.close();
+      this.browser = undefined;
+    }
+  }
   protected get outputDirectory(): string {
     return join(resolve(this.rootDirectory), 'results');
   }
@@ -248,6 +263,7 @@ export class ArtifactCreator {
 
     return analysis;
   }
+  
 
   async captureScreenshot(
       renderer: string, scenarioName: string, dimensions: Dimensions,
@@ -265,18 +281,23 @@ export class ArtifactCreator {
 
     console.log(`🚀 Launching browser`);
 
-    const browser = await puppeteer.launch({
-      defaultViewport: {
-        width: scaledWidth,
-        height: scaledHeight,
-        deviceScaleFactor: DEVICE_PIXEL_RATIO
-      },
-      headless: false
-    });
+    if( this.browser == undefined) {
+      this.browser = await puppeteer.launch({
+        headless: false,          
+      });
+      this.pagePromise = this.browser.newPage();
+    }
 
-    const page = await browser.newPage();
+    const page = await this.pagePromise;
+    this.pagePromise = undefined;
     const url = `${this.baseUrl}?hide-ui&config=../../config.json&scenario=${
         encodeURIComponent(scenarioName)}`;
+
+    await page.setViewport({
+      width: scaledWidth,
+      height: scaledHeight,
+      deviceScaleFactor: DEVICE_PIXEL_RATIO
+    });
 
     page.on('error', (error: any) => {
       console.log(`🚨 ${error}`);
@@ -303,7 +324,7 @@ export class ArtifactCreator {
     // variables are captured in its closure scope. TypeScript compiler
     // currently has no mechanism to detect this and will happily tell you
     // your code is correct when it isn't.
-    const evaluateError = await page.evaluate(async (maxTimeInSec) => {
+    const evaluateError = await page.evaluate(async (maxTimeInSec: number) => {
       const modelBecomesReady = new Promise<void>((resolve, reject) => {
         let timeout: NodeJS.Timeout;
         if (maxTimeInSec > 0) {
@@ -331,7 +352,8 @@ export class ArtifactCreator {
 
     if (evaluateError) {
       console.log(evaluateError);
-      await browser.close();
+      await this.browser.close();
+      this.browser = undefined;
       throw new Error(evaluateError);
     }
 
@@ -346,8 +368,9 @@ export class ArtifactCreator {
     const screenshot =
         await page.screenshot({path: outputPath, omitBackground: true});
 
-    await browser.close();
-
+    page.close();
+    this.pagePromise = this.browser.newPage();
+    
     return screenshot;
   }
 }

--- a/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
+++ b/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
@@ -62,6 +62,7 @@ screenshotCreator.fidelityTest(scenarioWhitelist)
     .then(() => {
       console.log(`✅ Results recorded to ${outputDirectory}`);
       server.close();
+      screenshotCreator.close();
 
       const fidelityRegressionPath =
           join(outputDirectory, 'fidelityRegressionResults.json');

--- a/packages/render-fidelity-tools/src/workflows/update-screenshots/renderer-screenshot.ts
+++ b/packages/render-fidelity-tools/src/workflows/update-screenshots/renderer-screenshot.ts
@@ -53,5 +53,6 @@ export const rendererScreenshot = async(
         renderer, scenarioName, dimensions, outputFile);
   } finally {
     server.close();
+    screenshotCreator.close();
   }
 };


### PR DESCRIPTION
These minor changes save a total of 50s out of the original 146s for each fidelity test run when run locally - thus a 32% savings.  I know of a few more ways to save time (render the next test while evaluating the results of the current one, and then run tests in parallel), but this is the low hanging fruit.

These timings are from a Mac mini M2 Pro:

```bash
# Initial timing runs before these changes
% time npm run test
146.62s user 36.70s system 124% cpu 2:26.74 total

# Reuse browser, rather than creating a new one for each test. saves 42 seconds.
% time npm run test
60.20s user 4.59s system 61% cpu 1:44.97 total

# Create pages ahead of time, hides page creation time.  saves 8 seconds.
% time npm run test
111.77s user 15.31s system 131% cpu 1:36.66 total
```

Also looking at this PR's CI time for the fidelity tests, it appears to have reduce the wall clock from 10m 36s to 8m 28s (2m 10s) for the test run.  I am comparing it to the CI time on this other PR: https://github.com/google/model-viewer/pull/4542