### PR TITLE
Fix: tone mapping dropdown used the wrong value (5: Custom instead of 7: Neutral)

### DIFF
--- a/packages/modelviewer.dev/examples/tone-mapping.html
+++ b/packages/modelviewer.dev/examples/tone-mapping.html
@@ -490,7 +490,7 @@
       >
         <p>
           <select id="tonemapper">
-            <option value="5">PBR Neutral</option>
+            <option value="7">PBR Neutral</option>
             <option value="1">Linear/Clamped</option>
             <option value="4">ACES</option>
             <option value="6">AgX</option>


### PR DESCRIPTION
Fixes https://github.com/google/model-viewer/issues/4804