### PR TITLE
fix: hide menu panel during model drag in world-space AR

### DIFF
--- a/packages/model-viewer/src/three-components/ARRenderer.ts
+++ b/packages/model-viewer/src/three-components/ARRenderer.ts
@@ -1149,7 +1149,10 @@ export class ARRenderer extends EventDispatcher<
     this.handleScalingInXR(scene, delta);
 
     if (pivot.parent !== scene) {
-      return;  // attached to controller instead
+      // attached to controller instead
+      // when moving the model, the menu panel should disapear
+      this.updateMenuPanel(scene, box, delta);
+      return;
     }
 
     const source = this.updatePivotPosition(scene, delta);


### PR DESCRIPTION
Fix inconsistency where menu panel stayed visible during drag but hid during rotation

