### PR TITLE
Improve shadow robustness

### DIFF
--- a/packages/model-viewer/src/three-components/Shadow.ts
+++ b/packages/model-viewer/src/three-components/Shadow.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {BackSide, Box3, Material, Mesh, MeshBasicMaterial, MeshDepthMaterial, Object3D, OrthographicCamera, PlaneGeometry, RenderTargetOptions, RGBAFormat, Scene, ShaderMaterial, Vector3, WebGLRenderer, WebGLRenderTarget} from 'three';
+import {BackSide, DoubleSide, Box3, Material, Mesh, MeshBasicMaterial, MeshDepthMaterial, Object3D, OrthographicCamera, PlaneGeometry, RenderTargetOptions, RGBAFormat, Scene, ShaderMaterial, Vector3, WebGLRenderer, WebGLRenderTarget} from 'three';
 import {HorizontalBlurShader} from 'three/examples/jsm/shaders/HorizontalBlurShader.js';
 import {VerticalBlurShader} from 'three/examples/jsm/shaders/VerticalBlurShader.js';
 import {lerp} from 'three/src/math/MathUtils.js';
@@ -107,6 +107,9 @@ export class Shadow extends Object3D {
           'gl_FragColor = vec4( vec3( 1.0 - fragCoordZ ), opacity );',
           'gl_FragColor = vec4( vec3( 0.0 ), ( 1.0 - fragCoordZ ) * opacity );');
     };
+    // Render both sides, back sides face the light source and
+    // front sides supply depth information for soft shadows
+    this.depthMaterial.side = DoubleSide;
 
     this.horizontalBlurMaterial.depthTest = false;
     this.verticalBlurMaterial.depthTest = false;


### PR DESCRIPTION
### Reference Issue
#4943

Make objects cast shadows from top facing geometry. Specifically, this improves the appearance of hard shadows cast from non-manifold geometry, which has holes on the bottom.

The softer shadows become, the less effect this change has.

Before, after:
![image](https://github.com/user-attachments/assets/1c125946-ff12-4e63-8640-eb31a1b06ddb)
![image](https://github.com/user-attachments/assets/e2ec2cb9-e865-42fc-a8f0-f24afea0eec6)
![image](https://github.com/user-attachments/assets/5f1b8190-31e0-4462-8c63-d5724178798e)

# Testing

~~I didn't actually manage to get the build setup on windows, so I have no idea if the code works. Let me know if there's an easy way to build/deploy so I can confirm functionality.~~