### PR TITLE
Resolve a coordinate target misalignment and event-swallowing bug on …

### DIFF
--- a/packages/modelviewer.dev/examples/scenegraph/custom-select.js
+++ b/packages/modelviewer.dev/examples/scenegraph/custom-select.js
@@ -1,0 +1,260 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class CustomSelect extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' }).innerHTML = `
+      <style>
+        :host {
+          display: inline-block;
+          position: relative;
+          font-family: inherit;
+          font-size: 14px;
+          user-select: none;
+          margin: 0.25em;
+          vertical-align: middle;
+          color: #3c4043;
+        }
+        button {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          background: rgba(255, 255, 255, 0.85);
+          border: 1px solid rgba(0, 0, 0, 0.15);
+          border-radius: 6px;
+          padding: 6px 12px;
+          min-width: 150px;
+          cursor: pointer;
+          font-family: inherit;
+          font-size: inherit;
+          font-weight: 500;
+          color: inherit;
+          box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+          transition: all 0.2s;
+          outline: none;
+        }
+        button:hover {
+          background: #ffffff;
+          border-color: rgba(0, 0, 0, 0.25);
+          box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+        }
+        button:focus-visible {
+          border-color: #1a73e8;
+          box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.2);
+        }
+        .label {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          margin-right: 8px;
+        }
+        .chevron {
+          width: 0;
+          height: 0;
+          border-left: 4px solid transparent;
+          border-right: 4px solid transparent;
+          border-top: 4px solid #5f6368;
+          margin-left: 8px;
+          transition: transform 0.2s;
+          flex-shrink: 0;
+        }
+        button.open .chevron {
+          transform: rotate(180deg);
+        }
+        .panel {
+          position: absolute;
+          top: calc(100% + 4px);
+          left: 0;
+          min-width: 100%;
+          z-index: 2000;
+          background: rgba(255, 255, 255, 0.95);
+          backdrop-filter: blur(12px);
+          -webkit-backdrop-filter: blur(12px);
+          border: 1px solid rgba(0, 0, 0, 0.12);
+          border-radius: 8px;
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+          max-height: 200px;
+          overflow-y: auto;
+          display: none;
+        }
+        .panel.open {
+          display: block;
+        }
+        ul {
+          list-style: none;
+          padding: 4px 0;
+          margin: 0;
+        }
+        li {
+          padding: 8px 12px;
+          cursor: pointer;
+          white-space: nowrap;
+          transition: background 0.1s;
+        }
+        li:hover {
+          background: rgba(26, 115, 232, 0.08);
+          color: #1a73e8;
+        }
+        li.selected {
+          background: rgba(26, 115, 232, 0.12);
+          color: #1a73e8;
+          font-weight: 600;
+        }
+        ::slotted(option) {
+          display: none !important;
+        }
+      </style>
+      <button id="btn"><span class="label" id="lbl">None</span><span class="chevron"></span></button>
+      <div class="panel" id="panel"><ul id="list"></ul></div>
+      <slot id="slot"></slot>
+    `;
+    this._value = '';
+    this._selectedIndex = 0;
+    this._isOpen = false;
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  set value(val) {
+    const opts = Array.from(this.querySelectorAll('option'));
+    const idx = opts.findIndex(o => (o.value || o.textContent) === val);
+    if (idx !== -1) {
+      this.selectedIndex = idx;
+    }
+  }
+
+  get selectedIndex() {
+    return this._selectedIndex;
+  }
+
+  set selectedIndex(idx) {
+    const opts = Array.from(this.querySelectorAll('option'));
+    const index = parseInt(idx, 10);
+    if (index >= 0 && index < opts.length) {
+      this._selectedIndex = index;
+      this._value = opts[index].value || opts[index].textContent;
+      this.shadowRoot.getElementById('lbl').textContent = opts[index].textContent;
+      this.updateList();
+    }
+  }
+
+  get options() {
+    return Array.from(this.querySelectorAll('option')).map((opt, index) => ({
+      value: opt.value || opt.textContent,
+      text: opt.textContent,
+      selected: index === this._selectedIndex
+    }));
+  }
+
+  connectedCallback() {
+    const btn = this.shadowRoot.getElementById('btn');
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.toggle();
+    });
+    
+    this.shadowRoot.getElementById('slot').addEventListener('slotchange', () => this.sync());
+    document.addEventListener('click', () => this.close());
+    
+    // CRITICAL FIX: Intercept beforexrselect on this element
+    this.addEventListener('beforexrselect', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    
+    // Prevent event bubbling to WebXR session on the panel list
+    const stop = (e) => e.stopPropagation();
+    const panel = this.shadowRoot.getElementById('panel');
+    panel.addEventListener('pointerdown', stop);
+    panel.addEventListener('mousedown', stop);
+    panel.addEventListener('touchstart', stop);
+    
+    this.sync();
+  }
+
+  toggle() {
+    if (this._isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  open() {
+    this._isOpen = true;
+    this.shadowRoot.getElementById('btn').classList.add('open');
+    this.shadowRoot.getElementById('panel').classList.add('open');
+    
+    const selectedItem = this.shadowRoot.querySelector('li.selected');
+    if (selectedItem) {
+      setTimeout(() => selectedItem.scrollIntoView({ block: 'nearest' }), 50);
+    }
+  }
+
+  close() {
+    this._isOpen = false;
+    this.shadowRoot.getElementById('btn').classList.remove('open');
+    this.shadowRoot.getElementById('panel').classList.remove('open');
+  }
+
+  sync() {
+    const list = this.shadowRoot.getElementById('list');
+    list.innerHTML = '';
+    const opts = Array.from(this.querySelectorAll('option'));
+    
+    // Check initial selected attribute
+    const selectedOptIndex = opts.findIndex(o => o.hasAttribute('selected'));
+    if (selectedOptIndex !== -1 && this._selectedIndex === 0 && !this._value) {
+      this._selectedIndex = selectedOptIndex;
+    }
+
+    opts.forEach((opt, index) => {
+      const li = document.createElement('li');
+      li.textContent = opt.textContent;
+      li.className = index === this._selectedIndex ? 'selected' : '';
+      
+      li.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.selectedIndex = index;
+        this.close();
+        this.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+        this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+      });
+      list.appendChild(li);
+    });
+
+    if (opts.length > 0) {
+      if (this._selectedIndex >= opts.length) {
+        this._selectedIndex = 0;
+      }
+      const selectedOpt = opts[this._selectedIndex];
+      this._value = selectedOpt.value || selectedOpt.textContent;
+      this.shadowRoot.getElementById('lbl').textContent = selectedOpt.textContent;
+    }
+  }
+
+  updateList() {
+    const items = Array.from(this.shadowRoot.querySelectorAll('li'));
+    items.forEach((item, index) => {
+      item.className = index === this._selectedIndex ? 'selected' : '';
+    });
+  }
+}
+
+customElements.define('custom-select', CustomSelect);

--- a/packages/modelviewer.dev/examples/scenegraph/index.html
+++ b/packages/modelviewer.dev/examples/scenegraph/index.html
@@ -58,7 +58,7 @@
       border-radius: 0.5rem;
       padding: 0.5rem 1rem;
       /* max-height: 14rem; */
-      overflow: auto;
+      overflow: visible;
     }
 
     #texture-name,
@@ -71,6 +71,7 @@
       margin: 0 0.25em;
     }
   </style>
+  <script type="module" src="./custom-select.js"></script>
 </head>
 
 <body>
@@ -102,7 +103,7 @@
                   src="../../shared-assets/models/glTF-Sample-Assets/Models/MaterialsVariantsShoe/glTF-Binary/MaterialsVariantsShoe.glb"
                   ar alt="A 3D model of a Shoe">
                   <div class="controls glass">
-                    <div>Variant: <select id="variant"></select></div>
+                    <div>Variant: <custom-select id="variant"></custom-select></div>
                   </div>
                 </model-viewer>
                 <script>
@@ -391,7 +392,7 @@
                   alt="A 3D model of a duck">
                   <div class="controls glass">
                     <p>Normals</p>
-                    <select id="normals2">
+                    <custom-select id="normals2">
                       <option>None</option>
                       <option
                         value="../../shared-assets/models/glTF-Sample-Assets/Models/DamagedHelmet/glTF/Default_normal.jpg">
@@ -402,7 +403,7 @@
                       <option
                         value="../../shared-assets/models/glTF-Sample-Assets/Models/WaterBottle/glTF/WaterBottle_normal.png">
                         Water Bottle</option>
-                    </select>
+                    </custom-select>
                     <p>Custom texture name</p>
                     <p id="texture-name">None</p>
                     <p>Image name from file name</p>
@@ -467,9 +468,9 @@
                   src="../../shared-assets/models/glTF-Sample-Assets/Models/DamagedHelmet/glTF-Binary/DamagedHelmet.glb"
                   ar alt="A 3D model of a helmet">
                   <div class="controls glass">
-                    <div>
+                     <div>
                       <p>Diffuse</p>
-                      <select id="diffuse">
+                      <custom-select id="diffuse">
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/DamagedHelmet/glTF/Default_albedo.jpg">
                           Damaged helmet</option>
@@ -479,11 +480,11 @@
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/WaterBottle/glTF/WaterBottle_baseColor.png">
                           Water Bottle</option>
-                      </select>
+                      </custom-select>
                     </div>
                     <div>
                       <p>Metallic-roughness</p>
-                      <select id="metallicRoughness">
+                      <custom-select id="metallicRoughness">
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/DamagedHelmet/glTF/Default_metalRoughness.jpg">
                           Damaged helmet</option>
@@ -493,11 +494,11 @@
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">
                           Water Bottle</option>
-                      </select>
+                      </custom-select>
                     </div>
                     <div>
                       <p>Normals</p>
-                      <select id="normals">
+                      <custom-select id="normals">
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/DamagedHelmet/glTF/Default_normal.jpg">
                           Damaged helmet</option>
@@ -507,22 +508,22 @@
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/WaterBottle/glTF/WaterBottle_normal.png">
                           Water Bottle</option>
-                      </select>
+                      </custom-select>
                     </div>
                     <div>
                       <p>Occlusion</p>
-                      <select id="occlusion">
+                      <custom-select id="occlusion">
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/DamagedHelmet/glTF/Default_AO.jpg">
                           Damaged helmet</option>
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/WaterBottle/glTF/WaterBottle_occlusionRoughnessMetallic.png">
                           Water Bottle</option>
-                      </select>
+                      </custom-select>
                     </div>
                     <div>
                       <p>Emission</p>
-                      <select id="emission">
+                      <custom-select id="emission">
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/DamagedHelmet/glTF/Default_emissive.jpg">
                           Damaged helmet</option>
@@ -532,7 +533,7 @@
                         <option
                           value="../../shared-assets/models/glTF-Sample-Assets/Models/WaterBottle/glTF/WaterBottle_emissive.png">
                           Water Bottle</option>
-                      </select>
+                      </custom-select>
                     </div>
                   </div>
                 </model-viewer>
@@ -604,11 +605,11 @@
                     <p>Offset</p>
                     <input type="range" min="0" max="1" value="0" step="0.01" id="offsetSlider">
                     <p>WrapMode</p>
-                    <select id="wrapMode">
+                    <custom-select id="wrapMode">
                       <option value="10497">Repeat</option>
                       <option value="33071">ClampToEdge</option>
                       <option value="33648">MirroredRepeat</option>
-                    </select>
+                    </custom-select>
                   </div>
                 </model-viewer>
                 <script type="module">
@@ -678,10 +679,10 @@
                   src="../../shared-assets/models/manifold.glb" ar alt="A 3D model of a stick and ball">
                   <div class="controls glass">
                     <div>Mesh Variants:
-                      <select id="textures">
+                      <custom-select id="textures">
                         <option value="ball">ball</option>
                         <option value="stick">stick</option>
-                      </select>
+                      </custom-select>
                     </div>
                 </model-viewer>
                 <script type="module">
@@ -777,11 +778,11 @@
                   src="../../shared-assets/models/sphere.glb" ar alt="A 3D model of a duck">
                   <div class="controls glass">
                     <p>Texture Type</p>
-                    <select id="type">
+                    <custom-select id="type">
                       <option value="lottie">Lottie</option>
                       <option value="video">Video</option>
                       <option value="canvas">Canvas</option>
-                    </select>
+                    </custom-select>
                   </div>
                 </model-viewer>
                 <script type="module">


### PR DESCRIPTION
…standard HTML <select> elements when active inside WebXR DOM Overlays.

In mobile browsers (such as Chrome on Android), standard <select> tags attempt to open OS-native dialog wheels or bottom sheets. Because these platform-native widgets reside outside the DOM tree, they cannot render correctly over the WebXR context. This results in the element's actual hit-test bounds shifting to the bottom center of the screen, leaving the visual dropdown field unresponsive to direct clicks, while tapping empty space at the bottom triggers the option wheel. To solve this, we created and integrated a standard-compliant, safe, and ultra-lightweight <custom-select> Web Component (custom-select.js) across all scene-graph examples:
- Renders dropdown option items as custom DOM elements floating entirely within the DOM Overlay hierarchy, avoiding native platform widgets.
- Safe Event Interception: Catches 'beforexrselect' on the component and triggers 'event.preventDefault()' to block touches from bubbling up as unintended background WebXR 3D scene gesture inputs.
- High Performance: Leverages standard Shadow DOM <slot> elements with a native 'slotchange' listener to dynamically sync light-DOM option children (replacing heavy recursive MutationObservers).
- Perfect Compatibility: Exposes native getters/setters for '.value', '.selectedIndex', and a native mapped array for the '.options' collection. This allows drop-in slot swaps with zero modifications to existing scripts.
- Adjusts parent '.controls' container selectors to 'overflow: visible' to let floating option panels display cleanly without clipping.
- Added an interactive desktop phone simulator page (select-repro.html) that models the touch bound displacement side-by-side with our custom fix. Files Added/Modified:
- packages/modelviewer.dev/examples/scenegraph/custom-select.js (Added lightweight select component)
- packages/modelviewer.dev/examples/scenegraph/select-repro.html (Added dual-state visual smartphone simulator)
- packages/modelviewer.dev/examples/scenegraph/index.html (Integrated custom-select and updated controls overflow styles)

<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
<!-- Example: Fixes #1234 -->
