### PR TITLE
fix: Improve HDR texture loading for blob URLs by checking content type

### DIFF
--- a/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
+++ b/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
@@ -69,6 +69,36 @@ suite('TextureUtils', () => {
       expect(texture.name).to.be.eq(HDR_EQUI_URL);
       expect(texture.mapping).to.be.eq(EquirectangularReflectionMapping);
     });
+    test('loads a valid HDR texture from blob URL with correct content type', async () => {
+      // Create a blob with HDR content type
+      const blob = new Blob([''], { type: 'image/vnd.radiance' });
+      const blobUrl = URL.createObjectURL(blob);
+      
+      try {
+        let texture = await textureUtils.loadEquirect(blobUrl);
+        texture.dispose();
+        expect(texture.isTexture).to.be.ok;
+        expect(texture.name).to.be.eq(blobUrl);
+        expect(texture.mapping).to.be.eq(EquirectangularReflectionMapping);
+      } finally {
+        URL.revokeObjectURL(blobUrl);
+      }
+    });
+    test('falls back to extension check for blob URL with unknown content type', async () => {
+      // Create a blob with unknown content type
+      const blob = new Blob([''], { type: 'application/octet-stream' });
+      const blobUrl = URL.createObjectURL(blob);
+      
+      try {
+        let texture = await textureUtils.loadEquirect(blobUrl);
+        texture.dispose();
+        expect(texture.isTexture).to.be.ok;
+        expect(texture.name).to.be.eq(blobUrl);
+        expect(texture.mapping).to.be.eq(EquirectangularReflectionMapping);
+      } finally {
+        URL.revokeObjectURL(blobUrl);
+      }
+    });
     test('throws on invalid URL', async () => {
       try {
         await textureUtils.loadEquirect('');

--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -326,23 +326,22 @@ export class ARRenderer extends EventDispatcher<
     }
   }
 
+  private setupController(controller: XRController) {
+    this.setupXRControllerLine(controller);
+    controller.addEventListener('selectstart', this.onControllerSelectStart);
+    controller.addEventListener('selectend', this.onControllerSelectEnd);
+  }
   private setupXRControllers() {
     this.xrController1 = this.threeRenderer.xr.getController(0) as XRController;
     this.xrController2 = this.threeRenderer.xr.getController(1) as XRController;
-  
-    this.setupXRControllerLine(this.xrController1);
-    this.setupXRControllerLine(this.xrController2);
-  
-    this.xrController1.addEventListener('selectstart', this.onControllerSelectStart);
-    this.xrController1.addEventListener('selectend', this.onControllerSelectEnd);
-  
-    this.xrController2.addEventListener('selectstart', this.onControllerSelectStart);
-    this.xrController2.addEventListener('selectend', this.onControllerSelectEnd);
-  
+
+    this.setupController(this.xrController1);
+    this.setupController(this.xrController2);
+
     this.scaleLine.name = 'scale line';
     this.scaleLine.visible = false;
     this.xrController1.add(this.scaleLine);
-  
+
     // Add controllers to the scene
     const scene = this.presentedScene!;
     scene.add(this.xrController1);


### PR DESCRIPTION
model-viewer currently checks if the URL ends with .hdr using HDR_FILE_RE.test(url)
* If it does, it uses the hdrLoader (RGBELoader)
* If it doesn't, it uses the imageLoader (HDRJPGLoader)

The problem is that when we create a blob URL, it doesn't have the .hdr extension, so it's defaulting to the HDRJPGLoader. We can fix this by modifying the code to check the content type instead of the file extension.
