### PR TITLE
Make Khronos PBR Neutral invertable

### DIFF
--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -158,7 +158,7 @@ export class Renderer extends
         color *= newPeak / peak;
 
         float g = 1. - 1. / (desaturation * (peak - newPeak) + 1.);
-        return mix(color, vec3(1, 1, 1), g);
+        return mix(color, newPeak * vec3(1, 1, 1), g);
       }`);
 
     try {

--- a/packages/modelviewer.dev/examples/tone-mapping.html
+++ b/packages/modelviewer.dev/examples/tone-mapping.html
@@ -415,7 +415,9 @@
     metals, as they physically color the light they reflect, but perceptually
     that color is lost when it is sufficiently bright. I accomplish this by
     taking a convex combination of the compressed color and white, only in the
-    nonlinear compression region.</p>
+    nonlinear compression region. In fact, "white" is slightly darkened in order
+    to maintain constant brightness with the compressed color, which makes this
+    tone mapper easily invertible.</p>
 
     <p>The convex parameter function I chose is another 1/x, this time based on
     the amount of brightness removed in the compression step, which ensures it
@@ -450,7 +452,7 @@
     color *= newPeak / peak;
 
     float g = 1. - 1. / (desaturation * (peak - newPeak) + 1.);
-    return mix(color, vec3(1, 1, 1), g);
+    return mix(color, newPeak * vec3(1, 1, 1), g);
   }
     </code>
     </p>


### PR DESCRIPTION
Feedback from Autodesk was that the ability to analytically invert a tone mapping function has a lot of important use cases through the industry. It turns out my tone mapper was quite difficult to invert, but a very small and almost imperceptible change made it trivial to invert. The key is making the desaturation step not change the compressed brightness value, so instead of mixing toward pure white `[1, 1, 1]`, instead go toward `peak * [1, 1, 1]`. Anywhere the mix is significant, `peak` is already very close to 1, so this is a minor change, but it helps enormously with invertibility since these asymptotes become so sensitive when inverted. 

I've included an analytical inverse function in `lut-writer.mjs` and verified the round-trip relative error is less than `2e-10`.