### PR TITLE
Load the renderer only when <model-viewer> is present

### DIFF
--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -60,15 +60,18 @@ const COMMERCE_EXPOSURE = 1.3;
  */
 export class Renderer extends
     EventDispatcher<{contextlost: {sourceEvent: WebGLContextEvent}}> {
-  private static _singleton = new Renderer({
-    powerPreference:
-        (((self as any).ModelViewerElement || {}) as ModelViewerGlobalConfig)
-            .powerPreference ||
-        DEFAULT_POWER_PREFERENCE,
-    debug: isDebugMode()
-  });
+  private static _singleton: Renderer;
 
   static get singleton() {
+    if (!this._singleton) {
+      this._singleton = new Renderer({
+        powerPreference:
+            (((self as any).ModelViewerElement || {}) as ModelViewerGlobalConfig)
+                .powerPreference ||
+            DEFAULT_POWER_PREFERENCE,
+        debug: isDebugMode()
+      });
+    }
     return this._singleton;
   }
 


### PR DESCRIPTION
I'm building an online store and I'm using Swup.js to have animated page transitions. It uses ajax to replace the contents of the website without doing a full reload.

This store has 3D objects **only** in each product page.  Nonetheless, I have to load the script as a module in every page because of the way Swup.js works. I cannot have a <script> for the product page and get it to load manually at some point without touching the code of the source script. They have to be bundled with the rest of the site.

I've noticed a good amount of stuttering when any page loads from cold. Tracing and profiling the site, I've noticed `Renderer._singleton` gets called on every page load, even though there may not be any `<model-viewer>` present in the page at that moment.

`Renderer._singleton` initializes a bunch of calls related to threejs and the canvas renderer, which takes a unnecessary hit to the main thread of the browser. Animations will stutter. Much more noticiable in mobile phones.

By moving the `new Renderer` declaration to `static get singleton()` we build the renderer only when the `<model-viewer>` HTML element is being constructed.

Apart from this, it would be awesome to make the process of creating the renderer much smoother and minimize the jank/stutter in the loading/construction process of the 3D scene. Is there a chance web workers could be used for this task? My knowledge regarding the render process is limited and I may be completely wrong on this assumption.

Thank you!
