### PR TITLE
Switching to https://ppng.io from https://piping.onrender.com/

### DIFF
--- a/packages/space-opera/src/components/mobile_view/components/mobile_modal.ts
+++ b/packages/space-opera/src/components/mobile_view/components/mobile_modal.ts
@@ -63,12 +63,15 @@ export class MobileModal extends ConnectedLitElement {
       Use the QR Code to open your edited model, environment image, and &ltmodel-viewer&gt snippet on a mobile device to test out AR features.
       After every subsequent change, click the "Refresh Mobile" button.
     </div>
-    <canvas id="qr" style="display: block; margin-bottom: 90px;"></canvas>
+    <canvas id="qr" style="display: block; margin-bottom: 10px;"></canvas>
+    <div class="modal-text" style="margin-bottom: 80px;">
+      <a href="${this.viewableSite}" target="_blank" style="color: white">${this.viewableSite}</a>
+    </div>
     <div class="modal-text">
       This uses a third-party <a href="https://github.com/nwtgck/piping-server" target="_blank" class="piping-link">piping server</a> to deploy to your mobile device. This server does not store data.
     </div>
     <div class="modal-text">
-      We use this server: <a href="https://piping.onrender.com/" target="_blank" class="piping-link">https://piping.onrender.com/</a>
+      We use this server: <a href="https://ppng.io/" target="_blank" class="piping-link">https://ppng.io/</a>
     </div>
   </div>
   <div class="FileModalCancel">

--- a/packages/space-opera/src/components/mobile_view/utils.ts
+++ b/packages/space-opera/src/components/mobile_view/utils.ts
@@ -15,7 +15,7 @@
  *
  */
 
-export const DOMAIN = 'https://piping.onrender.com/';
+export const DOMAIN = 'https://ppng.io/';
 
 export function getRandomInt(max: number): number {
   return Math.floor(Math.random() * Math.floor(max));


### PR DESCRIPTION
### Reference Issue

Addressing #5061 since glitch got deprecated and Render.com is not compatible with model-viewer. So switching to https://ppng.io/ (the most stable Piping Server hosting)

Here is the tested version. I also added the viewable link to the ux to streamline testing.

[editorexample.webm](https://github.com/user-attachments/assets/b65c66ab-0f46-4982-97e5-5ea38b383e66)



