### PR TITLE
update Piping server instance

### DIFF
--- a/packages/space-opera/src/components/mobile_view/components/mobile_modal.ts
+++ b/packages/space-opera/src/components/mobile_view/components/mobile_modal.ts
@@ -68,7 +68,7 @@ export class MobileModal extends ConnectedLitElement {
       This uses a third-party <a href="https://github.com/nwtgck/piping-server" target="_blank" class="piping-link">piping server</a> to deploy to your mobile device. This server does not store data.
     </div>
     <div class="modal-text">
-      We use this server: <a href="https://piping.glitch.me/" target="_blank" class="piping-link">https://piping.glitch.me/</a>
+      We use this server: <a href="https://piping.onrender.com/" target="_blank" class="piping-link">https://piping.onrender.com/</a>
     </div>
   </div>
   <div class="FileModalCancel">

--- a/packages/space-opera/src/components/mobile_view/utils.ts
+++ b/packages/space-opera/src/components/mobile_view/utils.ts
@@ -15,7 +15,7 @@
  *
  */
 
-export const DOMAIN = 'https://piping.glitch.me/';
+export const DOMAIN = 'https://piping.onrender.com/';
 
 export function getRandomInt(max: number): number {
   return Math.floor(Math.random() * Math.floor(max));


### PR DESCRIPTION
#5061

This pull request updates the piping server URL used for mobile deployment in the `MobileModal` component and related utility functions. The changes ensure the application uses the new server hosted on Render instead of the previous one hosted on Glitch. 

## Demo
Here is a demo video.
https://x.com/modelviewer/status/1352304331358236672

## Design Doc
This describes the connection flow.
https://github.com/google/model-viewer/pull/1746#issuecomment-745631641