### PR TITLE
fix DPR for iframes

### DIFF
--- a/packages/model-viewer/src/utilities.ts
+++ b/packages/model-viewer/src/utilities.ts
@@ -164,6 +164,12 @@ export const resolveDpr: () => number = (() => {
       return true;
     }
 
+    if (window.self !== window.top) {
+      // iframes can't detect the meta viewport tag, so assume the top-level
+      // page has one.
+      return true;
+    }
+
     const metas = document.head != null ?
         Array.from(document.head.querySelectorAll('meta')) :
         [];


### PR DESCRIPTION
Turns out any `<model-viewer>` embedded in an `<iframe>` gets the capped DPR=1 (no high-res render) unless the iframe has a meta viewport tag in its own `<head>`. That's a bit weird, since meta viewport tags are ignored in iframes and only the top-level document counts. As such, we'll assume the top level document has a meta viewport tag (as that's more common) when the element is inside an iframe and can't query its parent's `<head>`. 