### PR TITLE
fix: apply orientation attribute to <extra-model> elements

### DIFF
--- a/packages/model-viewer/src/test/features/extra-model-spec.ts
+++ b/packages/model-viewer/src/test/features/extra-model-spec.ts
@@ -78,6 +78,32 @@ suite('ExtraModel', () => {
       expect(scene._models[1].position.x).to.equal(5);
     });
 
+    test('applies orientation as rotation on the model quaternion', async () => {
+      element.loading = 'eager';
+      element.src = CUBE_GLB_PATH;
+
+      const extra = document.createElement('extra-model');
+      extra.setAttribute('src', CUBE_GLB_PATH);
+      // yaw = 90deg (third term in roll/pitch/yaw) → Euler(0, π/2, 0, 'YXZ')
+      // → quaternion.y ≈ 0.707, quaternion.w ≈ 0.707
+      extra.setAttribute('orientation', '0deg 0deg 90deg');
+      element.appendChild(extra);
+
+      await waitForEvent(element, 'load');
+
+      const scene = (element as any)[$scene];
+      const q = scene._models[1].quaternion;
+      expect(q.y).to.be.closeTo(Math.sin(Math.PI / 4), 0.001);
+      expect(q.w).to.be.closeTo(Math.cos(Math.PI / 4), 0.001);
+
+      // Update dynamically
+      extra.setAttribute('orientation', '0deg 0deg 0deg');
+      await timePasses();
+
+      expect(scene._models[1].quaternion.y).to.be.closeTo(0, 0.001);
+      expect(scene._models[1].quaternion.w).to.be.closeTo(1, 0.001);
+    });
+
     test(
         'does not calculate bounding box synchronously when offset changes',
         async () => {

--- a/packages/model-viewer/src/three-components/ModelScene.ts
+++ b/packages/model-viewer/src/three-components/ModelScene.ts
@@ -323,7 +323,7 @@ export class ModelScene extends Scene {
   }
 
   updateModelTransforms(
-      index: number, offset?: string|null, _orientation?: string|null,
+      index: number, offset?: string|null, orientation?: string|null,
       scale?: string|null) {
     const model = this._models[index];
     if (!model)
@@ -336,6 +336,17 @@ export class ModelScene extends Scene {
                         .map(Number);
       if (parts.length === 3 && !parts.some(isNaN)) {
         model.position.set(parts[0], parts[1], parts[2]);
+      }
+    }
+
+    if (orientation) {
+      const terms = parseExpressions(orientation)[0]
+                        .terms as [NumberNode, NumberNode, NumberNode];
+      if (terms.length >= 3) {
+        const roll = normalizeUnit(terms[0]).number;
+        const pitch = normalizeUnit(terms[1]).number;
+        const yaw = normalizeUnit(terms[2]).number;
+        model.quaternion.setFromEuler(new Euler(pitch, yaw, roll, 'YXZ'));
       }
     }
 

--- a/packages/modelviewer.dev/examples/multimodel/index.html
+++ b/packages/modelviewer.dev/examples/multimodel/index.html
@@ -137,12 +137,12 @@
                   
                   <extra-model id="robot"
                     src="../../shared-assets/models/RobotExpressive.glb"
-                    offset="-2.0 0 0" scale="0.2 0.2 0.2" orientation="0 30 0">
+                    offset="-2.0 0 0" scale="0.2 0.2 0.2" orientation="0deg 0deg 30deg">
                   </extra-model>
-                  
+
                   <extra-model id="astronaut"
                     src="../../shared-assets/models/Astronaut.glb"
-                    offset="2.0 0 0" scale="0.3 0.3 0.3" orientation="0 -30 0">
+                    offset="2.0 0 0" scale="0.3 0.3 0.3" orientation="0deg 0deg -30deg">
                   </extra-model>
                   
                   <div class="controls glass">


### PR DESCRIPTION
## Description

The multi-model feature introduced in #5134 is a really nice feature — this PR fixes a small gap in the initial implementation.

`<extra-model orientation="...">` had no effect. The `updateModelTransforms` method in `ModelScene.ts` accepted an `orientation` parameter but never applied it — it was prefixed `_orientation`, signalling intentional non-use. Only `offset` and `scale` were wired up, leaving models always in their default rotation regardless of the declared attribute.

## Root cause

`updateModelTransforms` ([source](https://github.com/Frank3K/model-viewer/blob/master/packages/model-viewer/src/three-components/ModelScene.ts#L325-L327)) received the orientation string from the `extra-model-changed` event but did not parse or apply it to the model's quaternion.

A secondary issue: the multimodel example used bare numbers (`orientation="0 30 0"`). 

## Changes

**`packages/model-viewer/src/three-components/ModelScene.ts`**
- Renamed `_orientation` → `orientation` and implemented parsing using the existing `parseExpressions` / `normalizeUnit` utilities — the same infrastructure used by `applyTransform`.
- Applies the result using the documented `$roll $pitch $yaw` convention: `model.quaternion.setFromEuler(new Euler(pitch, yaw, roll, 'YXZ'))`, consistent with the main `orientation` attribute behaviour.

**`packages/modelviewer.dev/examples/multimodel/index.html`**
- Updated orientation attribute values to use explicit `deg` units and correct roll/pitch/yaw ordering. A 30° yaw (Y-axis) rotation is now `"0deg 0deg 30deg"` (third term), matching the documented `$roll $pitch $yaw` format.

## Before / After

### Before

<img width="797" height="364" alt="image" src="https://github.com/user-attachments/assets/416b62eb-0307-44d1-8416-3d24928b8418" />

### After
 
<img width="800" height="384" alt="image" src="https://github.com/user-attachments/assets/5055b157-bcab-489d-b997-f04fc556cce7" />

Robot and Astronaut now rotate around their Y-axis as declared, facing slightly toward the scene center.

## Testing

Verified visually in the multimodel example page. The robot (left, `orientation="0deg 0deg 30deg"`) and the astronaut (right, `orientation="0deg 0deg -30deg"`) each rotate 30° around the Y-axis toward the center.