### PR TITLE
Remove IE11-specific code

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -888,11 +888,7 @@ export const ControlsMixin = <T extends Constructor<ModelViewerElementBase>>(
     };
 
     [$onPointerChange] = (event: PointerChangeEvent) => {
-      if (event.type === 'pointer-change-start') {
-        this[$container].classList.add('pointer-tumbling');
-      } else {
-        this[$container].classList.remove('pointer-tumbling');
-      }
+      this[$container].classList.toggle('pointer-tumbling', event.type === 'pointer-change-start');
     };
   }
 

--- a/packages/model-viewer/src/features/loading.ts
+++ b/packages/model-viewer/src/features/loading.ts
@@ -295,14 +295,7 @@ export const LoadingMixin = <T extends Constructor<ModelViewerElementBase>>(
           parentNode.appendChild(this[$defaultProgressBarElement]);
         }
 
-        // NOTE(cdata): IE11 does not properly respect the second parameter
-        // of classList.toggle, which this implementation originally used.
-        // @see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11865865/
-        if (progress === 1.0) {
-          this[$defaultProgressBarElement].classList.add('hide');
-        } else {
-          this[$defaultProgressBarElement].classList.remove('hide');
-        }
+        this[$defaultProgressBarElement].classList.toggle('hide', progress === 1.0);
       });
     }, PROGRESS_BAR_UPDATE_THRESHOLD);
 

--- a/packages/model-viewer/src/styles/deserializers.ts
+++ b/packages/model-viewer/src/styles/deserializers.ts
@@ -47,13 +47,7 @@ export const enumerationDeserializer = <T extends string>(allowedNames: T[]) =>
                           .map(valueNode => valueNode.value as T)
                           .filter(name => allowedNames.indexOf(name) > -1);
 
-        // NOTE(cdata): IE11 does not support constructing a Set directly from
-        // an iterable, so we need to manually add all the items:
-        const result = new Set<T>();
-        for (const name of names) {
-          result.add(name);
-        }
-        return result;
+        return new Set<T>(names);
       } catch (_error) {
       }
       return new Set();

--- a/packages/model-viewer/src/three-components/Hotspot.ts
+++ b/packages/model-viewer/src/three-components/Hotspot.ts
@@ -175,12 +175,7 @@ export class Hotspot extends CSS2DObject {
   }
 
   updateVisibility(show: boolean) {
-    // NOTE: IE11 doesn't support a second arg for classList.toggle
-    if (show) {
-      this.element.classList.remove('hide');
-    } else {
-      this.element.classList.add('hide');
-    }
+    this.element.classList.toggle('hide', !show);
 
     // NOTE: ShadyDOM doesn't support slot.assignedElements, otherwise we could
     // use that here.
@@ -196,12 +191,7 @@ export class Hotspot extends CSS2DObject {
       if (visibilityAttribute != null) {
         const attributeName = `data-${visibilityAttribute}`;
 
-        // NOTE: IE11 doesn't support toggleAttribute
-        if (show) {
-          element.setAttribute(attributeName, '');
-        } else {
-          element.removeAttribute(attributeName);
-        }
+        element.toggleAttribute(attributeName, show);
       }
 
       element.dispatchEvent(new CustomEvent('hotspot-visibility', {

--- a/packages/model-viewer/src/utilities.ts
+++ b/packages/model-viewer/src/utilities.ts
@@ -207,34 +207,6 @@ export const isDebugMode = (() => {
 
 
 /**
- * Returns the first key in a Map in iteration order.
- *
- * NOTE(cdata): This is necessary because IE11 does not implement iterator
- * methods of Map, and polymer-build does not polyfill these methods for
- * compatibility and performance reasons. This helper proposes that it is
- * a reasonable compromise to sacrifice a very small amount of runtime
- * performance in IE11 for the sake of code clarity.
- */
-export const getFirstMapKey = <T = any, U = any>(map: Map<T, U>): T|null => {
-  if (map.keys != null) {
-    return map.keys().next().value || null;
-  }
-
-  let firstKey: T|null = null;
-
-  try {
-    map.forEach((_value: U, key: T, _map: Map<T, U>) => {
-      firstKey = key;
-      // Stop iterating the Map with forEach:
-      throw new Error();
-    });
-  } catch (_error) {
-  }
-
-  return firstKey;
-};
-
-/**
  * Three.js EventDispatcher and DOM EventTarget use different event patterns,
  * so AnyEvent covers the shape of both event types.
  */


### PR DESCRIPTION
### Description

While browsing through the code, I found some IE11-specific code. Since IE11 is not a supported browser anymore (by model-viewer's [README](https://github.com/google/model-viewer/tree/99fa9a8ba5c31ba161880f8b82248a196759dee4/packages/model-viewer#browser-support)), nor by [three.js](https://github.com/mrdoob/three.js/blob/4acb78002425969f7c0cf46423ea5f728c41dfbc/package.json#L40), I think this code can be refactored to more modern code. This change leads to a somewhat smaller bundle size.

## Bundle size

File size after a `npm run build`:

| File name                          | Old size (byte) | New size (byte) | Size diff (byte) | Size difference (%) |
| ---------------------------------- | -------- | -------- | ----------------- | ------------------- |
| model-viewer-module-umd.js         | 811477   | 810695   | \-782             | \-0,10              |
| model-viewer-module-umd.js.map     | 1824995  | 1822288  | \-2707            | \-0,15              |
| model-viewer-module-umd.min.js     | 375008   | 374852   | \-156             | \-0,04              |
| model-viewer-module-umd.min.js.map | 1296291  | 1295330  | \-961             | \-0,07              |
| model-viewer-module.js             | 849033   | 847786   | \-1247            | \-0,15              |
| model-viewer-module.js.map         | 1833299  | 1830557  | \-2742            | \-0,15              |
| model-viewer-module.min.js         | 396451   | 396295   | \-156             | \-0,04              |
| model-viewer-module.min.js.map     | 1330861  | 1329425  | \-1436            | \-0,11              |
| model-viewer-umd.js                | 1751653  | 1750943  | \-710             | \-0,04              |
| model-viewer-umd.js.map            | 4288624  | 4285917  | \-2707            | \-0,06              |
| model-viewer-umd.min.js            | 896545   | 896389   | \-156             | \-0,02              |
| model-viewer-umd.min.js.map        | 2956094  | 2955163  | \-931             | \-0,03              |
| model-viewer.d.ts                  | 82362    | 82362    | 0                 | 0,00                |
| model-viewer.js                    | 1818886  | 1817639  | \-1247            | \-0,07              |
| model-viewer.js.map                | 4300191  | 4297449  | \-2742            | \-0,06              |
| model-viewer.min.js                | 920632   | 920476   | \-156             | \-0,02              |
| model-viewer.min.js.map            | 2986699  | 2985245  | \-1454            | \-0,05              |

## Testing

`npm run test` succeeds on my local machine.

## UMD bundles

In the rollup config I found this code:

https://github.com/google/model-viewer/blob/99fa9a8ba5c31ba161880f8b82248a196759dee4/packages/model-viewer/rollup.config.js#L73-L83

If I understand correctly this is not just for IE11, but for any browser that does not support ES Modules. The specific lines were introduced in https://github.com/google/model-viewer/commit/92111b3ac68c22508bc00edb6300404407308008. Since all modern / supported browsers support ES6 Modules ([caniuse](https://caniuse.com/es6-module)), I doubt if the UMD bundles are still required. I do not see any usage of the umd bundles in the repository itself (e.g. in the aforementioned unit test build).

Because I am not sure, I did not touch the rollup config.