### PR TITLE
Docs: Improve install instructions

### DIFF
--- a/packages/model-viewer/README.md
+++ b/packages/model-viewer/README.md
@@ -20,6 +20,8 @@ supported to provide a seamless development experience.
 
 ## Installing
 
+### NPM
+
 The `<model-viewer>` web component can be installed from [NPM](https://npmjs.org):
 
 ```sh
@@ -28,6 +30,14 @@ npm install three
 # install package
 npm install @google/model-viewer
 ```
+
+Finally, include the `<model-viewer>` script in your project.
+
+```js
+import '@google/model-viewer';
+```
+
+### CDN
 
 It can also be used directly from various free CDNs such as [jsDelivr](https://www.jsdelivr.com/package/npm/@google/model-viewer) and Google's own [hosted libraries](https://developers.google.com/speed/libraries#model-viewer):
 


### PR DESCRIPTION
### Reference Issue
#4942

Show how to import the NPM package in a project. Added NPM and CDN headings for clarity.

There's still lots of information missing, when comparing the instructions to [those of three.js](https://threejs.org/docs/#manual/en/introduction/Installation). They have an entire page dedicated to every involved concept.

But I think this is a small improvement.
Let me know what you think.