### PR TITLE
fix: small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The `<model-viewer>` project
 
-This is the main Github repository for the `<model-viewer>` web component and
+This is the main GitHub repository for the `<model-viewer>` web component and
 all of its related projects.
 
 **Getting started?** Check out the [`<model-viewer>`](packages/model-viewer) project!


### PR DESCRIPTION
This commit corrects a tiny typo in the capitalization of "GitHub".

<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
N/A
