### PR TITLE
resolve exit button touch responsiveness bug inside WebXR DOM Overlay…

### DIFF
--- a/packages/model-viewer/src/template.ts
+++ b/packages/model-viewer/src/template.ts
@@ -272,11 +272,17 @@ canvas {
   pointer-events: none;
 }
 
+.slot.exit-webxr-ar-button > slot,
+.slot.exit-webxr-ar-button ::slotted(*) {
+  pointer-events: auto;
+}
+
 .slot.exit-webxr-ar-button:not(.enabled) {
   display: none;
 }
 
 #default-exit-webxr-ar-button {
+  pointer-events: auto;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
…s on Chrome 142

In recent versions of Google Chrome on Android (specifically version 142.0.7444.159 with ARCore 1.51), the default exit (X) button in the upper right corner of the screen is completely unresponsive to direct screen taps while in AR mode. Touches on the button are bypassed, passing straight through as 3D WebXR target-select gestures (which trigger background model placement/movements) instead of exiting the AR session. Root Cause:
In the Shadow DOM template styling, the absolute container `.slot.exit-webxr-ar-button` is set to `pointer-events: none` (to keep empty screen coordinates transparent to 3D room actions). It relies on a generic `.slot > *` rule to restore pointer events. However, because the default close anchor `#default-exit-webxr-ar-button` is nested inside a `<slot>` element, it is a grandchild rather than a direct child of the host container. In Chrome 142's updated event hit-testing pipeline, grandchild elements nested inside a parent with `pointer-events: none` are completely skipped if intermediate structural tags (such as the slot element itself) do not explicitly declare `pointer-events: auto`. This makes the visually visible exit button a physical "ghost" target to touch hit-testing. Solution:
Apply explicit `pointer-events: auto` overrides to the exit button's slot structure:
1. Enable it directly on the intermediate `<slot>` tag to open the hit-test chain.
2. Target any custom user-slotted elements with a `::slotted(*)` pseudo-element rule.
3. Assert it directly on the default fallback close button `#default-exit-webxr-ar-button`. This guarantees that both the default exit button and custom user-defined close button slots are always interactive, while keeping the rest of the absolute overlay transparent to background 3D interactions.

<!-- Instructions: https://github.com/google/model-viewer/blob/master/CONTRIBUTING.md#code-reviews -->
### Reference Issue
<!-- Example: Fixes #1234 -->
