### PR TITLE
Add missed file extensions to relative imports of model-viewer and moddel-viewer-effects

### DIFF
--- a/packages/model-viewer-effects/src/test/utilities.ts
+++ b/packages/model-viewer-effects/src/test/utilities.ts
@@ -14,7 +14,7 @@
  */
 
 import {ModelViewerElement} from '@google/model-viewer';
-import {Renderer} from '@google/model-viewer/lib/three-components/Renderer';
+import {Renderer} from '@google/model-viewer/lib/three-components/Renderer.js';
 import {EventDispatcher, HSL} from 'three';
 
 import {getOwnPropertySymbolValue} from '../utilities.js';

--- a/packages/model-viewer/src/styles/evaluators.ts
+++ b/packages/model-viewer/src/styles/evaluators.ts
@@ -14,7 +14,7 @@
  */
 
 import {normalizeUnit} from './conversions.js';
-import {ExpressionNode, ExpressionTerm, FunctionNode, IdentNode, NumberNode, numberNode, OperatorNode, Percentage, Unit, ZERO} from './parsers';
+import {ExpressionNode, ExpressionTerm, FunctionNode, IdentNode, NumberNode, numberNode, OperatorNode, Percentage, Unit, ZERO} from './parsers.js';
 
 export type Evaluatable<T> = Evaluator<T>|T;
 

--- a/packages/model-viewer/src/test/features/scene-graph/nodes/primitive-node-spec.ts
+++ b/packages/model-viewer/src/test/features/scene-graph/nodes/primitive-node-spec.ts
@@ -14,7 +14,7 @@
  */
 
 import {expect} from '@esm-bundle/chai';
-import {MeshStandardMaterial} from 'three/src/materials/MeshStandardMaterial';
+import {MeshStandardMaterial} from 'three/src/materials/MeshStandardMaterial.js';
 
 import {$primitivesList, $variantData, Model} from '../../../../features/scene-graph/model.js';
 import {ModelViewerElement} from '../../../../model-viewer.js';

--- a/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialLoaderPlugin.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/VariantMaterialLoaderPlugin.ts
@@ -26,7 +26,7 @@
  */
 
 import {Material as ThreeMaterial, Mesh} from 'three';
-import {GLTFReference} from 'three/examples/jsm/loaders/GLTFLoader';
+import {GLTFReference} from 'three/examples/jsm/loaders/GLTFLoader.js';
 import {GLTF, GLTFLoaderPlugin, GLTFParser} from 'three/examples/jsm/loaders/GLTFLoader.js';
 
 

--- a/packages/model-viewer/src/three-components/gltf-instance/gltf-defaulted.ts
+++ b/packages/model-viewer/src/three-components/gltf-instance/gltf-defaulted.ts
@@ -1,6 +1,6 @@
 import {Vector2} from 'three';
 
-import {Accessor, AlphaMode, AnimationSampler, Asset, Camera, ExtensionDictionary, Extras, MagFilter, Mesh, MinFilter, RGB, RGBA, Scene, WrapMode} from './gltf-2.0';
+import {Accessor, AlphaMode, AnimationSampler, Asset, Camera, ExtensionDictionary, Extras, MagFilter, Mesh, MinFilter, RGB, RGBA, Scene, WrapMode} from './gltf-2.0.js';
 
 
 export interface Sampler {


### PR DESCRIPTION
I missed a few file extensions in my code search

### Reference Issue
Fixes #4688 again
