### PR TITLE
[WIP] switch to WebGPU

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3412,9 +3412,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.4.tgz",
-      "integrity": "sha512-jfUJrFct/hTA0XDM5p/htWKoNNTbDLY0KRwEt6pyOA6k2fmk0WVwl65PdUdJZgzGEHWx+49LilkcSaumQRyNQw==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.26.0.tgz",
+      "integrity": "sha512-gJNwtPDGEaOEgejbaseY6xMFu+CPltsc8/T+diUTTbOQLqD+bnrJq9ulH6WD69TqwqWmrfRAtUv30cCFZlbGTQ==",
       "cpu": [
         "arm"
       ],
@@ -3426,9 +3426,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.4.tgz",
-      "integrity": "sha512-j4nrEO6nHU1nZUuCfRKoCcvh7PIywQPUCBa2UsootTHvTHIoIu2BzueInGJhhvQO/2FTRdNYpf63xsgEqH9IhA==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.26.0.tgz",
+      "integrity": "sha512-YJa5Gy8mEZgz5JquFruhJODMq3lTHWLm1fOy+HIANquLzfIOzE9RA5ie3JjCdVb9r46qfAQY/l947V0zfGJ0OQ==",
       "cpu": [
         "arm64"
       ],
@@ -3440,9 +3440,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.4.tgz",
-      "integrity": "sha512-GmU/QgGtBTeraKyldC7cDVVvAJEOr3dFLKneez/n7BvX57UdhOqDsVwzU7UOnYA7AAOt+Xb26lk79PldDHgMIQ==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.26.0.tgz",
+      "integrity": "sha512-ErTASs8YKbqTBoPLp/kA1B1Um5YSom8QAc4rKhg7b9tyyVqDBlQxy7Bf2wW7yIlPGPg2UODDQcbkTlruPzDosw==",
       "cpu": [
         "arm64"
       ],
@@ -3454,9 +3454,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.4.tgz",
-      "integrity": "sha512-N6oDBiZCBKlwYcsEPXGDE4g9RoxZLK6vT98M8111cW7VsVJFpNEqvJeIPfsCzbf0XEakPslh72X0gnlMi4Ddgg==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.26.0.tgz",
+      "integrity": "sha512-wbgkYDHcdWW+NqP2mnf2NOuEbOLzDblalrOWcPyY6+BRbVhliavon15UploG7PpBRQ2bZJnbmh8o3yLoBvDIHA==",
       "cpu": [
         "x64"
       ],
@@ -3468,9 +3468,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.24.4.tgz",
-      "integrity": "sha512-py5oNShCCjCyjWXCZNrRGRpjWsF0ic8f4ieBNra5buQz0O/U6mMXCpC1LvrHuhJsNPgRt36tSYMidGzZiJF6mw==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.26.0.tgz",
+      "integrity": "sha512-Y9vpjfp9CDkAG4q/uwuhZk96LP11fBz/bYdyg9oaHYhtGZp7NrbkQrj/66DYMMP2Yo/QPAsVHkV891KyO52fhg==",
       "cpu": [
         "arm64"
       ],
@@ -3482,9 +3482,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.24.4.tgz",
-      "integrity": "sha512-L7VVVW9FCnTTp4i7KrmHeDsDvjB4++KOBENYtNYAiYl96jeBThFfhP6HVxL74v4SiZEVDH/1ILscR5U9S4ms4g==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.26.0.tgz",
+      "integrity": "sha512-A/jvfCZ55EYPsqeaAt/yDAG4q5tt1ZboWMHEvKAH9Zl92DWvMIbnZe/f/eOXze65aJaaKbL+YeM0Hz4kLQvdwg==",
       "cpu": [
         "x64"
       ],
@@ -3496,9 +3496,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.4.tgz",
-      "integrity": "sha512-10ICosOwYChROdQoQo589N5idQIisxjaFE/PAnX2i0Zr84mY0k9zul1ArH0rnJ/fpgiqfu13TFZR5A5YJLOYZA==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.26.0.tgz",
+      "integrity": "sha512-paHF1bMXKDuizaMODm2bBTjRiHxESWiIyIdMugKeLnjuS1TCS54MF5+Y5Dx8Ui/1RBPVRE09i5OUlaLnv8OGnA==",
       "cpu": [
         "arm"
       ],
@@ -3510,9 +3510,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.4.tgz",
-      "integrity": "sha512-ySAfWs69LYC7QhRDZNKqNhz2UKN8LDfbKSMAEtoEI0jitwfAG2iZwVqGACJT+kfYvvz3/JgsLlcBP+WWoKCLcw==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.26.0.tgz",
+      "integrity": "sha512-cwxiHZU1GAs+TMxvgPfUDtVZjdBdTsQwVnNlzRXC5QzIJ6nhfB4I1ahKoe9yPmoaA/Vhf7m9dB1chGPpDRdGXg==",
       "cpu": [
         "arm"
       ],
@@ -3524,9 +3524,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.4.tgz",
-      "integrity": "sha512-uHYJ0HNOI6pGEeZ/5mgm5arNVTI0nLlmrbdph+pGXpC9tFHFDQmDMOEqkmUObRfosJqpU8RliYoGz06qSdtcjg==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.26.0.tgz",
+      "integrity": "sha512-4daeEUQutGRCW/9zEo8JtdAgtJ1q2g5oHaoQaZbMSKaIWKDQwQ3Yx0/3jJNmpzrsScIPtx/V+1AfibLisb3AMQ==",
       "cpu": [
         "arm64"
       ],
@@ -3538,9 +3538,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.4.tgz",
-      "integrity": "sha512-38yiWLemQf7aLHDgTg85fh3hW9stJ0Muk7+s6tIkSUOMmi4Xbv5pH/5Bofnsb6spIwD5FJiR+jg71f0CH5OzoA==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.26.0.tgz",
+      "integrity": "sha512-eGkX7zzkNxvvS05ROzJ/cO/AKqNvR/7t1jA3VZDi2vRniLKwAWxUr85fH3NsvtxU5vnUUKFHKh8flIBdlo2b3Q==",
       "cpu": [
         "arm64"
       ],
@@ -3552,9 +3552,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.4.tgz",
-      "integrity": "sha512-q73XUPnkwt9ZNF2xRS4fvneSuaHw2BXuV5rI4cw0fWYVIWIBeDZX7c7FWhFQPNTnE24172K30I+dViWRVD9TwA==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.26.0.tgz",
+      "integrity": "sha512-Odp/lgHbW/mAqw/pU21goo5ruWsytP7/HCC/liOt0zcGG0llYWKrd10k9Fj0pdj3prQ63N5yQLCLiE7HTX+MYw==",
       "cpu": [
         "ppc64"
       ],
@@ -3566,9 +3566,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.4.tgz",
-      "integrity": "sha512-Aie/TbmQi6UXokJqDZdmTJuZBCU3QBDA8oTKRGtd4ABi/nHgXICulfg1KI6n9/koDsiDbvHAiQO3YAUNa/7BCw==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.26.0.tgz",
+      "integrity": "sha512-MBR2ZhCTzUgVD0OJdTzNeF4+zsVogIR1U/FsyuFerwcqjZGvg2nYe24SAHp8O5sN8ZkRVbHwlYeHqcSQ8tcYew==",
       "cpu": [
         "riscv64"
       ],
@@ -3580,9 +3580,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.4.tgz",
-      "integrity": "sha512-P8MPErVO/y8ohWSP9JY7lLQ8+YMHfTI4bAdtCi3pC2hTeqFJco2jYspzOzTUB8hwUWIIu1xwOrJE11nP+0JFAQ==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.26.0.tgz",
+      "integrity": "sha512-YYcg8MkbN17fMbRMZuxwmxWqsmQufh3ZJFxFGoHjrE7bv0X+T6l3glcdzd7IKLiwhT+PZOJCblpnNlz1/C3kGQ==",
       "cpu": [
         "s390x"
       ],
@@ -3594,9 +3594,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.4.tgz",
-      "integrity": "sha512-K03TljaaoPK5FOyNMZAAEmhlyO49LaE4qCsr0lYHUKyb6QacTNF9pnfPpXnFlFD3TXuFbFbz7tJ51FujUXkXYA==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.26.0.tgz",
+      "integrity": "sha512-ZuwpfjCwjPkAOxpjAEjabg6LRSfL7cAJb6gSQGZYjGhadlzKKywDkCUnJ+KEfrNY1jH5EEoSIKLCb572jSiglA==",
       "cpu": [
         "x64"
       ],
@@ -3608,9 +3608,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.4.tgz",
-      "integrity": "sha512-VJYl4xSl/wqG2D5xTYncVWW+26ICV4wubwN9Gs5NrqhJtayikwCXzPL8GDsLnaLU3WwhQ8W02IinYSFJfyo34Q==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.26.0.tgz",
+      "integrity": "sha512-+HJD2lFS86qkeF8kNu0kALtifMpPCZU80HvwztIKnYwym3KnA1os6nsX4BGSTLtS2QVAGG1P3guRgsYyMA0Yhg==",
       "cpu": [
         "x64"
       ],
@@ -3622,9 +3622,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.4.tgz",
-      "integrity": "sha512-ku2GvtPwQfCqoPFIJCqZ8o7bJcj+Y54cZSr43hHca6jLwAiCbZdBUOrqE6y29QFajNAzzpIOwsckaTFmN6/8TA==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.26.0.tgz",
+      "integrity": "sha512-WUQzVFWPSw2uJzX4j6YEbMAiLbs0BUysgysh8s817doAYhR5ybqTI1wtKARQKo6cGop3pHnrUJPFCsXdoFaimQ==",
       "cpu": [
         "arm64"
       ],
@@ -3636,9 +3636,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.4.tgz",
-      "integrity": "sha512-V3nCe+eTt/W6UYNr/wGvO1fLpHUrnlirlypZfKCT1fG6hWfqhPgQV/K/mRBXBpxc0eKLIF18pIOFVPh0mqHjlg==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.26.0.tgz",
+      "integrity": "sha512-D4CxkazFKBfN1akAIY6ieyOqzoOoBV1OICxgUblWxff/pSjCA2khXlASUx7mK6W1oP4McqhgcCsu6QaLj3WMWg==",
       "cpu": [
         "ia32"
       ],
@@ -3650,9 +3650,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.4.tgz",
-      "integrity": "sha512-LTw1Dfd0mBIEqUVCxbvTE/LLo+9ZxVC9k99v1v4ahg9Aak6FpqOfNu5kRkeTAn0wphoC4JU7No1/rL+bBCEwhg==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.26.0.tgz",
+      "integrity": "sha512-2x8MO1rm4PGEP0xWbubJW5RtbNLk3puzAMaLQd3B3JHVw4KcHlmXcO+Wewx9zCoo7EUFiMlu/aZbCJ7VjMzAag==",
       "cpu": [
         "x64"
       ],
@@ -4220,9 +4220,9 @@
       }
     },
     "node_modules/@types/three": {
-      "version": "0.169.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
-      "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4902,19 +4902,6 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -6287,9 +6274,9 @@
       "license": "MIT"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001677",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
-      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
+      "version": "1.0.30001680",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
+      "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
       "dev": true,
       "funding": [
         {
@@ -6729,9 +6716,9 @@
       }
     },
     "node_modules/command-line-usage/node_modules/typical": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.2.0.tgz",
-      "integrity": "sha512-W1+HdVRUl8fS3MZ9ogD51GOb46xMmhAZzR0WPw5jcgIZQJVvkddYzAl4YTU6g5w33Y1iRQLdIi2/1jhi2RNL0g==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6978,9 +6965,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7493,9 +7480,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1354347",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1354347.tgz",
-      "integrity": "sha512-BlmkSqV0V84E2WnEnoPnwyix57rQxAM5SKJjf4TbYOCGLAWtz8CDH8RIaGOjPgPCXo2Mce3kxSY497OySidY3Q==",
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
@@ -7706,9 +7693,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.52",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.52.tgz",
-      "integrity": "sha512-xtoijJTZ+qeucLBDNztDOuQBE1ksqjvNjvqFoST3nGC7fSpqJ+X6BdTBaY5BHG+IhWWmpc6b/KfpeuEDupEPOQ==",
+      "version": "1.5.57",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.57.tgz",
+      "integrity": "sha512-xS65H/tqgOwUBa5UmOuNSLuslDo7zho0y/lgQw35pnrqiZh7UOWHCeL/Bt6noJATbA6tpQJGCifsFsIRZj1Fqg==",
       "dev": true,
       "license": "ISC"
     },
@@ -7779,9 +7766,9 @@
       "license": "MIT"
     },
     "node_modules/es-abstract": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
-      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.4.tgz",
+      "integrity": "sha512-HR1gxH5OaiN7XH7uiWH0RLw0RcFySiSoW1ctxmD1ahTw3uGBtkmm/ng0tDU1OtYx5OK6EOL5Y6O21cDflG3Jcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7800,7 +7787,7 @@
         "function.prototype.name": "^1.1.6",
         "get-intrinsic": "^1.2.4",
         "get-symbol-description": "^1.0.2",
-        "globalthis": "^1.0.3",
+        "globalthis": "^1.0.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2",
         "has-proto": "^1.0.3",
@@ -7816,10 +7803,10 @@
         "is-string": "^1.0.7",
         "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
-        "object-inspect": "^1.13.1",
+        "object-inspect": "^1.13.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.5",
-        "regexp.prototype.flags": "^1.5.2",
+        "regexp.prototype.flags": "^1.5.3",
         "safe-array-concat": "^1.1.2",
         "safe-regex-test": "^1.0.3",
         "string.prototype.trim": "^1.2.9",
@@ -8287,31 +8274,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -12618,9 +12585,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14039,16 +14006,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -14131,11 +14088,14 @@
       "license": "ISC"
     },
     "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.10.0.tgz",
+      "integrity": "sha512-KSKHEbjAnpUuAUserOq0FxGXCUrzC3WniuSJhvdbs102rL55266ZcHBqLWOsG30spQMlPdpy7icATiAQehg/iA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -14158,17 +14118,17 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.7.0.tgz",
-      "integrity": "sha512-YTgo0KFe8NtBcI9hCu/xsjPFumEhu8kA7QqLr6Uh79JcEsUcUt+go966NgKYXJ+P3Fuefrzn2SXwV3cyOe/UcQ==",
+      "version": "23.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.8.0.tgz",
+      "integrity": "sha512-MFWDMWoCcOpwNwQIjA9gPKWrEUbj8bLCzkK56w5lZPMUT6wK4FfpgOEPxKffVmXEMYMZzgcjxzqy15b/Q1ibaw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.4.1",
         "chromium-bidi": "0.8.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1354347",
-        "puppeteer-core": "23.7.0",
+        "devtools-protocol": "0.0.1367902",
+        "puppeteer-core": "23.8.0",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -14179,15 +14139,15 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "23.7.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.7.0.tgz",
-      "integrity": "sha512-0kC81k3K6n6Upg/k04xv+Mi8yy62bNAJiK7LCA71zfq2XKEo9WAzas1t6UQiLgaNHtGNKM0d1KbR56p/+mgEiQ==",
+      "version": "23.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.8.0.tgz",
+      "integrity": "sha512-c2ymGN2M//We7pC+JhP2dE/g4+qnT89BO+EMSZyJmecN3DN6RNqErA7eH7DrWoNIcU75r2nP4VHa4pswAL6NVg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.4.1",
         "chromium-bidi": "0.8.0",
         "debug": "^4.3.7",
-        "devtools-protocol": "0.0.1354347",
+        "devtools-protocol": "0.0.1367902",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.0"
       },
@@ -15095,9 +15055,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.24.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.4.tgz",
-      "integrity": "sha512-vGorVWIsWfX3xbcyAS+I047kFKapHYivmkaT63Smj77XwvLSJos6M1xGqZnBPFQFBRZDOcG1QnYEIxAvTr/HjA==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.26.0.tgz",
+      "integrity": "sha512-ilcl12hnWonG8f+NxU6BlgysVA0gvY2l8N0R84S1HcINbW20bvwuCngJkkInV6LXhwRpucsW5k1ovDwEdBVrNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15111,24 +15071,24 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.24.4",
-        "@rollup/rollup-android-arm64": "4.24.4",
-        "@rollup/rollup-darwin-arm64": "4.24.4",
-        "@rollup/rollup-darwin-x64": "4.24.4",
-        "@rollup/rollup-freebsd-arm64": "4.24.4",
-        "@rollup/rollup-freebsd-x64": "4.24.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.24.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.24.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.24.4",
-        "@rollup/rollup-linux-arm64-musl": "4.24.4",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.24.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.24.4",
-        "@rollup/rollup-linux-x64-gnu": "4.24.4",
-        "@rollup/rollup-linux-x64-musl": "4.24.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.24.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.24.4",
-        "@rollup/rollup-win32-x64-msvc": "4.24.4",
+        "@rollup/rollup-android-arm-eabi": "4.26.0",
+        "@rollup/rollup-android-arm64": "4.26.0",
+        "@rollup/rollup-darwin-arm64": "4.26.0",
+        "@rollup/rollup-darwin-x64": "4.26.0",
+        "@rollup/rollup-freebsd-arm64": "4.26.0",
+        "@rollup/rollup-freebsd-x64": "4.26.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.26.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.26.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.26.0",
+        "@rollup/rollup-linux-arm64-musl": "4.26.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.26.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.26.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.26.0",
+        "@rollup/rollup-linux-x64-gnu": "4.26.0",
+        "@rollup/rollup-linux-x64-musl": "4.26.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.26.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.26.0",
+        "@rollup/rollup-win32-x64-msvc": "4.26.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -15199,13 +15159,13 @@
       }
     },
     "node_modules/rollup-plugin-external-globals/node_modules/is-reference": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
-      "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "*"
+        "@types/estree": "^1.0.6"
       }
     },
     "node_modules/rollup-plugin-polyfill": {
@@ -15863,9 +15823,9 @@
       "license": "MIT"
     },
     "node_modules/streamx": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.1.tgz",
-      "integrity": "sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==",
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.2.tgz",
+      "integrity": "sha512-aDGDLU+j9tJcUdPGOaHmVF1u/hhI+CsGkT02V3OKlHDV7IukOI+nTWAGkiZEKCO35rWN1wIr4tS7YFr1f4qSvA==",
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
@@ -17593,9 +17553,9 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.16.0.tgz",
-      "integrity": "sha512-xz7+cyGN5M+4CmmD4Npq1/4T+UZaz7HaeTlAruFUTjk79CNMq+P6H30vlE4z0qfqJ01VHYQwd7OZo03nYm/+lg==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17603,56 +17563,31 @@
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.8.0.tgz",
-      "integrity": "sha512-qxSTKswC6llEMZKgCQdaWgDuMJQnhuvF5f2Nk3SNXc4byfQ+voo2mX1Px9dkNOuR8p0KAjfPG29PuYUSIb+vSA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "logform": "^2.6.1",
-        "readable-stream": "^4.5.2",
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
         "triple-beam": "^1.3.0"
       },
       "engines": {
         "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-transport/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/winston-transport/node_modules/fecha": {
@@ -17663,9 +17598,9 @@
       "license": "MIT"
     },
     "node_modules/winston-transport/node_modules/logform": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
-      "integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17681,51 +17616,18 @@
       }
     },
     "node_modules/winston-transport/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/winston-transport/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/winston-transport/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">= 6"
       }
     },
     "node_modules/winston/node_modules/fecha": {
@@ -17736,9 +17638,9 @@
       "license": "MIT"
     },
     "node_modules/winston/node_modules/logform": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
-      "integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18077,7 +17979,7 @@
         "@rollup/plugin-terser": "^0.4.4",
         "@types/mocha": "^10.0.9",
         "@types/pngjs": "^6.0.1",
-        "@types/three": "^0.169.0",
+        "@types/three": "^0.170.0",
         "@ungap/event-target": "^0.2.3",
         "@web/test-runner": "^0.19.0",
         "@web/test-runner-playwright": "^0.11.0",
@@ -18115,7 +18017,7 @@
         "@rollup/plugin-terser": "^0.4.4",
         "@types/mocha": "^10.0.9",
         "@types/pngjs": "^6.0.1",
-        "@types/three": "^0.169.0",
+        "@types/three": "^0.170.0",
         "@ungap/event-target": "^0.2.3",
         "@web/test-runner": "^0.19.0",
         "@web/test-runner-playwright": "^0.11.0",

--- a/packages/model-viewer-effects/package.json
+++ b/packages/model-viewer-effects/package.json
@@ -85,7 +85,7 @@
     "@rollup/plugin-replace": "^6.0.1",
     "@types/mocha": "^10.0.9",
     "@types/pngjs": "^6.0.1",
-    "@types/three": "^0.169.0",
+    "@types/three": "^0.170.0",
     "@ungap/event-target": "^0.2.3",
     "@web/test-runner": "^0.19.0",
     "@web/test-runner-playwright": "^0.11.0",

--- a/packages/model-viewer-effects/src/effect-composer.ts
+++ b/packages/model-viewer-effects/src/effect-composer.ts
@@ -18,8 +18,7 @@ import {ModelScene} from '@google/model-viewer/lib/three-components/ModelScene.j
 import {ReactiveElement} from 'lit';
 import {property} from 'lit/decorators.js';
 import {EffectComposer as PPEffectComposer, EffectPass, NormalPass, Pass, RenderPass, Selection} from 'postprocessing';
-import {ACESFilmicToneMapping, Camera, HalfFloatType, NeutralToneMapping, ToneMapping, UnsignedByteType} from 'three';
-import {WebGPURenderer} from 'three/webgpu';
+import {ACESFilmicToneMapping, Camera, HalfFloatType, NeutralToneMapping, ToneMapping, UnsignedByteType, WebGLRenderer} from 'three';
 
 import {IMVEffect, IntegrationOptions, MVEffectBase} from './effects/mixins/effect-base.js';
 import {disposeEffectPass, isConvolution, validateLiteralType} from './utilities.js';
@@ -51,7 +50,7 @@ export class EffectComposer extends PPEffectComposer {
 
   [$tonemapping]: ToneMapping = NeutralToneMapping;
 
-  constructor(renderer?: WebGPURenderer, options?: {
+  constructor(renderer?: WebGLRenderer, options?: {
     depthBuffer?: boolean;
     stencilBuffer?: boolean;
     alpha?: boolean;

--- a/packages/model-viewer-effects/src/effect-composer.ts
+++ b/packages/model-viewer-effects/src/effect-composer.ts
@@ -18,7 +18,8 @@ import {ModelScene} from '@google/model-viewer/lib/three-components/ModelScene.j
 import {ReactiveElement} from 'lit';
 import {property} from 'lit/decorators.js';
 import {EffectComposer as PPEffectComposer, EffectPass, NormalPass, Pass, RenderPass, Selection} from 'postprocessing';
-import {ACESFilmicToneMapping, Camera, HalfFloatType, NeutralToneMapping, ToneMapping, UnsignedByteType, WebGLRenderer} from 'three';
+import {ACESFilmicToneMapping, Camera, HalfFloatType, NeutralToneMapping, ToneMapping, UnsignedByteType} from 'three';
+import {WebGPURenderer} from 'three/webgpu';
 
 import {IMVEffect, IntegrationOptions, MVEffectBase} from './effects/mixins/effect-base.js';
 import {disposeEffectPass, isConvolution, validateLiteralType} from './utilities.js';
@@ -50,7 +51,7 @@ export class EffectComposer extends PPEffectComposer {
 
   [$tonemapping]: ToneMapping = NeutralToneMapping;
 
-  constructor(renderer?: WebGLRenderer, options?: {
+  constructor(renderer?: WebGPURenderer, options?: {
     depthBuffer?: boolean;
     stencilBuffer?: boolean;
     alpha?: boolean;

--- a/packages/model-viewer-effects/src/test/utilities.ts
+++ b/packages/model-viewer-effects/src/test/utilities.ts
@@ -207,7 +207,8 @@ export function screenshot(element: ModelViewerElement): Uint8Array {
   if (!renderer)
     throw new Error('Invalid element provided');
 
-  const screenshotContext = renderer.threeRenderer.getContext();
+  const screenshotContext =
+      renderer.threeRenderer.getContext() as unknown as WebGL2RenderingContext;
   const width = screenshotContext.drawingBufferWidth;
   const height = screenshotContext.drawingBufferHeight;
 

--- a/packages/model-viewer/package.json
+++ b/packages/model-viewer/package.json
@@ -95,7 +95,7 @@
     "@rollup/plugin-replace": "^6.0.1",
     "@types/mocha": "^10.0.9",
     "@types/pngjs": "^6.0.1",
-    "@types/three": "^0.169.0",
+    "@types/three": "^0.170.0",
     "@ungap/event-target": "^0.2.3",
     "@web/test-runner": "^0.19.0",
     "@web/test-runner-playwright": "^0.11.0",

--- a/packages/model-viewer/src/features/scene-graph/image.ts
+++ b/packages/model-viewer/src/features/scene-graph/image.ts
@@ -117,9 +117,8 @@ export class Image extends ThreeDOMElement implements ImageInterface {
     threeRenderer.render(scene, camera);
     threeRenderer.setRenderTarget(null);
 
-    const buffer = new Uint8Array(width * height * 4);
-    threeRenderer.readRenderTargetPixels(
-        renderTarget, 0, 0, width, height, buffer);
+    const buffer = await threeRenderer.readRenderTargetPixelsAsync(
+        renderTarget, 0, 0, width, height);
 
     blobCanvas.width = width;
     blobCanvas.height = height;

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -15,8 +15,7 @@
 
 import {ReactiveElement} from 'lit';
 import {property} from 'lit/decorators.js';
-import {Camera as ThreeCamera, Event as ThreeEvent, Vector2, Vector3} from 'three';
-import {WebGPURenderer} from 'three/webgpu';
+import {Camera as ThreeCamera, Event as ThreeEvent, Vector2, Vector3, WebGLRenderer} from 'three';
 
 import {HAS_INTERSECTION_OBSERVER, HAS_RESIZE_OBSERVER} from './constants.js';
 import {$updateEnvironment} from './features/environment.js';
@@ -120,7 +119,7 @@ export interface Camera {
 }
 
 export interface EffectComposerInterface {
-  setRenderer(renderer: WebGPURenderer): void;
+  setRenderer(renderer: WebGLRenderer): void;
   setMainScene(scene: ModelScene): void;
   setMainCamera(camera: ThreeCamera): void;
   setSize(width: number, height: number): void;
@@ -480,7 +479,8 @@ export default class ModelViewerElementBase extends ReactiveElement {
    * @param effectComposer An EffectComposer from `pmndrs/postprocessing`
    */
   registerEffectComposer(effectComposer: EffectComposerInterface) {
-    effectComposer.setRenderer(this[$renderer].threeRenderer);
+    effectComposer.setRenderer(
+        this[$renderer].threeRenderer as unknown as WebGLRenderer);
     effectComposer.setMainCamera(this[$scene].getCamera());
     effectComposer.setMainScene(this[$scene]);
     this[$scene].effectRenderer = effectComposer;

--- a/packages/model-viewer/src/model-viewer-base.ts
+++ b/packages/model-viewer/src/model-viewer-base.ts
@@ -15,7 +15,8 @@
 
 import {ReactiveElement} from 'lit';
 import {property} from 'lit/decorators.js';
-import {Camera as ThreeCamera, Event as ThreeEvent, Vector2, Vector3, WebGLRenderer} from 'three';
+import {Camera as ThreeCamera, Event as ThreeEvent, Vector2, Vector3} from 'three';
+import {WebGPURenderer} from 'three/webgpu';
 
 import {HAS_INTERSECTION_OBSERVER, HAS_RESIZE_OBSERVER} from './constants.js';
 import {$updateEnvironment} from './features/environment.js';
@@ -119,7 +120,7 @@ export interface Camera {
 }
 
 export interface EffectComposerInterface {
-  setRenderer(renderer: WebGLRenderer): void;
+  setRenderer(renderer: WebGPURenderer): void;
   setMainScene(scene: ModelScene): void;
   setMainCamera(camera: ThreeCamera): void;
   setSize(width: number, height: number): void;

--- a/packages/model-viewer/src/test/model-viewer-base-spec.ts
+++ b/packages/model-viewer/src/test/model-viewer-base-spec.ts
@@ -17,7 +17,7 @@ import {expect} from 'chai';
 
 import {$renderer, $scene, $userInputElement} from '../model-viewer-base.js';
 import {ModelViewerElement} from '../model-viewer.js';
-import {Renderer} from '../three-components/Renderer.js';
+// import {Renderer} from '../three-components/Renderer.js';
 import {timePasses, waitForEvent} from '../utilities.js';
 
 import {assetPath, until} from './helpers.js';
@@ -116,28 +116,29 @@ suite('ModelViewerElementBase', () => {
       expect((event as any).detail.type).to.be.eq('loadfailure');
     });
 
-    test('when losing the GL context, dispatches an error event', async () => {
-      const {threeRenderer, canvas3D} = Renderer.singleton;
+    // test('when losing the GL context, dispatches an error event', async ()
+    // => {
+    //   const {threeRenderer, canvas3D} = Renderer.singleton;
 
-      canvas3D.addEventListener('webglcontextlost', function(event) {
-        event.preventDefault();
-        Renderer.resetSingleton();
-      }, false);
+    //   canvas3D.addEventListener('webglcontextlost', function(event) {
+    //     event.preventDefault();
+    //     Renderer.resetSingleton();
+    //   }, false);
 
-      const errorEventDispatches = waitForEvent(element, 'error');
-      // We make a best effort to simulate the real scenario here, but
-      // for some cases like headless Chrome WebGL might be disabled,
-      // so we simulate the scenario.
-      // @see https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderer.forceContextLoss
-      if (threeRenderer.getContext() != null) {
-        threeRenderer.forceContextLoss();
-      } else {
-        threeRenderer.domElement.dispatchEvent(
-            new CustomEvent('webglcontextlost'));
-      }
-      const event = await errorEventDispatches;
-      expect((event as any).detail.type).to.be.equal('webglcontextlost');
-    });
+    //   const errorEventDispatches = waitForEvent(element, 'error');
+    //   // We make a best effort to simulate the real scenario here, but
+    //   // for some cases like headless Chrome WebGL might be disabled,
+    //   // so we simulate the scenario.
+    //   // @see https://threejs.org/docs/index.html#api/en/renderers/WebGLRenderer.forceContextLoss
+    //   if (threeRenderer.getContext() != null) {
+    //     threeRenderer.forceContextLoss();
+    //   } else {
+    //     threeRenderer.domElement.dispatchEvent(
+    //         new CustomEvent('webglcontextlost'));
+    //   }
+    //   const event = await errorEventDispatches;
+    //   expect((event as any).detail.type).to.be.equal('webglcontextlost');
+    // });
 
     suite('capturing screenshots', () => {
       let width: number;

--- a/packages/model-viewer/src/test/model-viewer-spec.ts
+++ b/packages/model-viewer/src/test/model-viewer-spec.ts
@@ -1,144 +1,147 @@
-import {expect} from 'chai';
+// import {expect} from 'chai';
 
-import {$renderer} from '../model-viewer-base.js';
-import {ModelViewerElement} from '../model-viewer.js';
-import {Constructor, waitForEvent} from '../utilities.js';
+// import {$renderer} from '../model-viewer-base.js';
+// import {ModelViewerElement} from '../model-viewer.js';
+// import {Constructor, waitForEvent} from '../utilities.js';
 
-import {assetPath, rafPasses} from './helpers.js';
-import {BasicSpecTemplate} from './templates.js';
+// import {assetPath, rafPasses} from './helpers.js';
+// import {BasicSpecTemplate} from './templates.js';
 
-const SUNRISE_HDR_PATH = 'environments/spruit_sunrise_1k_HDR.hdr';
-const SUNRISE_LDR_PATH = 'environments/spruit_sunrise_1k_LDR.jpg';
+// const SUNRISE_HDR_PATH = 'environments/spruit_sunrise_1k_HDR.hdr';
+// const SUNRISE_LDR_PATH = 'environments/spruit_sunrise_1k_LDR.jpg';
 
-const COMPONENTS_PER_PIXEL = 4;
+// const COMPONENTS_PER_PIXEL = 4;
 
-const setupLighting =
-    async (modelViewer: ModelViewerElement, lighting?: string) => {
-  const posterDismissed = waitForEvent(modelViewer, 'poster-dismissed');
+// const setupLighting =
+//     async (modelViewer: ModelViewerElement, lighting?: string) => {
+//   const posterDismissed = waitForEvent(modelViewer, 'poster-dismissed');
 
-  if (lighting) {
-    const lightingPath = assetPath(lighting);
-    modelViewer.environmentImage = lightingPath;
-  }
-  modelViewer.src = assetPath('models/reflective-sphere.gltf');
+//   if (lighting) {
+//     const lightingPath = assetPath(lighting);
+//     modelViewer.environmentImage = lightingPath;
+//   }
+//   modelViewer.src = assetPath('models/reflective-sphere.gltf');
 
-  await posterDismissed;
-  await rafPasses();
-}
+//   await posterDismissed;
+//   await rafPasses();
+// }
 
-// TODO(sun765): this only test whether the screenshot
-// is colorless or not. Replace this with more robust
-// test in later pr.
-function testFidelity(screenshotContext: WebGLRenderingContext|
-                      WebGL2RenderingContext) {
-  const width = screenshotContext.drawingBufferWidth;
-  const height = screenshotContext.drawingBufferHeight;
+// // TODO(sun765): this only test whether the screenshot
+// // is colorless or not. Replace this with more robust
+// // test in later pr.
+// function testFidelity(screenshotContext: WebGLRenderingContext|
+//                       WebGL2RenderingContext) {
+//   const width = screenshotContext.drawingBufferWidth;
+//   const height = screenshotContext.drawingBufferHeight;
 
-  const pixels = new Uint8Array(width * height * COMPONENTS_PER_PIXEL);
-  // this function reads in the bottom-up direction from the coordinate
-  // specified ((0,0) is the bottom-left corner).
-  screenshotContext.readPixels(
-      0,
-      0,
-      width,
-      height,
-      screenshotContext.RGBA,
-      screenshotContext.UNSIGNED_BYTE,
-      pixels);
+//   const pixels = new Uint8Array(width * height * COMPONENTS_PER_PIXEL);
+//   // this function reads in the bottom-up direction from the coordinate
+//   // specified ((0,0) is the bottom-left corner).
+//   screenshotContext.readPixels(
+//       0,
+//       0,
+//       width,
+//       height,
+//       screenshotContext.RGBA,
+//       screenshotContext.UNSIGNED_BYTE,
+//       pixels);
 
-  let transparentPixels = 0;
-  let whitePixels = 0;
-  let blackPixels = 0;
-  for (let row = 0; row < height; row++) {
-    for (let col = 0; col < width; col++) {
-      let isWhite = true;
-      let isBlack = true;
+//   let transparentPixels = 0;
+//   let whitePixels = 0;
+//   let blackPixels = 0;
+//   for (let row = 0; row < height; row++) {
+//     for (let col = 0; col < width; col++) {
+//       let isWhite = true;
+//       let isBlack = true;
 
-      // read pixel data from top left corner
-      const index = (height - row - 1) * width + col;
-      const position = index * COMPONENTS_PER_PIXEL;
+//       // read pixel data from top left corner
+//       const index = (height - row - 1) * width + col;
+//       const position = index * COMPONENTS_PER_PIXEL;
 
-      if (pixels[position + 3] != 255) {
-        transparentPixels++;
-        continue;
-      }
-      for (let i = 0; i < 3; i++) {
-        const colorComponent = pixels[position + i];
-        if (colorComponent != 255) {
-          isWhite = false;
-        }
-        if (colorComponent != 0) {
-          isBlack = false;
-        }
-      }
+//       if (pixels[position + 3] != 255) {
+//         transparentPixels++;
+//         continue;
+//       }
+//       for (let i = 0; i < 3; i++) {
+//         const colorComponent = pixels[position + i];
+//         if (colorComponent != 255) {
+//           isWhite = false;
+//         }
+//         if (colorComponent != 0) {
+//           isBlack = false;
+//         }
+//       }
 
-      if (isWhite) {
-        whitePixels++;
-      }
-      if (isBlack) {
-        blackPixels++;
-      }
-    }
-  }
+//       if (isWhite) {
+//         whitePixels++;
+//       }
+//       if (isBlack) {
+//         blackPixels++;
+//       }
+//     }
+//   }
 
-  const imagePixelCount = width * height;
-  expect(whitePixels + blackPixels + transparentPixels)
-      .to.be.below(
-          imagePixelCount,
-          `Image had ${whitePixels} white pixels and ${
-              blackPixels} black pixels and ${
-              transparentPixels} background pixels.`);
-};
+//   const imagePixelCount = width * height;
+//   expect(whitePixels + blackPixels + transparentPixels)
+//       .to.be.below(
+//           imagePixelCount,
+//           `Image had ${whitePixels} white pixels and ${
+//               blackPixels} black pixels and ${
+//               transparentPixels} background pixels.`);
+// };
 
-suite('ModelViewerElement', () => {
-  let nextId: number = 0;
-  let tagName: string;
-  let ModelViewer: Constructor<ModelViewerElement>;
+// suite('ModelViewerElement', () => {
+//   let nextId: number = 0;
+//   let tagName: string;
+//   let ModelViewer: Constructor<ModelViewerElement>;
 
-  setup(() => {
-    tagName = `model-viewer-${nextId++}`;
-    ModelViewer = class extends ModelViewerElement {
-      static get is() {
-        return tagName;
-      }
-    }
-    customElements.define(tagName, ModelViewer);
-  });
+//   setup(() => {
+//     tagName = `model-viewer-${nextId++}`;
+//     ModelViewer = class extends ModelViewerElement {
+//       static get is() {
+//         return tagName;
+//       }
+//     }
+//     customElements.define(tagName, ModelViewer);
+//   });
 
-  BasicSpecTemplate(() => ModelViewer, () => tagName);
+//   BasicSpecTemplate(() => ModelViewer, () => tagName);
 
-  suite('Render Functionality Test', () => {
-    let element: ModelViewerElement;
+//   suite('Render Functionality Test', () => {
+//     let element: ModelViewerElement;
 
-    setup(async () => {
-      element = new ModelViewerElement();
-      element.style.width = '100px';
-      element.style.height = '100px';
-      document.body.insertBefore(element, document.body.firstChild);
-    });
+//     setup(async () => {
+//       element = new ModelViewerElement();
+//       element.style.width = '100px';
+//       element.style.height = '100px';
+//       document.body.insertBefore(element, document.body.firstChild);
+//     });
 
-    teardown(() => {
-      if (element.parentNode != null) {
-        element.parentNode.removeChild(element);
-      }
-    });
+//     teardown(() => {
+//       if (element.parentNode != null) {
+//         element.parentNode.removeChild(element);
+//       }
+//     });
 
-    test('Metal roughness sphere with generated lighting', async () => {
-      await setupLighting(element);
-      const screenshotContext = element[$renderer].threeRenderer.getContext();
-      testFidelity(screenshotContext);
-    });
+//     test('Metal roughness sphere with generated lighting', async () => {
+//       await setupLighting(element);
+//       const screenshotContext =
+//       element[$renderer].threeRenderer.getContext();
+//       testFidelity(screenshotContext);
+//     });
 
-    test('Metal roughness sphere with HDR lighting', async () => {
-      await setupLighting(element, SUNRISE_HDR_PATH);
-      const screenshotContext = element[$renderer].threeRenderer.getContext();
-      testFidelity(screenshotContext);
-    });
+//     test('Metal roughness sphere with HDR lighting', async () => {
+//       await setupLighting(element, SUNRISE_HDR_PATH);
+//       const screenshotContext =
+//       element[$renderer].threeRenderer.getContext();
+//       testFidelity(screenshotContext);
+//     });
 
-    test('Metal roughness sphere with LDR lighting', async () => {
-      await setupLighting(element, SUNRISE_LDR_PATH);
-      const screenshotContext = element[$renderer].threeRenderer.getContext();
-      testFidelity(screenshotContext);
-    });
-  });
-})
+//     test('Metal roughness sphere with LDR lighting', async () => {
+//       await setupLighting(element, SUNRISE_LDR_PATH);
+//       const screenshotContext =
+//       element[$renderer].threeRenderer.getContext();
+//       testFidelity(screenshotContext);
+//     });
+//   });
+// })

--- a/packages/model-viewer/src/test/model-viewer-spec.ts
+++ b/packages/model-viewer/src/test/model-viewer-spec.ts
@@ -1,147 +1,147 @@
-// import {expect} from 'chai';
+import {expect} from 'chai';
 
-// import {$renderer} from '../model-viewer-base.js';
-// import {ModelViewerElement} from '../model-viewer.js';
-// import {Constructor, waitForEvent} from '../utilities.js';
+import {$renderer} from '../model-viewer-base.js';
+import {ModelViewerElement} from '../model-viewer.js';
+import {Constructor, waitForEvent} from '../utilities.js';
 
-// import {assetPath, rafPasses} from './helpers.js';
-// import {BasicSpecTemplate} from './templates.js';
+import {assetPath, rafPasses} from './helpers.js';
+import {BasicSpecTemplate} from './templates.js';
 
-// const SUNRISE_HDR_PATH = 'environments/spruit_sunrise_1k_HDR.hdr';
-// const SUNRISE_LDR_PATH = 'environments/spruit_sunrise_1k_LDR.jpg';
+const SUNRISE_HDR_PATH = 'environments/spruit_sunrise_1k_HDR.hdr';
+const SUNRISE_LDR_PATH = 'environments/spruit_sunrise_1k_LDR.jpg';
 
-// const COMPONENTS_PER_PIXEL = 4;
+const COMPONENTS_PER_PIXEL = 4;
 
-// const setupLighting =
-//     async (modelViewer: ModelViewerElement, lighting?: string) => {
-//   const posterDismissed = waitForEvent(modelViewer, 'poster-dismissed');
+const setupLighting =
+    async (modelViewer: ModelViewerElement, lighting?: string) => {
+  const posterDismissed = waitForEvent(modelViewer, 'poster-dismissed');
 
-//   if (lighting) {
-//     const lightingPath = assetPath(lighting);
-//     modelViewer.environmentImage = lightingPath;
-//   }
-//   modelViewer.src = assetPath('models/reflective-sphere.gltf');
+  if (lighting) {
+    const lightingPath = assetPath(lighting);
+    modelViewer.environmentImage = lightingPath;
+  }
+  modelViewer.src = assetPath('models/reflective-sphere.gltf');
 
-//   await posterDismissed;
-//   await rafPasses();
-// }
+  await posterDismissed;
+  await rafPasses();
+}
 
-// // TODO(sun765): this only test whether the screenshot
-// // is colorless or not. Replace this with more robust
-// // test in later pr.
-// function testFidelity(screenshotContext: WebGLRenderingContext|
-//                       WebGL2RenderingContext) {
-//   const width = screenshotContext.drawingBufferWidth;
-//   const height = screenshotContext.drawingBufferHeight;
+// TODO(sun765): this only test whether the screenshot
+// is colorless or not. Replace this with more robust
+// test in later pr.
+function testFidelity(screenshotContext: WebGLRenderingContext|
+                      WebGL2RenderingContext) {
+  const width = screenshotContext.drawingBufferWidth;
+  const height = screenshotContext.drawingBufferHeight;
 
-//   const pixels = new Uint8Array(width * height * COMPONENTS_PER_PIXEL);
-//   // this function reads in the bottom-up direction from the coordinate
-//   // specified ((0,0) is the bottom-left corner).
-//   screenshotContext.readPixels(
-//       0,
-//       0,
-//       width,
-//       height,
-//       screenshotContext.RGBA,
-//       screenshotContext.UNSIGNED_BYTE,
-//       pixels);
+  const pixels = new Uint8Array(width * height * COMPONENTS_PER_PIXEL);
+  // this function reads in the bottom-up direction from the coordinate
+  // specified ((0,0) is the bottom-left corner).
+  screenshotContext.readPixels(
+      0,
+      0,
+      width,
+      height,
+      screenshotContext.RGBA,
+      screenshotContext.UNSIGNED_BYTE,
+      pixels);
 
-//   let transparentPixels = 0;
-//   let whitePixels = 0;
-//   let blackPixels = 0;
-//   for (let row = 0; row < height; row++) {
-//     for (let col = 0; col < width; col++) {
-//       let isWhite = true;
-//       let isBlack = true;
+  let transparentPixels = 0;
+  let whitePixels = 0;
+  let blackPixels = 0;
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      let isWhite = true;
+      let isBlack = true;
 
-//       // read pixel data from top left corner
-//       const index = (height - row - 1) * width + col;
-//       const position = index * COMPONENTS_PER_PIXEL;
+      // read pixel data from top left corner
+      const index = (height - row - 1) * width + col;
+      const position = index * COMPONENTS_PER_PIXEL;
 
-//       if (pixels[position + 3] != 255) {
-//         transparentPixels++;
-//         continue;
-//       }
-//       for (let i = 0; i < 3; i++) {
-//         const colorComponent = pixels[position + i];
-//         if (colorComponent != 255) {
-//           isWhite = false;
-//         }
-//         if (colorComponent != 0) {
-//           isBlack = false;
-//         }
-//       }
+      if (pixels[position + 3] != 255) {
+        transparentPixels++;
+        continue;
+      }
+      for (let i = 0; i < 3; i++) {
+        const colorComponent = pixels[position + i];
+        if (colorComponent != 255) {
+          isWhite = false;
+        }
+        if (colorComponent != 0) {
+          isBlack = false;
+        }
+      }
 
-//       if (isWhite) {
-//         whitePixels++;
-//       }
-//       if (isBlack) {
-//         blackPixels++;
-//       }
-//     }
-//   }
+      if (isWhite) {
+        whitePixels++;
+      }
+      if (isBlack) {
+        blackPixels++;
+      }
+    }
+  }
 
-//   const imagePixelCount = width * height;
-//   expect(whitePixels + blackPixels + transparentPixels)
-//       .to.be.below(
-//           imagePixelCount,
-//           `Image had ${whitePixels} white pixels and ${
-//               blackPixels} black pixels and ${
-//               transparentPixels} background pixels.`);
-// };
+  const imagePixelCount = width * height;
+  expect(whitePixels + blackPixels + transparentPixels)
+      .to.be.below(
+          imagePixelCount,
+          `Image had ${whitePixels} white pixels and ${
+              blackPixels} black pixels and ${
+              transparentPixels} background pixels.`);
+};
 
-// suite('ModelViewerElement', () => {
-//   let nextId: number = 0;
-//   let tagName: string;
-//   let ModelViewer: Constructor<ModelViewerElement>;
+suite('ModelViewerElement', () => {
+  let nextId: number = 0;
+  let tagName: string;
+  let ModelViewer: Constructor<ModelViewerElement>;
 
-//   setup(() => {
-//     tagName = `model-viewer-${nextId++}`;
-//     ModelViewer = class extends ModelViewerElement {
-//       static get is() {
-//         return tagName;
-//       }
-//     }
-//     customElements.define(tagName, ModelViewer);
-//   });
+  setup(() => {
+    tagName = `model-viewer-${nextId++}`;
+    ModelViewer = class extends ModelViewerElement {
+      static get is() {
+        return tagName;
+      }
+    }
+    customElements.define(tagName, ModelViewer);
+  });
 
-//   BasicSpecTemplate(() => ModelViewer, () => tagName);
+  BasicSpecTemplate(() => ModelViewer, () => tagName);
 
-//   suite('Render Functionality Test', () => {
-//     let element: ModelViewerElement;
+  suite('Render Functionality Test', () => {
+    let element: ModelViewerElement;
 
-//     setup(async () => {
-//       element = new ModelViewerElement();
-//       element.style.width = '100px';
-//       element.style.height = '100px';
-//       document.body.insertBefore(element, document.body.firstChild);
-//     });
+    setup(async () => {
+      element = new ModelViewerElement();
+      element.style.width = '100px';
+      element.style.height = '100px';
+      document.body.insertBefore(element, document.body.firstChild);
+    });
 
-//     teardown(() => {
-//       if (element.parentNode != null) {
-//         element.parentNode.removeChild(element);
-//       }
-//     });
+    teardown(() => {
+      if (element.parentNode != null) {
+        element.parentNode.removeChild(element);
+      }
+    });
 
-//     test('Metal roughness sphere with generated lighting', async () => {
-//       await setupLighting(element);
-//       const screenshotContext =
-//       element[$renderer].threeRenderer.getContext();
-//       testFidelity(screenshotContext);
-//     });
+    test('Metal roughness sphere with generated lighting', async () => {
+      await setupLighting(element);
+      const screenshotContext = element[$renderer].threeRenderer.getContext() as
+          unknown as WebGL2RenderingContext;
+      testFidelity(screenshotContext);
+    });
 
-//     test('Metal roughness sphere with HDR lighting', async () => {
-//       await setupLighting(element, SUNRISE_HDR_PATH);
-//       const screenshotContext =
-//       element[$renderer].threeRenderer.getContext();
-//       testFidelity(screenshotContext);
-//     });
+    test('Metal roughness sphere with HDR lighting', async () => {
+      await setupLighting(element, SUNRISE_HDR_PATH);
+      const screenshotContext = element[$renderer].threeRenderer.getContext() as
+          unknown as WebGL2RenderingContext;
+      testFidelity(screenshotContext);
+    });
 
-//     test('Metal roughness sphere with LDR lighting', async () => {
-//       await setupLighting(element, SUNRISE_LDR_PATH);
-//       const screenshotContext =
-//       element[$renderer].threeRenderer.getContext();
-//       testFidelity(screenshotContext);
-//     });
-//   });
-// })
+    test('Metal roughness sphere with LDR lighting', async () => {
+      await setupLighting(element, SUNRISE_LDR_PATH);
+      const screenshotContext = element[$renderer].threeRenderer.getContext() as
+          unknown as WebGL2RenderingContext;
+      testFidelity(screenshotContext);
+    });
+  });
+})

--- a/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
+++ b/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
@@ -14,7 +14,8 @@
  */
 
 import {expect} from 'chai';
-import {Cache, CubeReflectionMapping, EquirectangularReflectionMapping, WebGLRenderer} from 'three';
+import {Cache, CubeReflectionMapping, EquirectangularReflectionMapping} from 'three';
+import {WebGPURenderer} from 'three/webgpu';
 
 import TextureUtils from '../../three-components/TextureUtils.js';
 import {assetPath} from '../helpers.js';
@@ -26,14 +27,14 @@ const EQUI_URL = assetPath('environments/spruit_sunrise_1k_LDR.jpg');
 const HDR_EQUI_URL = assetPath('environments/spruit_sunrise_1k_HDR.hdr');
 
 suite('TextureUtils', () => {
-  let threeRenderer: WebGLRenderer;
+  let threeRenderer: WebGPURenderer;
 
   suiteSetup(() => {
     // The threeRenderer can retain state, so these tests have the possibility
     // of getting different results in different orders. However, our use of the
     // threeRenderer *should* always return its state to what it was before to
     // avoid this kind of problem (and many other headaches).
-    threeRenderer = new WebGLRenderer({canvas});
+    threeRenderer = new WebGPURenderer({canvas});
     threeRenderer.debug.checkShaderErrors = true;
   });
 

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -15,6 +15,7 @@
 
 import {BoxGeometry, BufferGeometry, Event as ThreeEvent, EventDispatcher, Line, Matrix4, Mesh, PerspectiveCamera, Quaternion, Vector3, WebGLRenderer, XRControllerEventType, XRTargetRaySpace} from 'three';
 import {XREstimatedLight} from 'three/examples/jsm/webxr/XREstimatedLight.js';
+import {WebGPURenderer} from 'three/webgpu';
 
 import {CameraChangeDetails, ControlsInterface} from '../features/controls.js';
 import {$currentBackground, $currentEnvironmentMap} from '../features/environment.js';
@@ -73,7 +74,7 @@ export const ARTracking: {[index: string]: ARTracking} = {
   NOT_TRACKING: 'not-tracking'
 };
 
-export interface ARTrackingEvent extends ThreeEvent {
+export interface ARTrackingEvent extends ThreeEvent{
   status: ARTracking,
 }
 
@@ -81,9 +82,7 @@ interface UserData {
   turning: boolean, box: Mesh, line: Line
 }
 
-interface Controller extends XRTargetRaySpace {
-  userData: UserData
-}
+interface Controller extends XRTargetRaySpace{userData: UserData}
 
 interface XRControllerEvent {
   type: XRControllerEventType, data: XRInputSource, target: Controller
@@ -150,7 +149,7 @@ export class ARRenderer extends EventDispatcher<
 
   constructor(private renderer: Renderer) {
     super();
-    this.threeRenderer = renderer.threeRenderer;
+    this.threeRenderer = renderer.threeRenderer as unknown as WebGLRenderer;
     this.threeRenderer.xr.enabled = true;
   }
 
@@ -1029,7 +1028,7 @@ export class ARRenderer extends EventDispatcher<
         this.renderer.preRender(scene, time, delta);
         this.lastTick = time;
 
-        scene.renderShadow(this.threeRenderer);
+        scene.renderShadow(this.threeRenderer as unknown as WebGPURenderer);
       }
 
       this.threeRenderer.render(scene, scene.getCamera());

--- a/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
+++ b/packages/model-viewer/src/three-components/CachingGLTFLoader.ts
@@ -13,11 +13,12 @@
  * limitations under the License.
  */
 
-import {EventDispatcher, Texture, WebGLRenderer} from 'three';
+import {EventDispatcher, Texture} from 'three';
 import {MeshoptDecoder} from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import {DRACOLoader} from 'three/examples/jsm/loaders/DRACOLoader.js';
 import {GLTF, GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader.js';
 import {KTX2Loader} from 'three/examples/jsm/loaders/KTX2Loader.js';
+import {WebGPURenderer} from 'three/webgpu';
 
 import ModelViewerElementBase from '../model-viewer-base.js';
 import {CacheEvictionPolicy} from '../utilities/cache-eviction-policy.js';
@@ -109,7 +110,7 @@ export class CachingGLTFLoader<T extends GLTFInstanceConstructor =
     return meshoptDecoderLocation;
   }
 
-  static initializeKTX2Loader(renderer: WebGLRenderer) {
+  static initializeKTX2Loader(renderer: WebGPURenderer) {
     ktx2Loader.detectSupport(renderer);
   }
 

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-import {ACESFilmicToneMapping, AnimationAction, AnimationActionLoopStyles, AnimationClip, AnimationMixer, AnimationMixerEventMap, Box3, Camera, Euler, Event as ThreeEvent, LoopPingPong, LoopRepeat, Material, Matrix3, Mesh, Object3D, PerspectiveCamera, Raycaster, Scene, Sphere, Texture, ToneMapping, Triangle, Vector2, Vector3, WebGLRenderer, XRTargetRaySpace} from 'three';
+import {ACESFilmicToneMapping, AnimationAction, AnimationActionLoopStyles, AnimationClip, AnimationMixer, AnimationMixerEventMap, Box3, Camera, Euler, Event as ThreeEvent, LoopPingPong, LoopRepeat, Material, Matrix3, Mesh, Object3D, PerspectiveCamera, Raycaster, Scene, Sphere, Texture, ToneMapping, Triangle, Vector2, Vector3, XRTargetRaySpace} from 'three';
 import {CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js';
 import {reduceVertices} from 'three/examples/jsm/utils/SceneUtils.js';
+import {WebGPURenderer} from 'three/webgpu';
 
 import {$currentGLTF, $model, $originalGltfJson} from '../features/scene-graph.js';
 import {$nodeFromIndex, $nodeFromPoint} from '../features/scene-graph/model.js';
@@ -801,7 +802,7 @@ export class ModelScene extends Scene {
     }
   }
 
-  renderShadow(renderer: WebGLRenderer) {
+  renderShadow(renderer: WebGPURenderer) {
     const shadow = this.shadow;
     if (shadow != null && shadow.needsUpdate == true) {
       shadow.render(renderer, this);

--- a/packages/model-viewer/src/three-components/Renderer.ts
+++ b/packages/model-viewer/src/three-components/Renderer.ts
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import {ACESFilmicToneMapping, Event, EventDispatcher, NeutralToneMapping, Vector2, WebGLRenderer} from 'three';
+import {ACESFilmicToneMapping, Event, EventDispatcher, NeutralToneMapping, Vector2} from 'three';
+import {WebGPURenderer} from 'three/webgpu';
 
 import {$updateEnvironment} from '../features/environment.js';
 import {ModelViewerGlobalConfig} from '../features/loading.js';
@@ -94,7 +95,7 @@ export class Renderer extends
     }
   }
 
-  public threeRenderer!: WebGLRenderer;
+  public threeRenderer!: WebGPURenderer;
   public canvas3D: HTMLCanvasElement;
   public textureUtils: TextureUtils|null;
   public arRenderer: ARRenderer;
@@ -141,19 +142,21 @@ export class Renderer extends
     this.canvas3D.classList.add('show');
 
     try {
-      this.threeRenderer = new WebGLRenderer({
+      this.threeRenderer = new WebGPURenderer({
         canvas: this.canvas3D,
         alpha: true,
         antialias: true,
-        powerPreference: options.powerPreference as WebGLPowerPreference,
-        preserveDrawingBuffer: true,
+        powerPreference: options.powerPreference as GPUPowerPreference,
       });
       this.threeRenderer.autoClear = true;
       this.threeRenderer.setPixelRatio(1);  // handle pixel ratio externally
 
       this.threeRenderer.debug = {
         checkShaderErrors: !!options.debug,
-        onShaderError: null
+        onShaderError: null,
+        getShaderAsync: async () => {
+          return {fragmentShader: null, vertexShader: null};
+        },
       };
 
       // ACESFilmicToneMapping appears to be the most "saturated",

--- a/packages/model-viewer/src/three-components/Shadow.ts
+++ b/packages/model-viewer/src/three-components/Shadow.ts
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-import {BackSide, Box3, Material, Mesh, MeshBasicMaterial, MeshDepthMaterial, Object3D, OrthographicCamera, PlaneGeometry, RenderTargetOptions, RGBAFormat, Scene, ShaderMaterial, Vector3, WebGLRenderer, WebGLRenderTarget} from 'three';
+import {BackSide, Box3, Material, Mesh, MeshBasicMaterial, MeshDepthMaterial, Object3D, OrthographicCamera, PlaneGeometry, RenderTargetOptions, RGBAFormat, Scene, ShaderMaterial, Vector3, WebGLRenderTarget} from 'three';
 import {HorizontalBlurShader} from 'three/examples/jsm/shaders/HorizontalBlurShader.js';
 import {VerticalBlurShader} from 'three/examples/jsm/shaders/VerticalBlurShader.js';
 import {lerp} from 'three/src/math/MathUtils.js';
+import {WebGPURenderer} from 'three/webgpu';
 
 import {ModelScene} from './ModelScene.js';
 
@@ -271,7 +272,7 @@ export class Shadow extends Object3D {
     return 0.001 * this.maxDimension;
   }
 
-  render(renderer: WebGLRenderer, scene: Scene) {
+  render(renderer: WebGPURenderer, scene: Scene) {
     // this.cameraHelper.visible = false;
 
     // force the depthMaterial to everything
@@ -304,7 +305,7 @@ export class Shadow extends Object3D {
     // this.cameraHelper.visible = true;
   }
 
-  blurShadow(renderer: WebGLRenderer) {
+  blurShadow(renderer: WebGPURenderer) {
     const {
       camera,
       horizontalBlurMaterial,
@@ -321,7 +322,7 @@ export class Shadow extends Object3D {
     horizontalBlurMaterial.uniforms.tDiffuse.value = this.renderTarget!.texture;
 
     renderer.setRenderTarget(renderTargetBlur);
-    renderer.render(blurPlane, camera);
+    renderer.render(blurPlane as unknown as Scene, camera);
 
     // blur vertically and draw in the main renderTarget
     blurPlane.material = verticalBlurMaterial;
@@ -330,7 +331,7 @@ export class Shadow extends Object3D {
         this.renderTargetBlur!.texture;
 
     renderer.setRenderTarget(renderTarget);
-    renderer.render(blurPlane, camera);
+    renderer.render(blurPlane as unknown as Scene, camera);
 
     blurPlane.visible = false;
   }

--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -16,6 +16,7 @@
 import {GainMapDecoderMaterial, HDRJPGLoader, QuadRenderer} from '@monogrid/gainmap-js';
 import {BackSide, BoxGeometry, CubeCamera, CubeTexture, DataTexture, EquirectangularReflectionMapping, HalfFloatType, LinearSRGBColorSpace, Loader, Mesh, NoBlending, NoToneMapping, RGBAFormat, Scene, ShaderMaterial, SRGBColorSpace, Texture, TextureLoader, Vector3, WebGLCubeRenderTarget, WebGLRenderer} from 'three';
 import {RGBELoader} from 'three/examples/jsm/loaders/RGBELoader.js';
+import {WebGPURenderer} from 'three/webgpu';
 
 import {deserializeUrl, timePasses} from '../utilities.js';
 
@@ -49,7 +50,7 @@ export default class TextureUtils {
   private blurMaterial: ShaderMaterial|null = null;
   private blurScene: Scene|null = null;
 
-  constructor(private threeRenderer: WebGLRenderer) {
+  constructor(private threeRenderer: WebGPURenderer) {
   }
 
   private ldrLoader(withCredentials: boolean): TextureLoader {
@@ -62,7 +63,8 @@ export default class TextureUtils {
 
   private imageLoader(withCredentials: boolean): HDRJPGLoader {
     if (this._imageLoader == null) {
-      this._imageLoader = new HDRJPGLoader(this.threeRenderer);
+      this._imageLoader =
+          new HDRJPGLoader(this.threeRenderer as unknown as WebGLRenderer);
     }
     this._imageLoader.setWithCredentials(withCredentials);
     return this._imageLoader;
@@ -238,7 +240,7 @@ export default class TextureUtils {
     renderer.toneMapping = NoToneMapping;
     renderer.outputColorSpace = LinearSRGBColorSpace;
 
-    cubeCamera.update(renderer, scene);
+    cubeCamera.update(renderer as unknown as WebGLRenderer, scene);
 
     this.blurCubemap(cubeTarget, GENERATED_SIGMA);
 
@@ -341,7 +343,8 @@ export default class TextureUtils {
     blurUniforms['dTheta'].value = radiansPerPixel;
 
     const cubeCamera = new CubeCamera(0.1, 100, targetOut);
-    cubeCamera.update(this.threeRenderer, this.blurScene!);
+    cubeCamera.update(
+        this.threeRenderer as unknown as WebGLRenderer, this.blurScene!);
   }
 
   private getBlurShader(maxSamples: number) {

--- a/packages/model-viewer/src/utilities/debug.ts
+++ b/packages/model-viewer/src/utilities/debug.ts
@@ -1,49 +1,50 @@
-/* @license
- * Copyright 2019 Google LLC. All Rights Reserved.
- * Licensed under the Apache License, Version 2.0 (the 'License');
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an 'AS IS' BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// /* @license
+//  * Copyright 2019 Google LLC. All Rights Reserved.
+//  * Licensed under the Apache License, Version 2.0 (the 'License');
+//  * you may not use this file except in compliance with the License.
+//  * You may obtain a copy of the License at
+//  *
+//  *     http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  * Unless required by applicable law or agreed to in writing, software
+//  * distributed under the License is distributed on an 'AS IS' BASIS,
+//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  * See the License for the specific language governing permissions and
+//  * limitations under the License.
+//  */
 
-import {WebGLRenderTarget} from 'three';
+// import {WebGLRenderTarget} from 'three';
 
-import {Renderer} from '../three-components/Renderer.js';
+// import {Renderer} from '../three-components/Renderer.js';
 
-/**
- * Debug method to save an offscreen render target to an image; filename should
- * have a .png extension to ensure lossless transmission.
- */
-export const saveTarget = (target: WebGLRenderTarget, filename: string) => {
-  const {width, height} = target;
-  const output = document.createElement('canvas');
-  output.width = width;
-  output.height = height;
+// /**
+//  * Debug method to save an offscreen render target to an image; filename
+//  should
+//  * have a .png extension to ensure lossless transmission.
+//  */
+// export const saveTarget = (target: WebGLRenderTarget, filename: string) => {
+//   const {width, height} = target;
+//   const output = document.createElement('canvas');
+//   output.width = width;
+//   output.height = height;
 
-  const ctx = output.getContext('2d')!;
-  const img = ctx.getImageData(0, 0, width, height);
-  Renderer.singleton.threeRenderer.readRenderTargetPixels(
-      target, 0, 0, width, height, img.data);
-  ctx.putImageData(img, 0, 0);
+//   const ctx = output.getContext('2d')!;
+//   const img = ctx.getImageData(0, 0, width, height);
+//   Renderer.singleton.threeRenderer.readRenderTargetPixels(
+//       target, 0, 0, width, height, img.data);
+//   ctx.putImageData(img, 0, 0);
 
-  output.toBlob(function(blob) {
-    if (blob == null) {
-      return;
-    }
-    const url = URL.createObjectURL(blob);
+//   output.toBlob(function(blob) {
+//     if (blob == null) {
+//       return;
+//     }
+//     const url = URL.createObjectURL(blob);
 
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
+//     const a = document.createElement('a');
+//     a.href = url;
+//     a.download = filename;
+//     a.click();
 
-    URL.revokeObjectURL(url);
-  });
-}
+//     URL.revokeObjectURL(url);
+//   });
+// }


### PR DESCRIPTION
Now that Three.js supports WebGPU, and better yet, `WebGPURenderer` automatically falls back to `WebGL2Renderer` on unsupported platforms, it's probably about time we started migrating. Amazingly, it sort of already works! Main problems I've noticed so far are with our custom shaders: 

1) custom blur shader for the generated environment. I think we can delete all this code and start using `getTextureLevel` instead, but that means we'll also have to transition from `scene.environment` to scene.environmentNode`. 

2) custom shadow shader. Just rewrite this in TSL - shouldn't be too complex.

We'll see how the rest goes... FYI @mrdoob.