### PR TITLE
fix(scenegraph): suppress Gboard autofill prompts on model transform …

### DIFF
--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -187,19 +187,32 @@
                       transform: translateY(0px);
                     }
                   }
+                  .controls input.number {
+                    width: 40px;
+                  }
+                  /* Hide spin-button for Chrome, Safari, Edge, Opera */
+                  .controls input::-webkit-outer-spin-button,
+                  .controls input::-webkit-inner-spin-button {
+                    -webkit-appearance: none;
+                    margin: 0;
+                  }
+                  /* Hide spin-button for Firefox */
+                  .controls input[type=number] {
+                    -moz-appearance: textfield;
+                  }
                 </style>
                 <model-viewer id="transform" orientation="20deg 0 0" shadow-intensity="1" camera-controls
                   touch-action="pan-y" ar src="../../shared-assets/models/Astronaut.glb"
                   alt="A 3D model of an astronaut">
                   <button slot="ar-button" class="custom-ar-button">View in AR</button>
                   <div class="controls glass">
-                    <div>Roll: <input id="roll" value="20" size="3" class="number"> degrees</div>
-                    <div>Pitch: <input id="pitch" value="0" size="3" class="number"> degrees</div>
-                    <div>Yaw: <input id="yaw" value="0" size="3" class="number"> degrees</div>
+                    <div>Roll: <input type="number" step="any" inputmode="decimal" id="roll" value="20" size="3" class="number" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false"> degrees</div>
+                    <div>Pitch: <input type="number" step="any" inputmode="decimal" id="pitch" value="0" size="3" class="number" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false"> degrees</div>
+                    <div>Yaw: <input type="number" step="any" inputmode="decimal" id="yaw" value="0" size="3" class="number" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false"> degrees</div>
                     <div>
-                      Scale: X: <input id="x" value="1" size="3" class="number">,
-                      Y: <input id="y" value="1" size="3" class="number">,
-                      Z: <input id="z" value="1" size="3" class="number">
+                      Scale: X: <input type="number" step="any" inputmode="decimal" id="x" value="1" size="3" class="number" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">,
+                      Y: <input type="number" step="any" inputmode="decimal" id="y" value="1" size="3" class="number" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">,
+                      Z: <input type="number" step="any" inputmode="decimal" id="z" value="1" size="3" class="number" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false">
                     </div>
                     <button id="frame">Update Framing</button>
                   </div>


### PR DESCRIPTION
…inputs

On Samsung and Chrome mobile platforms, simple unconfigured inputs are analyzed by standard browser credentials heuristics, causing Gboard to incorrectly display sensitive password/payment/address autofill strip buttons on measurement values.

This fix updates the model transform fields to use safe, explicit attributes:  - type="number" and step="any" to prevent general text field heuristics  - inputmode="decimal" to guarantee decimal numeric layout triggers  - autocomplete="off", autocorrect="off", autocapitalize="none", spellcheck="false" parameters to disable autofill caching pipelines

Additionally, this commit adds clean CSS overrides to suppress default browser increment/decrement spin arrows and enforce the compact 40px styling rules on desktop

<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
<!-- Example: Fixes #1234 -->
