### PR TITLE
enable complex arguments for fidelity test command

### DIFF
--- a/.github/workflows/fidelity-tests.yml
+++ b/.github/workflows/fidelity-tests.yml
@@ -29,4 +29,4 @@ jobs:
     - name: Fidelity tests
       uses: GabrielBB/xvfb-action@v1.0
       with:
-        run: npm run test --workspace=@google/model-viewer-render-fidelity-tools
+        run: npm run test --workspace=@google/model-viewer-render-fidelity-tools -- --quiet

--- a/package-lock.json
+++ b/package-lock.json
@@ -3247,6 +3247,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/yargs": {
+      "version": "17.0.29",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.29.tgz",
+      "integrity": "sha512-nacjqA3ee9zRF/++a3FUY1suHTFKZeHba2n8WeDw9cCVdmzmHpIxyzOJBcpHvvEmS8E9KqWlSnWHUkOrkhWcvA==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.2.tgz",
+      "integrity": "sha512-5qcvofLPbfjmBfKaLfj/+f+Sbd6pN4zl7w7VSVI5uz7m9QZTuB2aZAa2uo1wHFBNN2x6g/SoTkXmd8mQnQF2Cw==",
+      "dev": true
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.1.tgz",
@@ -15755,6 +15770,7 @@
         "@rollup/plugin-commonjs": "^22.0.1",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-replace": "^4.0.0",
+        "@types/yargs": "^17.0.29",
         "polymer-build": "^3.1.4",
         "rollup": "^2.77.2",
         "rollup-plugin-external-globals": "^0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15748,7 +15748,8 @@
         "puppeteer": "^21.3.4",
         "rimraf": "^3.0.2",
         "three": "^0.157.0",
-        "three-gpu-pathtracer": "^0.0.13"
+        "three-gpu-pathtracer": "^0.0.13",
+        "yargs": "^17.7.2"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.1",
@@ -15763,6 +15764,19 @@
         "node": ">=12.0.0"
       }
     },
+    "packages/render-fidelity-tools/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "packages/render-fidelity-tools/node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -15772,6 +15786,60 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/render-fidelity-tools/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/render-fidelity-tools/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "packages/render-fidelity-tools/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/render-fidelity-tools/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/space-opera": {

--- a/packages/render-fidelity-tools/package.json
+++ b/packages/render-fidelity-tools/package.json
@@ -51,6 +51,7 @@
     "@rollup/plugin-commonjs": "^22.0.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-replace": "^4.0.0",
+    "@types/yargs": "^17.0.29",
     "polymer-build": "^3.1.4",
     "rollup": "^2.77.2",
     "rollup-plugin-external-globals": "^0.6.1",

--- a/packages/render-fidelity-tools/package.json
+++ b/packages/render-fidelity-tools/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "description": "<model-viewer> rendering fidelity test suite and tools",
   "scripts": {
-    "test": "node --experimental-modules ./lib/workflows/test-fidelity.js ./test/config.json",
+    "test": "node --experimental-modules ./lib/workflows/test-fidelity.js --config=./test/config.json",
     "test:ci": "./scripts/ci-check-fidelity.sh",
     "update-screenshots": "node --experimental-modules ./lib/workflows/update-screenshots.js ./test/config.json",
     "build": "tsc && rollup -c",
@@ -44,7 +44,8 @@
     "puppeteer": "^21.3.4",
     "rimraf": "^3.0.2",
     "three": "^0.157.0",
-    "three-gpu-pathtracer": "^0.0.13"
+    "three-gpu-pathtracer": "^0.0.13",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.1",

--- a/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
+++ b/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
@@ -63,7 +63,7 @@ async function main() {
       'dry-run': {
         type: 'boolean',
         alias: 'd',
-        description: 'Lists which images would be rendered but doesn\'t render',
+        description: 'Checks that all comparison images exist',
         default: false,
       },
       'quiet': {

--- a/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
+++ b/packages/render-fidelity-tools/src/workflows/test-fidelity.ts
@@ -18,6 +18,19 @@ import module from 'module';
 import {dirname, join, resolve} from 'path';
 import rimraf from 'rimraf';
 
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+ type CommandLineArgs = {
+   config: string;
+   scenario: string[];
+   port: number;
+   dryRun: boolean;
+   quiet: boolean;
+ }
+ 
+
 const require = module.createRequire(import.meta.url);
 // actions/core can only be imported using commonJS's require here
 const core = require('@actions/core');
@@ -25,110 +38,176 @@ const core = require('@actions/core');
 import {ArtifactCreator} from '../artifact-creator.js';
 import {FIDELITY_TEST_THRESHOLD, toDecibel} from '../common.js';
 
-const configPath = resolve(process.argv[2]);
-const rootDirectory = resolve(dirname(configPath));
-const config = require(configPath);
+async function main() {
 
-const outputDirectory = join(rootDirectory, 'results');
-const port = 9030;
-const screenshotCreator = new ArtifactCreator(
-    config,
-    rootDirectory,
-    `http://localhost:${
-        port}/packages/render-fidelity-tools/test/renderers/model-viewer/`);
-const server = HTTPServer.createServer({root: '../../', cache: -1});
-server.listen(port);
+  const argv = await yargs(hideBin(process.argv))
+    .options({
+      'config': {
+        type: 'string',
+        alias: 'c',
+        description: 'Path to configuration json',
+        demandOption: true, // Makes it mandatory. Adjust as per your needs.
+      },
+      'scenario': {
+        type: 'array',
+        alias: 's',
+        description: 'Limit to specific scenarios',
+        demandOption: false, // Makes it mandatory. Adjust as per your needs.
+      },
+      'port': {
+        type: 'number',
+        alias: 'p',
+        description: 'Port for web server',
+        default: 9030,
+      },
+      'dry-run': {
+        type: 'boolean',
+        alias: 'd',
+        description: 'Lists which images would be rendered but doesn\'t render',
+        default: false,
+      },
+      'quiet': {
+        type: 'boolean',
+        alias: 'q',
+        description: 'Hide the puppeteer controlled browser',
+        default: false,
+      },
+    })
+    .help()
+    .alias('help', 'h')
+    .argv;
+
+  const args: CommandLineArgs = {
+    config: argv.config as string,
+    scenario: ( argv.scenario  || [] ) as string[],
+    port: argv.port as number,
+    dryRun: argv['dry-run'],
+    quiet: argv.quiet,
+  };
+
+  console.log( args );
+  const configPath = resolve(args.config);
+  const rootDirectory = resolve(dirname(configPath));
+  const config = require(configPath);
+
+  const outputDirectory = join(rootDirectory, 'results');
+  const screenshotCreator = new ArtifactCreator(
+      config,
+      rootDirectory,
+      `http://localhost:${
+        args.port}/packages/render-fidelity-tools/test/renderers/model-viewer/`);
+  const server = HTTPServer.createServer({root: '../../', cache: -1});
+  server.listen(args.port);
 
 
-try {
-  rimraf.sync(outputDirectory);
-} catch (error) {
-  console.warn(error);
-}
+  try {
+    rimraf.sync(outputDirectory);
+  } catch (error) {
+    console.warn(error);
+  }
 
-let scenarioWhitelist: Set<string>|null = null;
+  let scenarioWhitelist: Set<string>|null = null;
 
-// default update screenshots command takes 3 arguments. If there's more than 3,
-// user has specified scenarios to test
-if (process.argv.length > 3) {
-  scenarioWhitelist = new Set();
+  // user has specified scenarios to test
+  if( args.scenario.length > 0 ) {
+    scenarioWhitelist = new Set();
+    args.scenario.forEach( (scenarioName: string) => {
+      const scenarioNameLower = scenarioName.toLowerCase();
+      let numMatches = 0;
+      config.scenarios.forEach( (scenario: any) => {
+        if( scenario.name.toLowerCase().indexOf( scenarioNameLower ) >= 0 ) {
+          if( ! scenarioWhitelist!.has( scenario.name ) ) {
+            scenarioWhitelist!.add(scenario.name);
+          }
+          numMatches++;
+        }
+      });
+      if( numMatches) {
+        console.warn(`Requested scenario "${scenarioName}" does not match any names found in config`);
+      }
+    });
+  }
 
-  for (let i = 3; i < process.argv.length; i++) {
-    scenarioWhitelist.add(process.argv[i]);
+  try {
+    await screenshotCreator.fidelityTest(scenarioWhitelist, args.dryRun, args.quiet);
+
+    console.log(`✅ Results recorded to ${outputDirectory}`);
+  
+    const fidelityRegressionPath =
+        join(outputDirectory, 'fidelityRegressionResults.json');
+    const {
+      results: fidelityRegressionResults,
+      errors: fidelityRegressionErrors,
+      warnings: fidelityRegressionWarnings
+    } = require(fidelityRegressionPath);
+
+    const fidelityRegressionPassedCount = fidelityRegressionResults.length;
+    const fidelityRegressionErrorCount = fidelityRegressionErrors.length;
+    const fidelityRegressionWarningCount = fidelityRegressionWarnings.length;
+    const scenarioCount = fidelityRegressionPassedCount +
+        fidelityRegressionErrorCount + fidelityRegressionWarningCount
+
+    console.log(`\nFidelity regression test on ${
+        scenarioCount} scenarios finished. (Uses ${
+        FIDELITY_TEST_THRESHOLD} dB as threshold)`);
+    console.log(`Passed ${fidelityRegressionPassedCount} scenarios ✅`);
+    if (fidelityRegressionErrorCount > 0) {
+      console.log(`Failed ${fidelityRegressionErrorCount} scenarios ❌`);
+    } else {
+      let maxError = -Infinity;
+      for (const result of fidelityRegressionResults) {
+        maxError = Math.max(maxError, toDecibel(result.rmsDistanceRatio));
+      }
+      console.log('Worst scenario RMS:', maxError, 'dB');
+    }
+
+    if (fidelityRegressionWarningCount > 0) {
+      console.log(`Warnings on ${fidelityRegressionWarningCount} senarios❗️`);
+      console.log('\n🔍 Logging warning scenarios: ');
+      for (const warning of fidelityRegressionWarnings) {
+        console.log(warning);
+      }
+
+      core.warning(
+          '❗️Fidelity test detected some warnings! Please try to fix them');
+    }
+
+    if (fidelityRegressionErrorCount > 0) {
+      console.log('\n🔍 Logging failed scenarios: ');
+      for (const error of fidelityRegressionErrors) {
+        console.log(error);
+      }
+    }
+
+    const compareRendererResultPath = join(outputDirectory, 'config.json');
+    const {scenarios: comparedRenderResult, errors: compareRendererErrors} =
+        require(compareRendererResultPath);
+    const compareRendererPassCount = comparedRenderResult.length;
+    const compareRendererErrorCount = compareRendererErrors.length;
+
+    if (compareRendererErrorCount > 0) {
+      console.log(
+          `\nCompare Renderers on ${scenarioCount} scenarios finished. ${
+              compareRendererPassCount} scenarios passed ✅, ${
+              compareRendererErrorCount} scenarios failed ❌`);
+      console.log('\n🔍 Logging failed scenarios: ');
+      for (const error of compareRendererErrors) {
+        console.log(error);
+      }
+    }
+
+    if (fidelityRegressionErrorCount > 0 || compareRendererErrorCount > 0) {
+      throw new Error(
+          ' ❌ Fidelity test failed! Please fix the errors listed above before mering this pr!');
+    }
+  }
+  catch(error: any) {
+    core.setFailed(error.message);
+  }
+  finally {
+    server.close();
   }
 }
 
-screenshotCreator.fidelityTest(scenarioWhitelist)
-    .then(() => {
-      console.log(`✅ Results recorded to ${outputDirectory}`);
-      server.close();
 
-      const fidelityRegressionPath =
-          join(outputDirectory, 'fidelityRegressionResults.json');
-      const {
-        results: fidelityRegressionResults,
-        errors: fidelityRegressionErrors,
-        warnings: fidelityRegressionWarnings
-      } = require(fidelityRegressionPath);
-
-      const fidelityRegressionPassedCount = fidelityRegressionResults.length;
-      const fidelityRegressionErrorCount = fidelityRegressionErrors.length;
-      const fidelityRegressionWarningCount = fidelityRegressionWarnings.length;
-      const scenarioCount = fidelityRegressionPassedCount +
-          fidelityRegressionErrorCount + fidelityRegressionWarningCount
-
-      console.log(`\nFidelity regression test on ${
-          scenarioCount} scenarios finished. (Uses ${
-          FIDELITY_TEST_THRESHOLD} dB as threshold)`);
-      console.log(`Passed ${fidelityRegressionPassedCount} scenarios ✅`);
-      if (fidelityRegressionErrorCount > 0) {
-        console.log(`Failed ${fidelityRegressionErrorCount} scenarios ❌`);
-      } else {
-        let maxError = -Infinity;
-        for (const result of fidelityRegressionResults) {
-          maxError = Math.max(maxError, toDecibel(result.rmsDistanceRatio));
-        }
-        console.log('Worst scenario RMS:', maxError, 'dB');
-      }
-
-      if (fidelityRegressionWarningCount > 0) {
-        console.log(`Warnings on ${fidelityRegressionWarningCount} senarios❗️`);
-        console.log('\n🔍 Logging warning scenarios: ');
-        for (const warning of fidelityRegressionWarnings) {
-          console.log(warning);
-        }
-
-        core.warning(
-            '❗️Fidelity test detected some warnings! Please try to fix them');
-      }
-
-      if (fidelityRegressionErrorCount > 0) {
-        console.log('\n🔍 Logging failed scenarios: ');
-        for (const error of fidelityRegressionErrors) {
-          console.log(error);
-        }
-      }
-
-      const compareRendererResultPath = join(outputDirectory, 'config.json');
-      const {scenarios: comparedRenderResult, errors: compareRendererErrors} =
-          require(compareRendererResultPath);
-      const compareRendererPassCount = comparedRenderResult.length;
-      const compareRendererErrorCount = compareRendererErrors.length;
-
-      if (compareRendererErrorCount > 0) {
-        console.log(
-            `\nCompare Renderers on ${scenarioCount} scenarios finished. ${
-                compareRendererPassCount} scenarios passed ✅, ${
-                compareRendererErrorCount} scenarios failed ❌`);
-        console.log('\n🔍 Logging failed scenarios: ');
-        for (const error of compareRendererErrors) {
-          console.log(error);
-        }
-      }
-
-      if (fidelityRegressionErrorCount > 0 || compareRendererErrorCount > 0) {
-        throw new Error(
-            ' ❌ Fidelity test failed! Please fix the errors listed above before mering this pr!');
-      }
-    })
-    .catch((error: any) => core.setFailed(error.message));
+main();


### PR DESCRIPTION
This is very similar to this other PR where I add CLI options to the "update-screenshots" command: #4542 

This implements this idea #4536, but for the "test" command:

```
Options:
      --version   Show version number                                  [boolean]
  -c, --config    Path to configuration json                 [string] [required]
  -s, --scenario  Limit to specific scenarios                            [array]
  -p, --port      Port for web server                   [number] [default: 9030]
  -d, --dry-run   Checks that all comparison images exist
                                                      [boolean] [default: false]
  -q, --quiet     Hide the puppeteer controlled browser
                                                      [boolean] [default: false]
  -h, --help      Show help                                            [boolean]
```

To run the new test ci command, use this command line:

```bash
% npm run test -- --scenario=texture --quiet
```

Explanation of the new features:
--scenario, this now also allows you to specify multiple scenarios in the whitelist, rather than only one. It now also selects scenarios based on being a subset of the config.json scenario name, thus you can run all tests that contain say "transform" or "clearcoat".
--missing-only is very useful when I add new tests and I don't want to render all other tests just to get goldens for the new ones.
--dry-run, when I want to figure out which goldens are missing.
--quiet, I can run the test in the background.  Also gives about a 10% speed boost on my machine.
--port, allows me to run two of these at the same time, useful when I want to run two different renderers at the same time, or work on two separate branches simultaneously.