### PR TITLE
cleanup and redirect

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -28,12 +28,6 @@ jobs:
     - name: Build packages
       run: npm run build
 
-    - name: Generate fidelity artifacts 
-      continue-on-error: true
-      uses: GabrielBB/xvfb-action@v1.0
-      with:
-        run: npm run test --workspace=@google/model-viewer-render-fidelity-tools
-
     - name: Stage documentation artifacts
       run: ./packages/modelviewer.dev/scripts/ci-before-deploy.sh
 

--- a/packages/modelviewer.dev/examples/fidelity.html
+++ b/packages/modelviewer.dev/examples/fidelity.html
@@ -1,0 +1,27 @@
+<!--
+/* @license
+ * Copyright 2024 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url='https://github.khronos.org/glTF-Render-Fidelity/comparison/'" />
+</head>
+<body>
+  <p>This glTF render fidelity comparison page has moved to official Khronos ownership and now lives at <a href="https://github.khronos.org/glTF-Render-Fidelity/comparison/">this link</a>.</p>
+</body>
+</html>

--- a/packages/modelviewer.dev/scripts/ci-before-deploy.sh
+++ b/packages/modelviewer.dev/scripts/ci-before-deploy.sh
@@ -97,6 +97,7 @@ done
 set -x
 
 # Copy the latest fidelity testing results:
+mkdir -p $DEPLOY_ROOT/fidelity
 mkdir -p $DEPLOY_ROOT/editor
 mkdir -p $DEPLOY_ROOT/editor/view
 mkdir -p $DEPLOY_ROOT/dist
@@ -109,6 +110,7 @@ mkdir -p $DEPLOY_ROOT/node_modules/@google/model-viewer-effects/dist
 mkdir -p $DEPLOY_ROOT/node_modules/js-beautify
 mkdir -p $DEPLOY_ROOT/node_modules/web-animations-js
 
+cp examples/fidelity.html $DEPLOY_ROOT/fidelity/index.html
 cp ../space-opera/editor/index.html $DEPLOY_ROOT/editor/
 cp ../space-opera/editor/view/index.html $DEPLOY_ROOT/editor/view/
 cp ../space-opera/dist/space-opera.js $DEPLOY_ROOT/dist/


### PR DESCRIPTION
This should set our old modelviewer.dev/fidelity link to redirect to the new Khronos page. It also speeds up our deployment process, since we no longer have to generate goldens for that. 