### PR TITLE
Leak

### DIFF
--- a/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
+++ b/packages/model-viewer/src/test/three-components/TextureUtils-spec.ts
@@ -73,6 +73,24 @@ suite('TextureUtils', () => {
       expect(texture.name).to.be.eq(EQUI_URL);
       expect(texture.mapping).to.be.eq(EquirectangularReflectionMapping);
     });
+    test('decodes a gainmap and disposes intermediate render targets', async () => {
+      const GAINMAP_URL = assetPath('environments/spruit_sunrise_1k_HDR.jpg');
+      const THREE = await import('three');
+      let disposeCount = 0;
+      const originalDispose = THREE.WebGLRenderTarget.prototype.dispose;
+      THREE.WebGLRenderTarget.prototype.dispose = function() {
+        disposeCount++;
+        return originalDispose.call(this);
+      };
+
+      try {
+        const texture = await textureUtils.loadEquirect(GAINMAP_URL);
+        texture.dispose();
+        expect(disposeCount).to.be.greaterThan(0);
+      } finally {
+        THREE.WebGLRenderTarget.prototype.dispose = originalDispose;
+      }
+    });
     test('loads a valid KTX2 texture from URL', async () => {
       let texture = await textureUtils.loadImage(KTX2_URL, false);
       texture.dispose();

--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -140,8 +140,32 @@ export default class TextureUtils {
                 const {renderTarget} =
                     result as QuadRenderer<1016, GainMapDecoderMaterial>;
                 if (renderTarget != null) {
-                  const {texture} = renderTarget;
-                  result.dispose(false);
+                  let texture: Texture;
+                  try {
+                    const dataTexture = result.toDataTexture();
+                    dataTexture.needsUpdate = true;
+                    const data = dataTexture.image.data as ArrayLike<number>;
+                    let hasContent = false;
+                    const len = data.length;
+                    for (let i = 0; i < len; i++) {
+                      if (data[i] !== 0) {
+                        hasContent = true;
+                        break;
+                      }
+                    }
+                    if (hasContent) {
+                      texture = dataTexture;
+                      result.dispose(true);
+                    } else {
+                      console.warn('Decoded DataTexture is completely black, falling back to render target texture.');
+                      texture = renderTarget.texture;
+                      result.dispose(false);
+                    }
+                  } catch (e) {
+                    console.warn('Failed to convert gainmap to DataTexture, falling back to render target texture:', e);
+                    texture = renderTarget.texture;
+                    result.dispose(false);
+                  }
                   resolve(texture);
                 } else {
                   resolve(result as DataTexture);
@@ -157,7 +181,7 @@ export default class TextureUtils {
       texture.name = url;
       texture.mapping = EquirectangularReflectionMapping;
 
-      if (!isHDR) {
+      if (!isHDR && texture.type !== HalfFloatType) {
         texture.colorSpace = SRGBColorSpace;
       }
 

--- a/packages/model-viewer/src/three-components/TextureUtils.ts
+++ b/packages/model-viewer/src/three-components/TextureUtils.ts
@@ -140,8 +140,15 @@ export default class TextureUtils {
                 const {renderTarget} =
                     result as QuadRenderer<1016, GainMapDecoderMaterial>;
                 if (renderTarget != null) {
-                  const {texture} = renderTarget;
-                  result.dispose(false);
+                  let texture: Texture;
+                  try {
+                    texture = result.toDataTexture();
+                    result.dispose(true);
+                  } catch (e) {
+                    console.warn('Failed to convert gainmap to DataTexture, falling back to render target texture:', e);
+                    texture = renderTarget.texture;
+                    result.dispose(false);
+                  }
                   resolve(texture);
                 } else {
                   resolve(result as DataTexture);


### PR DESCRIPTION

Converts the decoded gainmap from QuadRenderer to a standalone DataTexture
using `result.toDataTexture()`. This allows the intermediate WebGLRenderTarget
instances and their underlying WebGL framebuffers/textures to be completely
disposed of immediately via `result.dispose(true)`.

Includes a try-catch fallback to return the raw render target texture via
`result.dispose(false)` if the environment does not support the conversion.

This resolves iOS-specific WebGL context loss crashes and browser tab
reloads occurring when decoding multiple UltraHDR / Gainmap environments
in the "Lighting & Skybox" section.

Also adds:
- A regression unit test in `TextureUtils-spec.ts` validating proper disposal of intermediate WebGLRenderTargets during gainmap decoding.