### PR TITLE
Add CreateVideoTextureOptions to support crossOrigin videos

### DIFF
--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -42,6 +42,10 @@ interface SceneExportOptions {
       forceIndices?: boolean
 }
 
+interface CreateVideoTextureOptions {
+  crossOrigin?: string
+}
+
 export interface SceneGraphInterface {
   readonly model?: Model;
   variantName: string|null;
@@ -53,7 +57,7 @@ export interface SceneGraphInterface {
   createTexture(uri: string, type?: string): Promise<ModelViewerTexture|null>;
   createLottieTexture(uri: string, quality?: number):
       Promise<ModelViewerTexture|null>;
-  createVideoTexture(uri: string): ModelViewerTexture;
+  createVideoTexture(uri: string, options?: CreateVideoTextureOptions): ModelViewerTexture;
   createCanvasTexture(): ModelViewerTexture;
   /**
    * Intersects a ray with the scene and returns a list of materials who's
@@ -146,8 +150,11 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       return this[$buildTexture](texture);
     }
 
-    createVideoTexture(uri: string): ModelViewerTexture {
+    createVideoTexture(uri: string, options?: CreateVideoTextureOptions): ModelViewerTexture {
       const video = document.createElement('video');
+      if(options?.crossOrigin) {
+        video.crossOrigin = options.crossOrigin;
+      }
       video.src = uri;
       video.muted = true;
       video.playsInline = true;

--- a/packages/model-viewer/src/features/scene-graph.ts
+++ b/packages/model-viewer/src/features/scene-graph.ts
@@ -42,10 +42,6 @@ interface SceneExportOptions {
       forceIndices?: boolean
 }
 
-interface CreateVideoTextureOptions {
-  crossOrigin?: string
-}
-
 export interface SceneGraphInterface {
   readonly model?: Model;
   variantName: string|null;
@@ -57,7 +53,7 @@ export interface SceneGraphInterface {
   createTexture(uri: string, type?: string): Promise<ModelViewerTexture|null>;
   createLottieTexture(uri: string, quality?: number):
       Promise<ModelViewerTexture|null>;
-  createVideoTexture(uri: string, options?: CreateVideoTextureOptions): ModelViewerTexture;
+  createVideoTexture(uri: string): ModelViewerTexture;
   createCanvasTexture(): ModelViewerTexture;
   /**
    * Intersects a ray with the scene and returns a list of materials who's
@@ -150,11 +146,9 @@ export const SceneGraphMixin = <T extends Constructor<ModelViewerElementBase>>(
       return this[$buildTexture](texture);
     }
 
-    createVideoTexture(uri: string, options?: CreateVideoTextureOptions): ModelViewerTexture {
+    createVideoTexture(uri: string): ModelViewerTexture {
       const video = document.createElement('video');
-      if(options?.crossOrigin) {
-        video.crossOrigin = options.crossOrigin;
-      }
+      video.crossOrigin = this.withCredentials ? 'use-credentials' : 'anonymous';
       video.src = uri;
       video.muted = true;
       video.playsInline = true;

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -1122,9 +1122,9 @@
         ]
       },
       {
-        "name": "createVideoTexture(uri, options?)",
+        "name": "createVideoTexture(uri)",
         "htmlName": "createVideoTexture",
-        "description": "Returns a Texture object for use with the <code>setTexture</code> method on <code>TextureInfo</code> objects in the Materials API. The video element created is available through <code>texture.source.element</code> for controlling playback. for cross origin resources, you can set `options.crossOrigin` to `anonymous`.",
+        "description": "Returns a Texture object for use with the <code>setTexture</code> method on <code>TextureInfo</code> objects in the Materials API. The video element created is available through <code>texture.source.element</code> for controlling playback.",
         "links": [
           "<a href=\"../examples/scenegraph/#animatedTexturesExample\">Create animated textures example</a>"
         ]

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -1122,9 +1122,9 @@
         ]
       },
       {
-        "name": "createVideoTexture(uri)",
+        "name": "createVideoTexture(uri, options?)",
         "htmlName": "createVideoTexture",
-        "description": "Returns a Texture object for use with the <code>setTexture</code> method on <code>TextureInfo</code> objects in the Materials API. The video element created is available through <code>texture.source.element</code> for controlling playback.",
+        "description": "Returns a Texture object for use with the <code>setTexture</code> method on <code>TextureInfo</code> objects in the Materials API. The video element created is available through <code>texture.source.element</code> for controlling playback. for cross origin resources, you can set `options.crossOrigin` to `anonymous`.",
         "links": [
           "<a href=\"../examples/scenegraph/#animatedTexturesExample\">Create animated textures example</a>"
         ]


### PR DESCRIPTION
<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
Fixes #4634
<!-- Example: Fixes #1234 -->


### Features
- Adds `option: CreateVideoTextureOptions` argument to `createVideoTexture`. Allowing to call it like `createVideoTexture(url, {crossOrigin: "anonymous"})`


Please let me know if there is any change needed if the solution is accepted (like updating documents, etc).
