### PR TITLE
fixed two examples bugs

### DIFF
--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -184,18 +184,14 @@
 
   window.addEventListener("resize", onResize);
 
-  function setVisible(visible) {
+  modelViewer1.addEventListener('ar-status', (event) => {
     lines.forEach((element) => {
-      if (visible) {
+      if (event.detail.status !== 'session-started') {
         element.classList.remove('hide');
       } else {
         element.classList.add('hide');
       }
     });
-  }
-
-  modelViewer1.addEventListener('ar-status', (event) => {
-    setVisible(event.detail.status !== 'session-started');
     onResize();
   });
 

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -184,7 +184,20 @@
 
   window.addEventListener("resize", onResize);
 
-  modelViewer1.addEventListener('ar-status', onResize);
+  function setVisible(visible) {
+    lines.forEach((element) => {
+      if (visible) {
+        element.classList.remove('hide');
+      } else {
+        element.classList.add('hide');
+      }
+    });
+  }
+
+  modelViewer1.addEventListener('ar-status', (event) => {
+    setVisible(event.detail.status !== 'session-started');
+    onResize();
+  });
 
   modelViewer1.addEventListener('load', () => {
     onResize();

--- a/packages/modelviewer.dev/examples/annotations/index.html
+++ b/packages/modelviewer.dev/examples/annotations/index.html
@@ -174,7 +174,9 @@
   let tailRect;
   
   function onResize(){
-    baseRect = modelViewer1.getBoundingClientRect();
+    const arStatus = modelViewer1.getAttribute('ar-status');
+    baseRect = (arStatus == "not-presenting" || arStatus == "failed") ? 
+      modelViewer1.getBoundingClientRect() : new DOMRect();
     noseRect = document.querySelector('#nose').getBoundingClientRect();
     hoofRect = document.querySelector('#hoof').getBoundingClientRect();
     tailRect = document.querySelector('#tail').getBoundingClientRect();

--- a/packages/modelviewer.dev/examples/postprocessing/index.html
+++ b/packages/modelviewer.dev/examples/postprocessing/index.html
@@ -305,7 +305,7 @@ tonemapping.addEventListener('input', (e) => colorGradeEffect.tonemapping = e.ta
           </div>
           <example-snippet stamp-to="combining-effects" highlight-as="html">
             <template>
-<model-viewer id="effectsViewer" camera-controls touch-action="pan-y" src="../../shared-assets/models/EmissiveStrengthTest.glb" ar alt="A 3D ">
+<model-viewer id="effectsViewer" camera-controls scale="0.1 0.1 0.1" touch-action="pan-y" src="../../shared-assets/models/EmissiveStrengthTest.glb" ar alt="A 3D ">
   <effect-composer render-mode="quality">
     <outline-effect color="blue" blend-mode="skip"></outline-effect>
     <ssao-effect blend-mode="skip"></ssao-effect>


### PR DESCRIPTION
Apparently the trick in WebXR is to remember that we don't fullscreen the whole MV element, but just the slot that carries its children. This means you can't ask about the size of MV - it's still hidden on the old page. But in AR mode, you know you're always full-screen, so use those dimensions instead.