### PR TITLE
 parse_hotspot_config.ts DOM text reinterpreted as HTML 

### DIFF
--- a/packages/space-opera/src/components/model_viewer_snippet/parse_hotspot_config.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/parse_hotspot_config.ts
@@ -61,7 +61,7 @@ function parseHotspotConfig(element: HTMLElement): HotspotConfig {
         element.getAttribute('slot')}"`);
   }
   const annotation =
-      element.querySelector('.HotspotAnnotation')?.innerHTML || undefined;
+      element.querySelector('.HotspotAnnotation')?.innerText || undefined;
   return {name, surface, position, normal, annotation};
 }
 

--- a/packages/space-opera/src/components/model_viewer_snippet/parse_hotspot_config.ts
+++ b/packages/space-opera/src/components/model_viewer_snippet/parse_hotspot_config.ts
@@ -60,10 +60,10 @@ function parseHotspotConfig(element: HTMLElement): HotspotConfig {
     throw new Error(`no surface or position for hotspot at slot "${
         element.getAttribute('slot')}"`);
   }
-  const annotation =
-      element.querySelector('.HotspotAnnotation')?.innerText || undefined;
+  const annotation = (element.querySelector('.HotspotAnnotation') as HTMLElement)?.innerText || undefined; // Update here
   return {name, surface, position, normal, annotation};
 }
+
 
 /**
  * Returns the slot name of the element without 'hotspot-'. Returns undefined if


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.
