### PR TITLE
allow top and bottom view by default

### DIFF
--- a/packages/model-viewer/src/features/controls.ts
+++ b/packages/model-viewer/src/features/controls.ts
@@ -170,7 +170,7 @@ const minCameraOrbitIntrinsics = (element: ModelViewerElementBase&
   return {
     basis: [
       numberNode(-Infinity, 'rad'),
-      numberNode(Math.PI / 8, 'rad'),
+      numberNode(0, 'rad'),
       numberNode(radius, 'm')
     ],
     keywords: {auto: [null, null, null]}
@@ -185,7 +185,7 @@ const maxCameraOrbitIntrinsics = (element: ModelViewerElementBase) => {
   return {
     basis: [
       numberNode(Infinity, 'rad'),
-      numberNode(Math.PI - Math.PI / 8, 'rad'),
+      numberNode(Math.PI, 'rad'),
       numberNode(defaultRadius, 'm')
     ],
     keywords: {auto: [null, null, null]}

--- a/packages/model-viewer/src/three-components/SmoothControls.ts
+++ b/packages/model-viewer/src/three-components/SmoothControls.ts
@@ -58,8 +58,8 @@ export interface SmoothControlsOptions {
 export const DEFAULT_OPTIONS = Object.freeze<SmoothControlsOptions>({
   minimumRadius: 0,
   maximumRadius: Infinity,
-  minimumPolarAngle: Math.PI / 8,
-  maximumPolarAngle: Math.PI - Math.PI / 8,
+  minimumPolarAngle: 0,
+  maximumPolarAngle: Math.PI,
   minimumAzimuthalAngle: -Infinity,
   maximumAzimuthalAngle: Infinity,
   minimumFieldOfView: 10,

--- a/packages/modelviewer.dev/data/docs.json
+++ b/packages/modelviewer.dev/data/docs.json
@@ -618,7 +618,7 @@
         "htmlName": "maxCameraOrbit",
         "description": "Set the maximum orbital values of the camera. Takes values in the same form as camera-orbit, but does not support <span class='attribute'>env()</span>. Note \"Infinity\" is not an accepted keyword, but the default can still be obtained by passing \"auto\". The radius value for \"auto\" is the same as the <span class='attribute'>camera-orbit</span> radius \"auto\" value.",
         "default": {
-          "default": "Infinity 157.5deg auto",
+          "default": "Infinity 180deg auto",
           "options": "$theta $phi $radius"
         }
       },
@@ -627,7 +627,7 @@
         "htmlName": "minCameraOrbit",
         "description": "Set the minimum orbital values of the camera. Note \"Infinity\" is not an accepted keyword, but the default can still be obtained by passing \"auto\". The radius value for \"auto\" is a conservative value to ensure the camera never enters the model, so be careful when setting this to another value.",
         "default": {
-          "default": "-Infinity 22.5deg auto",
+          "default": "-Infinity 0deg auto",
           "options": "$theta $phi $radius"
         }
       },

--- a/packages/render-fidelity-tools/test/config.json
+++ b/packages/render-fidelity-tools/test/config.json
@@ -795,7 +795,7 @@
       "model": "../../../shared-assets/models/glTF-Sample-Assets/Models/RecursiveSkeletons/glTF-Binary/RecursiveSkeletons.glb",
       "orbit": {
         "radius": 120.0,
-        "phi": 5
+        "phi": 22.5
       },
       "target": {
         "y": 95


### PR DESCRIPTION
As this updates our defaults, it is technically a breaking change, though very minor. Our default camera limits used to not allow a pure top or bottom view - they had to be manually extended to get the full 0-180 range of camera elevation. Now that is our default, but you can always set them back to how they were if you desire the legacy behavior. 